### PR TITLE
Validate package options against the config.json schema during install

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -18,6 +18,7 @@ object CosmosBuild extends Build {
     val scalaUri = "0.4.11"
     val scalaTest = "2.2.4"
     val scalaCheck = "1.10.0"
+    val jsonSchema = "2.2.6"
   }
 
   object Deps {
@@ -54,6 +55,10 @@ object CosmosBuild extends Build {
 
     val scalaTest = Seq(
       "org.scalatest"       %% "scalatest"        % V.scalaTest     % "test"
+    )
+
+    val jsonSchema = Seq(
+      "com.github.fge" % "json-schema-validator" % V.jsonSchema
     )
 
   }
@@ -139,6 +144,7 @@ object CosmosBuild extends Build {
           ++ Deps.mustache
           ++ Deps.scalaTest
           ++ Deps.scalaUri
+          ++ Deps.jsonSchema
     )
 
   //////////////////////////////////////////////////////////////////////////////

--- a/src/it/scala/com/mesosphere/cosmos/ErrorResponseSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/ErrorResponseSpec.scala
@@ -3,7 +3,6 @@ package com.mesosphere.cosmos
 import cats.data.Xor
 import com.twitter.io.Buf
 import com.twitter.finagle.http.Status
-import io.circe._
 import io.circe.parse._
 import io.circe.syntax._
 import io.circe.generic.auto._    // Required for auto-parsing case classes from JSON

--- a/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.cosmos
 
 import cats.data.NonEmptyList
+import com.github.fge.jsonschema.core.report.ProcessingMessage
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http.Status
 
@@ -23,7 +24,7 @@ sealed trait CosmosError extends RuntimeException {
         s"Received response status code ${marathonStatus.code} from Marathon"
       case MarathonBadGateway(marathonStatus) =>
         s"Received response status code ${marathonStatus.code} from Marathon"
-      case IndexNotFound(repoUri: Uri) => s"Index file missing for repo [$repoUri]"
+      case IndexNotFound(repoUri) => s"Index file missing for repo [$repoUri]"
       case MarathonAppMetadataError(note) => note
       case MarathonAppDeleteError(appId) => s"Error while deleting marathon app '$appId'"
       case MarathonAppNotFound(appId) => s"Unable to locate service with marathon appId: '$appId'"
@@ -35,6 +36,7 @@ sealed trait CosmosError extends RuntimeException {
       case mfi @ MultipleFrameworkIds(_, _) => mfi.toString
       case me @ MultipleError(_) => me.toString
       case nelE @ NelErrors(_) => nelE.toString
+      case JsonSchemaMismatch() => "Options JSON failed validation"
     }
   }
 
@@ -66,3 +68,5 @@ case class MultipleFrameworkIds(frameworkName: String, ids: List[String]) extend
 
 case class MultipleError(errs: List[CosmosError]) extends CosmosError
 case class NelErrors(errs: NonEmptyList[CosmosError]) extends CosmosError //TODO: Cleanup
+
+case class JsonSchemaMismatch() extends CosmosError

--- a/src/main/scala/com/mesosphere/cosmos/PackageInstall.scala
+++ b/src/main/scala/com/mesosphere/cosmos/PackageInstall.scala
@@ -5,6 +5,7 @@ import java.util.Base64
 
 import cats.data.Xor
 import com.github.mustachejava.DefaultMustacheFactory
+import com.mesosphere.cosmos.jsonschema.JsonSchemaValidation
 import com.mesosphere.cosmos.model.{InstallRequest, PackageFiles, Resource}
 import com.twitter.io.Charsets
 import io.circe.generic.auto._
@@ -40,6 +41,11 @@ object PackageInstall {
 
     val defaults = extractDefaultsFromConfig(packageFiles.configJson)
     val merged = merge(defaults, options)
+
+    if (!JsonSchemaValidation.matchesSchema(Json.fromJsonObject(merged), packageFiles.configJson)) {
+      throw JsonSchemaMismatch()
+    }
+
     val resource = extractAssetsAsJson(packageFiles.resourceJson)
     val complete = merged + ("resource", Json.fromJsonObject(resource))
     val params = jsonToJava(Json.fromJsonObject(complete))

--- a/src/main/scala/com/mesosphere/cosmos/jsonschema/Jackson.scala
+++ b/src/main/scala/com/mesosphere/cosmos/jsonschema/Jackson.scala
@@ -1,0 +1,47 @@
+package com.mesosphere.cosmos.jsonschema
+
+import cats.data.Xor
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
+import io.circe.parse.parse
+import io.circe.{Decoder, Encoder, Json}
+
+import scala.collection.JavaConverters._
+
+private[jsonschema] object Jackson {
+
+  private[jsonschema] implicit val JsonNodeEncoder: Encoder[JsonNode] = Encoder.instance(jsonNodeToCirceJson)
+
+  private[jsonschema] implicit val JsonNodeDecoder: Decoder[JsonNode] = Decoder.instance { hcursor =>
+    Xor.Right(circeJsonToJsonNode(hcursor.top))
+  }
+
+  private[this] def jsonNodeToCirceJson(node: JsonNode): Json = {
+    // Inefficient, but good enough for now
+    val Xor.Right(json) = parse(node.toString)
+    json
+  }
+
+  private[this] def circeJsonToJsonNode(json: Json): JsonNode = {
+    json.fold(
+      jsonNull = JsonNodeFactory.instance.nullNode,
+      jsonBoolean = JsonNodeFactory.instance.booleanNode,
+      jsonNumber = { jsonNumber =>
+        jsonNumber.toBigInt match {
+          case Some(bigInt) => JsonNodeFactory.instance.numberNode(bigInt.underlying())
+          case _ => JsonNodeFactory.instance.numberNode(jsonNumber.toBigDecimal.underlying())
+        }
+      },
+      jsonString = JsonNodeFactory.instance.textNode,
+      jsonArray = { arr =>
+        val arrayNode = JsonNodeFactory.instance.arrayNode()
+        arrayNode.addAll(arr.map(circeJsonToJsonNode).asJava)
+      },
+      jsonObject = { obj =>
+        val objectNode = JsonNodeFactory.instance.objectNode()
+        objectNode.setAll(obj.toMap.mapValues(circeJsonToJsonNode).asJava)
+      }
+    )
+  }
+
+}

--- a/src/main/scala/com/mesosphere/cosmos/jsonschema/JsonSchemaValidation.scala
+++ b/src/main/scala/com/mesosphere/cosmos/jsonschema/JsonSchemaValidation.scala
@@ -1,0 +1,22 @@
+package com.mesosphere.cosmos.jsonschema
+
+import cats.data.Xor
+import com.fasterxml.jackson.databind.JsonNode
+import com.github.fge.jsonschema.main.JsonSchemaFactory
+import com.mesosphere.cosmos.jsonschema.Jackson._
+import io.circe.Json
+
+private[cosmos] object JsonSchemaValidation {
+
+  private[cosmos] def matchesSchema(document: Json, schema: Json): Boolean = {
+    val Xor.Right(documentNode) = document.as[JsonNode]
+    val Xor.Right(schemaNode) = schema.as[JsonNode]
+
+    JsonSchemaFactory
+      .byDefault()
+      .getValidator
+      .validate(schemaNode, documentNode)
+      .isSuccess
+  }
+
+}


### PR DESCRIPTION
This is the first part of #63 -- actually doing the validation. The next step is to return detailed information about the validation failure in the response. But that needs further refinement of how we translate `CosmosError`s into JSON.

As mentioned in the `#cosmos` channel on Slack, this code is very strict; it will fail the request even if the validation only generates warnings. As we test package install against packages other than `helloworld` and `cassandra`, we'll likely need to fix some of their `config.json` files to be conformant to the validator. The `chronos` package currently fails, for example.
