### PR TITLE
Remove CosmosResult type

### DIFF
--- a/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -57,7 +57,7 @@ final class PackageDescribeSpec extends FreeSpec with CosmosSpec {
     val service = new Cosmos(
       packageCache,
       new MarathonPackageRunner(adminRouter),
-      (r : UninstallRequest) => { Future.value(Xor.Right(UninstallResponse(Nil))) }
+      (r : UninstallRequest) => { Future.value(UninstallResponse(Nil)) }
     ).service
     val server = Http.serve(s":$servicePort", service)
     val client = Http.newService(s"127.0.0.1:$servicePort")

--- a/src/it/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
@@ -154,7 +154,7 @@ final class PackageInstallSpec extends FreeSpec with BeforeAndAfterAll with Cosm
               expectedAppIdOpt = Some(appId)
             )
             // TODO Confirm that the correct config was sent to Marathon - see issue #38
-            val Right(packageInfo) = Await.result(getPackageInfo(appId))
+            val packageInfo = Await.result(getPackageInfo(appId))
             assertResult(uriSet)(packageInfo.uris.toSet)
             labelsOpt.foreach(labels => assertResult(labels)(StandardLabels(packageInfo.labels)))
           }
@@ -265,12 +265,10 @@ private object PackageInstallSpec extends CosmosSpec {
     ("cassandra", "foobar")
   )
 
