### PR TITLE
Add package uninstall endpoint

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -69,7 +69,6 @@ object CosmosBuild extends Build {
       "Clojars Repository" at "http://clojars.org/repo",
       "Conjars Repository" at "http://conjars.org/repo",
       "Twitter Maven" at "http://maven.twttr.com",
-      "Finch.io" at "http://repo.konfettin.ru",
       "finch-server" at "http://storage.googleapis.com/benwhitehead_me/maven/public"
     ),
 
@@ -119,7 +118,9 @@ object CosmosBuild extends Build {
 
     parallelExecution in Test := false,
 
-    fork := false
+    fork := false,
+
+    cancelable in Global := true
   )
 
   lazy val cosmos = Project("cosmos", file("."))

--- a/src/it/scala/com/mesosphere/cosmos/IntegrationSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/IntegrationSpec.scala
@@ -14,7 +14,7 @@ abstract class IntegrationSpec
     val adminRouterUri = dcosHost()
     val dcosClient = Services.adminRouterClient(adminRouterUri)
     val adminRouter = new AdminRouter(adminRouterUri, dcosClient)
-    new Cosmos(PackageCache.empty, new MarathonPackageRunner(adminRouter)).service
+    new Cosmos(PackageCache.empty, new MarathonPackageRunner(adminRouter), new UninstallHandler(adminRouter)).service
   }
 
   protected[this] final override val servicePort: Int = port

--- a/src/it/scala/com/mesosphere/cosmos/UninstallHandlerSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/UninstallHandlerSpec.scala
@@ -1,0 +1,57 @@
+package com.mesosphere.cosmos
+
+import java.nio.file.Files
+
+import cats.data.Xor._
+import com.netaporter.uri.dsl._
+import com.twitter.finagle.Service
+import com.twitter.finagle.http.{Request, Response, Status}
+import com.twitter.io
+import com.twitter.io.Buf
+import com.twitter.util.Await
+
+final class UninstallHandlerSpec extends IntegrationSpec {
+
+  val tmpDir = {
+    val tempDir = Files.createTempDirectory("cosmos-UninstallHandlerSpec")
+    val file = tempDir.toFile
+    Runtime.getRuntime.addShutdownHook(new Thread() {
+      override def run(): Unit = {
+        if (!io.Files.delete(file)) {
+          logger.warn("unable to cleanup temp dir: {}", file.getAbsolutePath)
+        }
+      }
+    })
+    file.deleteOnExit()
+    val value = file.getAbsolutePath
+    logger.info("Setting com.mesosphere.cosmos.universeCacheDir={}", value)
+    System.setProperty("com.mesosphere.cosmos.universeCacheDir", value)
+    tempDir
+  }
+
+  override def createService: Service[Request, Response] = {
+    Cosmos.service
+  }
+
+  "The uninstall handler" should "be able to uninstall a service" in { service =>
+    val installRequest = requestBuilder("v1/package/install")
+      .buildPost(Buf.Utf8("""{"name":"cassandra","options":{}}"""))
+    val installResponse = service(installRequest)
+    val installResponseBody = installResponse.contentString
+    logger.info("installResponseBody = {}", installResponseBody)
+    assertResult(Status.Ok)(installResponse.status)
+
+    val Right(marathonApp) = Await.result(adminRouter.getApp("cassandra" / "dcos"))
+    assertResult("/cassandra/dcos")(marathonApp.app.id)
+
+    //TODO: Assert framework starts up
+
+    val uninstallRequest = requestBuilder("v1/package/uninstall")
+      .buildPost(Buf.Utf8("""{"name":"cassandra"}"""))
+    val uninstallResponse = service(uninstallRequest)
+    val uninstallResponseBody = uninstallResponse.contentString
+    logger.info("uninstallResponseBody = {}", uninstallResponseBody)
+    assertResult(Status.Ok)(uninstallResponse.status)
+  }
+
+}

--- a/src/main/scala/com/mesosphere/cosmos/AdminRouter.scala
+++ b/src/main/scala/com/mesosphere/cosmos/AdminRouter.scala
@@ -1,5 +1,7 @@
 package com.mesosphere.cosmos
 
