### PR TITLE
Add support for generating the API HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 An [orderly, harmonius, complete](http://www.thefreedictionary.com/cosmos) API for DCOS services.
 
+## Requirements
+
+- SBT
+- Install raml2html - This is needed to generate the HTML documentation from a RAML file.
+  - Install NPM
+  - Install raml2html - `npm i -g raml2html`
+
 ## Running tests
 
 Note that the tests currently leave some apps running on Marathon, and cannot be run again
@@ -10,7 +17,6 @@ for keeping test runs independent of each other.
 
 ### Requirements
 
-- SBT
 - An existing DCOS cluster or access to `ccm.mesosphere.com`
 
 ### Running with an existing cluster

--- a/project/build.scala
+++ b/project/build.scala
@@ -82,6 +82,29 @@ object CosmosBuild extends Build {
       "-Xlint:deprecation"
     ),
 
+    resourceGenerators in Compile += Def.task {
+      val logger = streams.value.log
+      val inputRaml = (sourceDirectory in Compile).value / "resources" / "api" / "api.raml"
+      val outputHtml = (resourceManaged in Compile).value / "api.html"
+
+      logger.debug(s"inputRaml = ${inputRaml.getPath}")
+      logger.debug(s"outputHtml = ${outputHtml.getPath}")
+
+      // Make sure that we create all of the necessary directories
+      outputHtml.getParentFile.mkdirs()
+
+      val raml2html = Process(
+        "raml2html",
+        Seq("--input", inputRaml.getPath, "--output", outputHtml.getPath)
+      )
+
+      if (raml2html.run().exitValue() != 0) {
+        logger.warn(s"Unable to generate API HTML for ${inputRaml.getPath}")
+      }
+
+      Seq(outputHtml)
+    }.taskValue,
+
     scalacOptions ++= Seq(
       "-deprecation", // Emit warning and location for usages of deprecated APIs.
       "-encoding", "UTF-8",

--- a/src/main/resources/api/api.raml
+++ b/src/main/resources/api/api.raml
@@ -1,0 +1,41 @@
+#%RAML 0.8
+title: Cosmos API
+version: v1
+schemas:
+  - InstallRequest: schema/install_request.json
+  - InstallResponse: schema/install_response.json
+traits:
+  - errored:
+      responses:
+        400:
+          body:
+            application/json:
+              schema: # TODO: specify this better
+        500:
+          body:
+            application/json:
+              schema: # TODO: specify this better
+
+/package/install:
+  is: [ errored ]
+  post:
+    body:
+      application/json:
+        example: |
+          {
+            "name": "cassandra",
+            "version": "0.1.0",
+            "options": {...}
+          }
+        schema: # TODO: specify this with an external file
+    responses:
+      200:
+        body:
+          application/json:
+            example: |
+              {
+                "name": "cassandra",
+                "version": "0.1.0",
+                "appId": "cassnadra.dcos"
+              }
+            schema: # TODO: specify this with an external file


### PR DESCRIPTION
This is a partial commit but it is good to get the conversation started.
We still need to add an endpoint to Cosmos that would return this file
from the JAR.