-  private def getPackageInfo(appId: String): Future[CosmosResult[PackageInfo]] = {
+  private def getPackageInfo(appId: String): Future[PackageInfo] = {
     adminRouter.getApp(appId)
-      .map {
-        _.map { appResp =>
-          PackageInfo(appResp.app.uris, appResp.app.labels)
-        }
+      .map { appResp =>
+        PackageInfo(appResp.app.uris, appResp.app.labels)
       }
   }
 
@@ -337,13 +335,13 @@ private object PackageInstallSpec extends CosmosSpec {
   ): Unit = {
     val Right(marathonJson) = parse(packageFiles.marathonJsonMustache)
     val expectedLabel = extractTestLabel(marathonJson.cursor)
-    val Right(actualLabel) = Await.result(getMarathonJsonTestLabel(packageName))
+    val actualLabel = Await.result(getMarathonJsonTestLabel(packageName))
     assertResult(expectedLabel)(actualLabel)
   }
 
-  private def getMarathonJsonTestLabel(packageName: String): Future[CosmosResult[Option[String]]] = {
+  private def getMarathonJsonTestLabel(packageName: String): Future[Option[String]] = {
     adminRouter.getApp(Uri.parse(packageName)) map {
-      _.map(_.app.labels.get("test-id"))
+      _.app.labels.get("test-id")
     }
   }
 
@@ -403,15 +401,13 @@ private final class ApiTestAssertionDecorator(apiClient: Service[Request, Respon
   }
 
   private[this] def isAppInstalled(appId: String): Boolean = {
-    val Right(appIds) = Await.result(listMarathonAppIds())
+    val appIds = Await.result(listMarathonAppIds())
       appIds.contains(s"/$appId")
   }
 
-  private[this] def listMarathonAppIds(): Future[CosmosResult[Seq[String]]] = {
-    adminRouter.listApps() map {
-      _.map { marathonAppsResponse =>
-        marathonAppsResponse.apps.map(_.id)
-      }
+  private[this] def listMarathonAppIds(): Future[Seq[String]] = {
+    adminRouter.listApps() map { marathonAppsResponse =>
+      marathonAppsResponse.apps.map(_.id)
     }
   }
 

--- a/src/it/scala/com/mesosphere/cosmos/UninstallHandlerSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/UninstallHandlerSpec.scala
@@ -2,7 +2,6 @@ package com.mesosphere.cosmos
 
 import java.nio.file.Files
 
-import cats.data.Xor._
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status}
@@ -41,7 +40,7 @@ final class UninstallHandlerSpec extends IntegrationSpec {
     logger.info("installResponseBody = {}", installResponseBody)
     assertResult(Status.Ok)(installResponse.status)
 
-    val Right(marathonApp) = Await.result(adminRouter.getApp("cassandra" / "dcos"))
+    val marathonApp = Await.result(adminRouter.getApp("cassandra" / "dcos"))
     assertResult("/cassandra/dcos")(marathonApp.app.id)
 
     //TODO: Assert framework starts up

--- a/src/main/scala/com/mesosphere/cosmos/BaseScope.scala
+++ b/src/main/scala/com/mesosphere/cosmos/BaseScope.scala
@@ -1,0 +1,3 @@
+package com.mesosphere.cosmos
+
+case class BaseScope(name: Option[String] = None)

--- a/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -1,36 +1,41 @@
 package com.mesosphere.cosmos
 
+import cats.data.NonEmptyList
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http.Status
 import io.circe.Encoder
 
-sealed trait CosmosError {
+sealed trait CosmosError extends RuntimeException {
 
-  private[cosmos] def message: String = {
+  def status: Status = Status.BadRequest
+
+  override def getMessage: String = {
     this match {
       case PackageNotFound(packageName) => s"Package [$packageName] not found"
       case VersionNotFound(packageName, packageVersion) =>
         s"Version [$packageVersion] of package [$packageName] not found"
-      case EmptyPackageImport => "Package is empty"
+      case EmptyPackageImport() => "Package is empty"
       case PackageFileMissing(fileName) => s"Package file [$fileName] not found"
       case PackageFileNotJson(fileName, parseError) =>
         s"Package file [$fileName] is not JSON: $parseError"
       case PackageFileSchemaMismatch(fileName) => s"Package file [$fileName] does not match schema"
-      case PackageAlreadyInstalled => "Package is already installed"
-      case MarathonBadResponse(statusCode) =>
-        s"Received response status code $statusCode from Marathon"
-      case IndexNotFound => s"Index file missing for repo [${universeBundleUri()}]"
+      case PackageAlreadyInstalled() => "Package is already installed"
+      case MarathonBadResponse(marathonStatus) =>
+        s"Received response status code ${marathonStatus.code} from Marathon"
+      case MarathonBadGateway(marathonStatus) =>
+        s"Received response status code ${marathonStatus.code} from Marathon"
+      case IndexNotFound() => s"Index file missing for repo [${universeBundleUri()}]"
       case MarathonAppMetadataError(note) => note
       case MarathonAppDeleteError(appId) => s"Error while deleting marathon app '$appId'"
       case MarathonAppNotFound(appId) => s"Unable to locate service with marathon appId: '$appId'"
       case CirceError(cerr) => cerr.getMessage
       case MesosRequestError(note) => note
-      case ce @ ClientError(s, note) => ce.toString
-      case se @ ServerError(s, note) => se.toString
       case uct @ UnsupportedContentType(_, _) => uct.toString
       case ghe @ GenericHttpError(uri, status) => ghe.toString
       case aai @ AmbiguousAppId(_, _) => aai.toString
       case mfi @ MultipleFrameworkIds(_, _) => mfi.toString
+      case me @ MultipleError(_) => me.toString
+      case nelE @ NelErrors(_) => nelE.toString
     }
   }
 
@@ -39,34 +44,38 @@ sealed trait CosmosError {
 object CosmosError {
 
   implicit val jsonEncoder: Encoder[CosmosError] = {
-    Encoder[Map[String, String]].contramap { error =>
-      Map("message" -> error.message)
+    Encoder[Map[String, List[Map[String, String]]]].contramap { error =>
+      Map("errors" -> List(
+        Map("message" -> error.getMessage)
+      ))
     }
   }
 
 }
 
-private case class PackageNotFound(packageName: String) extends CosmosError
-private case class VersionNotFound(packageName: String, packageVersion: String) extends CosmosError
-private case object EmptyPackageImport extends CosmosError
-private case class PackageFileMissing(packageName: String) extends CosmosError
-private case class PackageFileNotJson(fileName: String, parseError: String) extends CosmosError
-private case class PackageFileSchemaMismatch(fileName: String) extends CosmosError
-private case object PackageAlreadyInstalled extends CosmosError
-private case class MarathonBadResponse(statusCode: Int) extends CosmosError
-private case object IndexNotFound extends CosmosError
+case class PackageNotFound(packageName: String) extends CosmosError
+case class VersionNotFound(packageName: String, packageVersion: String) extends CosmosError
+case class EmptyPackageImport() extends CosmosError
+case class PackageFileMissing(packageName: String) extends CosmosError
+case class PackageFileNotJson(fileName: String, parseError: String) extends CosmosError
+case class PackageFileSchemaMismatch(fileName: String) extends CosmosError
+case class PackageAlreadyInstalled() extends CosmosError { override val status = Status.Conflict }
+case class MarathonBadResponse(marathonStatus: Status) extends CosmosError { override val status = Status.InternalServerError }
+case class MarathonBadGateway(marathonStatus: Status) extends CosmosError { override val status = Status.BadGateway }
+case class IndexNotFound() extends CosmosError
 
-private case class MarathonAppMetadataError(note: String) extends CosmosError
-private case class MarathonAppDeleteError(appId: String) extends CosmosError
-private case class MarathonAppNotFound(appId: String) extends CosmosError
-private case class MesosRequestError(note: String) extends CosmosError
-private case class CirceError(cerr: io.circe.Error) extends CosmosError
+case class MarathonAppMetadataError(note: String) extends CosmosError
+case class MarathonAppDeleteError(appId: String) extends CosmosError
+case class MarathonAppNotFound(appId: String) extends CosmosError
+case class MesosRequestError(note: String) extends CosmosError
+case class CirceError(cerr: io.circe.Error) extends CosmosError
 
-private case class ClientError(status: Int, note: String) extends CosmosError
-private case class ServerError(status: Int, note: String) extends CosmosError
-private case class UnsupportedContentType(contentType: Option[String], supported: String) extends CosmosError
+case class UnsupportedContentType(contentType: Option[String], supported: String) extends CosmosError
 
-private case class GenericHttpError(uri: Uri, status: Status) extends CosmosError
+case class GenericHttpError(uri: Uri, override val status: Status) extends CosmosError
 
-private case class AmbiguousAppId(packageName: String, appIds: List[String]) extends CosmosError
-private case class MultipleFrameworkIds(frameworkName: String, ids: List[String]) extends CosmosError
+case class AmbiguousAppId(packageName: String, appIds: List[String]) extends CosmosError
+case class MultipleFrameworkIds(frameworkName: String, ids: List[String]) extends CosmosError
+
+case class MultipleError(errs: List[CosmosError]) extends CosmosError
+case class NelErrors(errs: NonEmptyList[CosmosError]) extends CosmosError //TODO: Cleanup

--- a/src/main/scala/com/mesosphere/cosmos/CosmosErrorFilter.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosErrorFilter.scala
@@ -1,0 +1,43 @@
+package com.mesosphere.cosmos
+
+import com.twitter.finagle.http._
+import com.twitter.finagle.stats.StatsReceiver
+import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.util.Future
+
+class CosmosErrorFilter()(implicit baseScope: BaseScope, statsReceiver: StatsReceiver) extends SimpleFilter[Request, Response] {
+  lazy val logger = org.slf4j.LoggerFactory.getLogger(classOf[CosmosErrorFilter])
+  val stats = {
+    baseScope.name match {
+      case Some(bs) if bs.nonEmpty => statsReceiver.scope(s"$bs/errorFilter")
+      case _ => statsReceiver.scope("errorFilter")
+    }
+  }
+  override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+    service(request)
+      .map { resp =>
+        val code = resp.status.code
+        if (500 <= code && code < 600) {
+          stats.counter(s"manual5xxResponse/$code").incr()
+          logger.warn("Manually returned 5xx response: {}", resp.toString)
+        }
+        resp
+      }
+      .handle {
+        case ce: CosmosError =>
+          stats.counter(s"definedError/${ce.getClass.getName}").incr()
+          val response = Response(ce.status)
+          val jsonString = CosmosError.jsonEncoder(ce).noSpaces
+          response.setContentTypeJson()
+          response.setContentString(jsonString)
+          response
+        case t: Throwable =>
+          stats.counter(s"unhandledThrowable/${t.getClass.getName}").incr()
+          logger.warn("Unhandled exception: ", t)
+          val response = Response(Status.InternalServerError)
+          response.setContentTypeJson()
+          response.setContentString(s"""{"message":"${t.getMessage}"}""")
+          response
+      }
+  }
+}

--- a/src/main/scala/com/mesosphere/cosmos/MarathonPackageRunner.scala
+++ b/src/main/scala/com/mesosphere/cosmos/MarathonPackageRunner.scala
@@ -12,11 +12,11 @@ final class MarathonPackageRunner(adminRouter: AdminRouter) extends PackageRunne
     adminRouter.createApp(renderedConfig)
       .map { response =>
         response.status match {
-          case Status.Conflict => failureOutput(errorNel(PackageAlreadyInstalled), Status.Conflict)
+          case Status.Conflict => throw PackageAlreadyInstalled()
           case status if (400 until 500).contains(status.code) =>
-            failureOutput(errorNel(MarathonBadResponse(status.code)), Status.InternalServerError)
+            throw MarathonBadResponse(status)
           case status if (500 until 600).contains(status.code) =>
-            failureOutput(errorNel(MarathonBadResponse(status.code)), Status.BadGateway)
+            throw MarathonBadGateway(status)
           case _ => Ok(Json.obj())
         }
       }

--- a/src/main/scala/com/mesosphere/cosmos/PackageCache.scala
+++ b/src/main/scala/com/mesosphere/cosmos/PackageCache.scala
@@ -1,6 +1,5 @@
 package com.mesosphere.cosmos
 
-import cats.data.Xor
 import com.mesosphere.cosmos.model.PackageFiles
 import com.twitter.util.Future
 
@@ -10,7 +9,7 @@ trait PackageCache {
   def getPackageFiles(
     packageName: String,
     version: Option[String]
-  ): Future[CosmosResult[PackageFiles]]
+  ): Future[PackageFiles]
 
 }
 
@@ -22,8 +21,8 @@ object PackageCache {
     def getPackageFiles(
       packageName: String,
       version: Option[String]
-    ): Future[CosmosResult[PackageFiles]] = {
-      Future.value(Xor.Left(errorNel(PackageNotFound(packageName))))
+    ): Future[PackageFiles] = {
+      Future.exception(PackageNotFound(packageName))
     }
   }
 

--- a/src/main/scala/com/mesosphere/cosmos/package.scala
+++ b/src/main/scala/com/mesosphere/cosmos/package.scala
@@ -25,11 +25,7 @@ object `package` {
     }
   }
 
-  type CosmosResult[A] = Xor[NonEmptyList[CosmosError], A]
-
   def errorNel(error: CosmosError): NonEmptyList[CosmosError] = NonEmptyList(error)
-
-  def leftErrorNel(error: CosmosError): Left[NonEmptyList[CosmosError]] = Xor.Left(errorNel(error))
 
   def successOutput(message: String): Output[Json] = {
     Output.payload(Map("message" -> message).asJson)

--- a/src/test/scala/com/mesosphere/cosmos/MemoryPackageCache.scala
+++ b/src/test/scala/com/mesosphere/cosmos/MemoryPackageCache.scala
@@ -1,6 +1,5 @@
 package com.mesosphere.cosmos
 
-import cats.syntax.option._
 import com.mesosphere.cosmos.model.PackageFiles
 import com.twitter.util.Future
 
@@ -13,8 +12,13 @@ final case class MemoryPackageCache(packages: Map[String, PackageFiles]) extends
   def getPackageFiles(
     packageName: String,
     version: Option[String]
-  ): Future[CosmosResult[PackageFiles]] = {
-    Future.value(packages.get(packageName).toRightXor(errorNel(PackageNotFound(packageName))))
+  ): Future[PackageFiles] = {
+    Future.value {
+      packages.get(packageName) match {
+        case None => throw PackageNotFound(packageName)
+        case Some(a) => a
+      }
+    }
   }
 
 }

--- a/src/test/scala/com/mesosphere/cosmos/UserOptionsSpec.scala
+++ b/src/test/scala/com/mesosphere/cosmos/UserOptionsSpec.scala
@@ -49,7 +49,7 @@ final class UserOptionsSpec extends UnitSpec {
         val cosmos = new Cosmos(
           packageCache,
           packageRunner,
-          (r : UninstallRequest) => { Future.value(Xor.Right(UninstallResponse(Nil))) }
+          (r : UninstallRequest) => { Future.value(UninstallResponse(Nil)) }
         )
         val request = RequestBuilder()
           .url("http://dummy.cosmos.host/v1/package/install")


### PR DESCRIPTION
This is being done after a discussion regarding project work velocity. For now the additional overhead of dealing with CosmosResult and xor is adding a fair amount of additional work in terms of getting the compiler to carry things through the way we want/expect.

The idea of CosmosResult may resurface in the future but for now it's being ripped out.