+import cats.data.Xor.{Left, Right}
+import com.mesosphere.cosmos.model.mesos.master._
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.Service
@@ -7,14 +9,19 @@ import com.twitter.finagle.http._
 import com.twitter.io.Buf
 import com.twitter.util.Future
 import io.circe.Json
+import io.circe.parse._
+import io.circe.generic.auto._
 
 class AdminRouter(adminRouterUri: Uri, client: Service[Request, Response]) {
+
   private val baseUri = {
     val uri = adminRouterUri.toString
-    if (uri.endsWith("/"))
+    if (uri.endsWith("/")) {
       uri.substring(0, uri.length)
-    else
+    }
+    else {
       uri
+    }
   }
 
   private[this] def get(uri: Uri): Request = {
@@ -32,6 +39,14 @@ class AdminRouter(adminRouterUri: Uri, client: Service[Request, Response]) {
       .buildPost(Buf.Utf8(jsonBody.noSpaces))
   }
 
+  private[this] def postForm(uri: Uri, postBody: String): Request = {
+    RequestBuilder()
+      .url(s"$baseUri${uri.toString}")
+      .setHeader("Accept", "application/json; charset=utf-8")
+      .setHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+      .buildPost(Buf.Utf8(postBody))
+  }
+
   private[this] def delete(uri: Uri): Request = {
     RequestBuilder()
       .url(s"$baseUri${uri.toString}")
@@ -39,16 +54,49 @@ class AdminRouter(adminRouterUri: Uri, client: Service[Request, Response]) {
       .buildDelete()
   }
 
+  private[this] def validateResponseStatus(uri: Uri, response: Response): CosmosResult[Response] = {
+    response.status match {
+      case Status.Ok =>
+        Right(response)
+      case s: Status => leftErrorNel(GenericHttpError(uri, s))
+    }
+  }
+
+  private[this] def decodeJsonTo[A](response: Response)(implicit d: io.circe.Decoder[A]): CosmosResult[A] = {
+    response.headerMap.get("Content-Type") match {
+      case Some(ct) if ct.startsWith("application/json") =>
+        decode[A](response.contentString) match {
+          case Left(err) => leftErrorNel(CirceError(err))
+          case Right(a) => Right(a)
+        }
+      case a: Option[String] =>
+        leftErrorNel(UnsupportedContentType(a, "application/json"))
+    }
+  }
+
+  private[this] def decodeTo[A](uri: Uri, response: Response)(implicit d: io.circe.Decoder[A]): CosmosResult[A] = {
+    validateResponseStatus(uri, response)
+      .flatMap(decodeJsonTo[A])
+  }
+
   def createApp(appJson: Json): Future[Response] = {
     client(post("marathon" / "v2" / "apps" , appJson))
   }
 
-  def getApp(appId: Uri): Future[Response] = {
-    client(get("marathon" / "v2" / "apps" / appId))
+  def getApp(appId: Uri): Future[CosmosResult[MarathonAppResponse]] = {
+    val uri = "marathon" / "v2" / "apps" / appId
+    client(get(uri)).map { response =>
+      response.status match {
+        case Status.Ok => decodeJsonTo(response)
+        case Status.NotFound => leftErrorNel(MarathonAppNotFound(appId.toString))
+        case s: Status => leftErrorNel(GenericHttpError(uri, s))
+      }
+    }
   }
 
-  def listApps(): Future[Response] = {
-    client(get("marathon" / "v2" / "apps"))
+  def listApps(): Future[CosmosResult[MarathonAppsResponse]] = {
+    val uri = "marathon" / "v2" / "apps"
+    client(get(uri)).map(decodeTo[MarathonAppsResponse](uri, _))
   }
 
   def deleteApp(appId: Uri, force: Boolean = false): Future[Response] = {
@@ -56,5 +104,21 @@ class AdminRouter(adminRouterUri: Uri, client: Service[Request, Response]) {
       case true => client(delete("marathon" / "v2" / "apps" / appId ? ("force" -> "true")))
       case false => client(delete("marathon" / "v2" / "apps" / appId))
     }
+  }
+
+  def tearDownFramework(frameworkId: String): Future[CosmosResult[MesosFrameworkTearDownResponse]] = {
+    val formData = Uri.empty.addParam("frameworkId", frameworkId)
+    // scala-uri makes it convenient to encode the actual framework id, but it will think its for a Uri
+    // so we strip the leading '?' that signifies the start of a query string
+    val encodedString = formData.toString.substring(1)
+    val uri = "mesos" / "master" / "teardown"
+    client(postForm(uri, encodedString))
+      .map(validateResponseStatus(uri, _))
+      .flatMapXor { _ : Response => Future.value(Right(MesosFrameworkTearDownResponse())) }
+  }
+
+  def getMasterState(frameworkName: String): Future[CosmosResult[MasterState]] = {
+    val uri = "mesos" / "master" / "state.json"
+    client(get(uri)).map(decodeTo[MasterState](uri, _))
   }
 }

--- a/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -1,5 +1,7 @@
 package com.mesosphere.cosmos
 
+import com.netaporter.uri.Uri
+import com.twitter.finagle.http.Status
 import io.circe.Encoder
 
 sealed trait CosmosError {
@@ -18,6 +20,17 @@ sealed trait CosmosError {
       case MarathonBadResponse(statusCode) =>
         s"Received response status code $statusCode from Marathon"
       case IndexNotFound => s"Index file missing for repo [${universeBundleUri()}]"
+      case MarathonAppMetadataError(note) => note
+      case MarathonAppDeleteError(appId) => s"Error while deleting marathon app '$appId'"
+      case MarathonAppNotFound(appId) => s"Unable to locate service with marathon appId: '$appId'"
+      case CirceError(cerr) => cerr.getMessage
+      case MesosRequestError(note) => note
+      case ce @ ClientError(s, note) => ce.toString
+      case se @ ServerError(s, note) => se.toString
+      case uct @ UnsupportedContentType(_, _) => uct.toString
+      case ghe @ GenericHttpError(uri, status) => ghe.toString
+      case aai @ AmbiguousAppId(_, _) => aai.toString
+      case mfi @ MultipleFrameworkIds(_, _) => mfi.toString
     }
   }
 
@@ -42,3 +55,18 @@ private case class PackageFileSchemaMismatch(fileName: String) extends CosmosErr
 private case object PackageAlreadyInstalled extends CosmosError
 private case class MarathonBadResponse(statusCode: Int) extends CosmosError
 private case object IndexNotFound extends CosmosError
+
+private case class MarathonAppMetadataError(note: String) extends CosmosError
+private case class MarathonAppDeleteError(appId: String) extends CosmosError
+private case class MarathonAppNotFound(appId: String) extends CosmosError
+private case class MesosRequestError(note: String) extends CosmosError
+private case class CirceError(cerr: io.circe.Error) extends CosmosError
+
+private case class ClientError(status: Int, note: String) extends CosmosError
+private case class ServerError(status: Int, note: String) extends CosmosError
+private case class UnsupportedContentType(contentType: Option[String], supported: String) extends CosmosError
+
+private case class GenericHttpError(uri: Uri, status: Status) extends CosmosError
+
+private case class AmbiguousAppId(packageName: String, appIds: List[String]) extends CosmosError
+private case class MultipleFrameworkIds(frameworkName: String, ids: List[String]) extends CosmosError

--- a/src/main/scala/com/mesosphere/cosmos/Flags.scala
+++ b/src/main/scala/com/mesosphere/cosmos/Flags.scala
@@ -19,6 +19,6 @@ object universeBundleUri extends GlobalFlag[Uri](
 
 // TODO: Make this application state instead of config parameter
 object universeCacheDir extends GlobalFlag[file.Path](
-  file.Paths.get(System.getProperty("java.io.tmpdir")),
+  file.Paths.get(System.getProperty("java.io.tmpdir"), "cosmos"),
   help = "directory for local universe cache"
 )(Flaggables.flagOfFilePath)

--- a/src/main/scala/com/mesosphere/cosmos/UninstallHandler.scala
+++ b/src/main/scala/com/mesosphere/cosmos/UninstallHandler.scala
@@ -1,0 +1,140 @@
+package com.mesosphere.cosmos
+
+import cats.data.Xor.{Left, Right}
+import com.mesosphere.cosmos.model.{UninstallResult, UninstallRequest, UninstallResponse}
+import com.netaporter.uri.dsl._
+import com.twitter.finagle.http.Status
+import com.twitter.util.Future
+
+private[cosmos] final class UninstallHandler(adminRouter: AdminRouter)
+  extends Function[UninstallRequest, Future[CosmosResult[UninstallResponse]]] {
+
+  private type FwIds = List[String]
+
+  private def lookupFrameworkIds(fwName: String): Future[CosmosResult[FwIds]] = {
+    adminRouter.getMasterState(fwName).map { xor =>
+      xor.map { masterState =>
+        masterState.frameworks
+          .filter(_.name == fwName)
+          .map(_.id)
+      }
+    }
+  }
+  private def destroyMarathonAppsAndTearDownFrameworkIfPresent(
+    xor: CosmosResult[List[UninstallOperation]]
+  ): Future[CosmosResult[List[UninstallDetails]]] = xor match {
+    case Left(err) => Future.value(Left(err))
+    case Right(uninstallOperations) =>
+      val appDeletes = for {
+        op <- uninstallOperations
+        appId = op.appId
+      } yield destroyMarathonApp(appId) flatMap {
+        case Left(err) => Future.value(Left(err))
+        case Right(_) =>
+          op.frameworkName match {
+            case Some(fwName) =>
+              lookupFrameworkIds(fwName).flatMap {
+                case Left(err) => Future.value(Left(err))
+                case Right(fwIds) =>
+                  fwIds match {
+                    case Nil =>
+                      Future.value(Right(UninstallDetails.from(op)))
+                    case fwId :: Nil =>
+                      adminRouter.tearDownFramework(fwId)
+                        .map { xor =>
+                          xor.map(_ => UninstallDetails.from(op).copy(frameworkId = Some(fwId)))
+                        }
+                    case all =>
+                      Future.value(leftErrorNel(MultipleFrameworkIds(fwName, all)))
+                  }
+              }
+            case None =>
+              Future.value(Right(UninstallDetails.from(op)))
+          }
+      }
+
+      Future.collect(appDeletes) map { xors =>
+        import cats.std.list._
+        import cats.syntax.traverse._
+        xors.toList.sequenceU
+      }
+  }
+  private def destroyMarathonApp(appId: String): Future[CosmosResult[MarathonAppDeleteSuccess]] = {
+    adminRouter.deleteApp(appId, force = true) map { resp =>
+      resp.status match {
+        case Status.Ok => Right(MarathonAppDeleteSuccess())
+        case a => leftErrorNel(MarathonAppDeleteError(appId))
+      }
+    }
+  }
+
+  override def apply(req: UninstallRequest): Future[CosmosResult[UninstallResponse]] = {
+    // the following implementation is based on what the current CLI implementation does.
+    // I've decided to follow it as close as possible so that we reduce any possible behavioral
+    // changes that could have unforeseen consequences.
+    //
+    // In the future this will probably be revisited once Cosmos is the actual authority on services
+    adminRouter.listApps().
+      map {
+        _.flatMap { marathonApps =>
+          val appIds = for {
+            app <- marathonApps.apps
+            labels = app.labels
+            packageName <- labels.get("DCOS_PACKAGE_NAME")
+            if packageName == req.name
+          } yield UninstallOperation(
+            appId = app.id,
+            packageName = packageName,
+            version = labels.get("DCOS_PACKAGE_VERSION"),
+            frameworkName = labels.get("DCOS_PACKAGE_FRAMEWORK_NAME")
+          )
+
+          val res: CosmosResult[List[UninstallOperation]] = req.all match {
+            case Some(true) =>
+              Right(appIds)
+            case _ if appIds.size > 1 =>
+              leftErrorNel(AmbiguousAppId(req.name, appIds.map(_.appId)))
+            case _ => // we've only got one package installed with the name continue with it
+              Right(appIds)
+          }
+          res
+        }
+      }
+      .flatMap { xor =>
+        destroyMarathonAppsAndTearDownFrameworkIfPresent(xor)
+      }
+      .map {
+        _.map { uninstallDetails =>
+          UninstallResponse(
+            uninstallDetails.map { detail => UninstallResult(detail.packageName, detail.appId, detail.version) }
+          )
+        }
+      }
+  }
+
+  private case class MarathonAppDeleteSuccess()
+  private case class UninstallOperation(
+    appId: String,
+    packageName: String,
+    version: Option[String],
+    frameworkName: Option[String]
+  )
+  private case class UninstallDetails(
+    appId: String,
+    packageName: String,
+    version: Option[String],
+    frameworkName: Option[String] = None,
+    frameworkId: Option[String] = None
+  )
+  private case object UninstallDetails {
+    def from(uninstallOperation: UninstallOperation): UninstallDetails = {
+      UninstallDetails(
+        appId = uninstallOperation.appId,
+        packageName = uninstallOperation.packageName,
+        version = uninstallOperation.version,
+        frameworkName = uninstallOperation.frameworkName
+      )
+    }
+  }
+}
+

--- a/src/main/scala/com/mesosphere/cosmos/model/InstallRequest.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/InstallRequest.scala
@@ -8,3 +8,15 @@ case class InstallRequest(
   options: JsonObject = JsonObject.empty,
   appId: Option[String] = None
 )
+case class UninstallRequest(
+  name: String,
+  appId: Option[String],
+  all: Option[Boolean]
+)
+
+case class UninstallResponse(results: List[UninstallResult])
+case class UninstallResult(
+  name: String,
+  appId: String,
+  version: Option[String]
+)

--- a/src/main/scala/com/mesosphere/cosmos/model/mesos/master/Master.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/mesos/master/Master.scala
@@ -1,0 +1,21 @@
+package com.mesosphere.cosmos.model.mesos.master
+
+//todo: flush out
+case class MasterState(
+  frameworks: List[Framework]
+)
+
+case class Framework(
+  id: String,
+  name: String
+)
+
+case class MesosFrameworkTearDownResponse()
+
+case class MarathonAppResponse(app: MarathonApp)
+case class MarathonAppsResponse(apps: List[MarathonApp])
+case class MarathonApp(
+  id: String,
+  labels: Map[String, String],
+  uris: List[String] /*TODO: uri type*/
+)

--- a/src/main/scala/com/mesosphere/cosmos/package.scala
+++ b/src/main/scala/com/mesosphere/cosmos/package.scala
@@ -29,6 +29,8 @@ object `package` {
 
   def errorNel(error: CosmosError): NonEmptyList[CosmosError] = NonEmptyList(error)
 
+  def leftErrorNel(error: CosmosError): Left[NonEmptyList[CosmosError]] = Xor.Left(errorNel(error))
+
   def successOutput(message: String): Output[Json] = {
     Output.payload(Map("message" -> message).asJson)
   }

--- a/src/test/scala/com/mesosphere/cosmos/UserOptionsSpec.scala
+++ b/src/test/scala/com/mesosphere/cosmos/UserOptionsSpec.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.cosmos
 
-import com.mesosphere.cosmos.model.{Resource, PackageDefinition, PackageFiles, InstallRequest}
+import cats.data.Xor
+import com.mesosphere.cosmos.model._
 import com.twitter.finagle.http.RequestBuilder
 import com.twitter.io.Buf
 import com.twitter.util.{Future, Await}
@@ -45,7 +46,11 @@ final class UserOptionsSpec extends UnitSpec {
         val packageCache = MemoryPackageCache(packages)
         val packageRunner = new RecordingPackageRunner
 
-        val cosmos = new Cosmos(packageCache, packageRunner)
+        val cosmos = new Cosmos(
+          packageCache,
+          packageRunner,
+          (r : UninstallRequest) => { Future.value(Xor.Right(UninstallResponse(Nil))) }
+        )
         val request = RequestBuilder()
           .url("http://dummy.cosmos.host/v1/package/install")
           .buildPost(Buf.Utf8(reqBody.asJson.noSpaces))


### PR DESCRIPTION
Add a new endpoint that can be used to uninstall a package.

The implementation follows the current behavior of the dcos-cli, namely:
1. list all apps in marathon, filtered to those apps with package names
matching the supplied `name`
2. If more than 1 app and `all` is set to `true` proceed, otherwise
return an error
3. for each app to remove do a force delete from marathon, if a
framework name label is present query mesos for a list of frameworks,
filter where framework name matches the value of the label. If more than
one framework return an error otherwise proceed to tear down the
framework.
4. Upon success return the deails of all apps that were removed
