### PR TITLE
Imported package must be a non-empty Zip archive

### DIFF
--- a/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -1,10 +1,12 @@
 package com.mesosphere.cosmos
 
-import com.twitter.finagle.http.exp.Multipart.FileUpload
-import com.twitter.finagle.http.{Request, Response}
-import com.twitter.finagle.{Service, Http}
-import com.twitter.util.Await
+import java.io.{BufferedInputStream, ByteArrayInputStream, FileInputStream, InputStream}
+import java.util.zip.ZipInputStream
 
+import com.twitter.finagle.http.exp.Multipart.{FileUpload, InMemoryFileUpload, OnDiskFileUpload}
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.finagle.{Http, Service}
+import com.twitter.util.Await
 import io.finch._
 
 object Cosmos {
@@ -20,11 +22,50 @@ object Cosmos {
   val ping: Endpoint[String] = get("ping") { Ok("pong") }
 
   val packageImport: Endpoint[String] =
-    post("v1" / "package" / "import" ? validFileUpload) { _: FileUpload =>
-      Ok("Import successful!\n")
+    post("v1" / "package" / "import" ? validFileUpload) { file: FileUpload =>
+      fileUploadBytes(file).flatMap { fileBytes =>
+        if (nonEmptyArchive(fileBytes)) {
+          Ok("Import successful!\n")
+        } else {
+          BadRequest(new Exception("Package is empty"))
+        }
+      }
     }
 
   val service: Service[Request, Response] = (ping :+: packageImport).toService
+
+  /** Attempts to provide access to the content of the given file upload as a byte stream.
+    *
+    * @param file the file upload to get the content for
+    * @return the file's content as a byte stream, if it was available; an error message otherwise.
+    */
+  private[this] def fileUploadBytes(file: FileUpload): Output[InputStream] = {
+    file match {
+      case InMemoryFileUpload(content, _, _, _) =>
+        val bytes = Array.ofDim[Byte](content.length)
+        content.write(bytes, 0)
+        Output.payload(new ByteArrayInputStream(bytes))
+      case OnDiskFileUpload(content, _, _, _) =>
+        Output.payload(new BufferedInputStream(new FileInputStream(content)))
+      case _ => Output.failure(new Exception("Unknown file upload type"), Status.NotImplemented)
+    }
+  }
+
+  /** Determines whether the given byte stream encodes a Zip archive containing at least one file.
+    *
+    * @param packageBytes the byte stream to test
+    * @return `true` if the byte stream is a non-empty Zip archive; `false` otherwise.
+    */
+  private[this] def nonEmptyArchive(packageBytes: InputStream): Boolean = {
+    val zis = new ZipInputStream(packageBytes)
+    try {
+      val entryOpt = Option(zis.getNextEntry)
+      entryOpt.foreach(_ => zis.closeEntry())
+      entryOpt.nonEmpty
+    } finally {
+      zis.close()
+    }
+  }
 
   def main(args: Array[String]): Unit = {
     val _ = Await.ready(Http.serve(":8080", service))


### PR DESCRIPTION
This took me a bit longer than I intended. I thought that the Zip parser would throw an exception on a non-Zip file, but it actually silently treats as empty any file that doesn't have the correct header for the Zip format.

Once #9 and #10 are implemented, this code will change to actually look at the file contents of the archive.
