### PR TITLE
Generate package install endpoint response from case class

### DIFF
--- a/src/it/scala/com/mesosphere/cosmos/CosmosSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/CosmosSpec.scala
@@ -1,17 +1,17 @@
 package com.mesosphere.cosmos
 
 import com.netaporter.uri.Uri
-import com.netaporter.uri.Uri
 import com.twitter.app.{FlagParseException, FlagUsageError, Flags}
 import com.twitter.finagle.http.RequestBuilder
 import com.twitter.finagle.http.RequestConfig.Yes
 import org.scalatest.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
+import org.slf4j.{LoggerFactory, Logger}
 
 /** Mixins used by all Cosmos tests. */
 trait CosmosSpec extends Matchers with TableDrivenPropertyChecks {
-  private val name: String = getClass.getName.stripSuffix("$")
-  protected[this] lazy val logger = org.slf4j.LoggerFactory.getLogger(name)
+  private[this] val name: String = getClass.getName.stripSuffix("$")
+  protected[this] lazy val logger: Logger = LoggerFactory.getLogger(name)
 
   // Enable definition of implicit conversion methods; see below
   import scala.language.implicitConversions

--- a/src/it/scala/com/mesosphere/cosmos/ErrorResponseSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/ErrorResponseSpec.scala
@@ -21,7 +21,7 @@ class ErrorResponseSpec extends IntegrationSpec {
     val msg = err.errors.head.message
     assert(msg.contains("body"))
     assert(msg.contains("decode value"))
-    assert(msg.contains("name"))
+    assert(msg.contains("packageName"))
   }
 
 }

--- a/src/it/scala/com/mesosphere/cosmos/IntegrationHelpers.scala
+++ b/src/it/scala/com/mesosphere/cosmos/IntegrationHelpers.scala
@@ -7,9 +7,6 @@ import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 import java.nio.file.attribute.BasicFileAttributes
 import java.io.IOException
 
-import io.circe.Json
-import io.circe.syntax._
-
 object IntegrationHelpers {
 
   def withTempDirectory[A](f: Path => A): A = {
@@ -36,10 +33,5 @@ object IntegrationHelpers {
         val _ = Files.walkFileTree(tempDir, visitor)
       }.get()
   }
-
-  def errorJson(message: String): Json = {
-    Map("errors" -> Seq(Map("message" -> message))).asJson
-  }
-
 
 }

--- a/src/it/scala/com/mesosphere/cosmos/UninstallHandlerSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/UninstallHandlerSpec.scala
@@ -2,6 +2,7 @@ package com.mesosphere.cosmos
 
 import java.nio.file.Files
 import com.mesosphere.cosmos.http.MediaTypes
+import com.mesosphere.cosmos.model.AppId
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status}
@@ -34,21 +35,22 @@ final class UninstallHandlerSpec extends IntegrationSpec {
 
   "The uninstall handler" should "be able to uninstall a service" in { service =>
     val installRequest = requestBuilder("v1/package/install")
-      .buildPost(Buf.Utf8("""{"name":"cassandra","options":{}}"""))
+      .buildPost(Buf.Utf8("""{"packageName":"cassandra","options":{}}"""))
     val installResponse = service(installRequest)
     val installResponseBody = installResponse.contentString
     logger.info("installResponseBody = {}", installResponseBody)
     assertResult(Status.Ok)(installResponse.status)
 
-    val marathonApp = Await.result(adminRouter.getApp("cassandra" / "dcos"))
-    assertResult("/cassandra/dcos")(marathonApp.app.id)
+    val appId = AppId("cassandra" / "dcos")
+    val marathonApp = Await.result(adminRouter.getApp(appId))
+    assertResult(appId)(marathonApp.app.id)
 
     //TODO: Assert framework starts up
 
     val uninstallRequest = requestBuilder("v1/package/uninstall")
       .setHeader("Accept", MediaTypes.UninstallResponse.show)
       .setHeader("Content-Type", MediaTypes.UninstallRequest.show)
-      .buildPost(Buf.Utf8("""{"name":"cassandra"}"""))
+      .buildPost(Buf.Utf8("""{"packageName":"cassandra"}"""))
     val uninstallResponse = service(uninstallRequest)
     val uninstallResponseBody = uninstallResponse.contentString
     logger.info("uninstallResponseBody = {}", uninstallResponseBody)

--- a/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -53,10 +53,8 @@ private[cosmos] final class Cosmos(
   val packageInstall: Endpoint[Json] = {
 
     def respond(reqBody: InstallRequest): Future[Output[Json]] = {
-      packageCache
-        .getPackageFiles(reqBody.name, reqBody.version)
-        .map(PackageInstall.preparePackageConfig(reqBody, _))
-        .flatMap(packageRunner.launch)
+      PackageInstall.install(packageCache, packageRunner)(reqBody)
+        .map(res => Ok(res.asJson))
     }
 
     post("v1" / "package" / "install" ? body.as[InstallRequest])(respond _)

--- a/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -2,6 +2,7 @@ package com.mesosphere.cosmos
 
 import cats.data.NonEmptyList
 import com.github.fge.jsonschema.core.report.ProcessingMessage
+import com.mesosphere.cosmos.model.AppId
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http.Status
 
@@ -56,8 +57,8 @@ case class IndexNotFound(repoUri: Uri) extends CosmosError
 case class RepositoryNotFound() extends CosmosError
 
 case class MarathonAppMetadataError(note: String) extends CosmosError
-case class MarathonAppDeleteError(appId: String) extends CosmosError
-case class MarathonAppNotFound(appId: String) extends CosmosError
+case class MarathonAppDeleteError(appId: AppId) extends CosmosError
+case class MarathonAppNotFound(appId: AppId) extends CosmosError
 case class MesosRequestError(note: String) extends CosmosError
 case class CirceError(cerr: io.circe.Error) extends CosmosError
 
@@ -65,7 +66,7 @@ case class UnsupportedContentType(contentType: Option[String], supported: String
 
 case class GenericHttpError(uri: Uri, override val status: Status) extends CosmosError
 
-case class AmbiguousAppId(packageName: String, appIds: List[String]) extends CosmosError
+case class AmbiguousAppId(packageName: String, appIds: List[AppId]) extends CosmosError
 case class MultipleFrameworkIds(frameworkName: String, ids: List[String]) extends CosmosError
 
 case class MultipleError(errs: List[CosmosError]) extends CosmosError

--- a/src/main/scala/com/mesosphere/cosmos/PackageRunner.scala
+++ b/src/main/scala/com/mesosphere/cosmos/PackageRunner.scala
@@ -1,8 +1,8 @@
 package com.mesosphere.cosmos
 
+import com.mesosphere.cosmos.model.mesos.master.MarathonApp
 import com.twitter.util.Future
 import io.circe.Json
-import io.finch.Output
 
 /** The service that packages are installed to; currently defaults to Marathon in DCOS. */
 trait PackageRunner {
@@ -10,8 +10,8 @@ trait PackageRunner {
   /** Execute the package described by the given JSON configuration.
     *
     * @param renderedConfig the fully-specified configuration of the package to run
-    * @return An HTTP status code and message indicating success or failure.
+    * @return The response from Marathon, if the request was successful.
     */
-  def launch(renderedConfig: Json): Future[Output[Json]]
+  def launch(renderedConfig: Json): Future[MarathonApp]
 
 }

--- a/src/main/scala/com/mesosphere/cosmos/model/AppId.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/AppId.scala
@@ -1,0 +1,28 @@
+package com.mesosphere.cosmos.model
+
+import com.netaporter.uri.Uri
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder}
+
+/** Normalizes the representation of Marathon app IDs to ensure we can compare them correctly.
+  *
+  * Stores the app ID as a string for the common case where we're just passing it along with other
+  * data. Converting it to a URI to invoke a Marathon endpoint should happen more rarely.
+  *
+  * Extends [[scala.AnyVal]] to avoid allocation overhead.
+  */
+final class AppId private(override val toString: String) extends AnyVal {
+
+  def toUri: Uri = Uri.parse(toString)
+
+}
+
+object AppId {
+
+  def apply(s: String): AppId = new AppId(if (s.startsWith("/")) s else "/" + s)
+
+  implicit val encoder: Encoder[AppId] = Encoder.instance(_.toString.asJson)
+
+  implicit val decoder: Decoder[AppId] = Decoder.decodeString.map(AppId(_))
+
+}

--- a/src/main/scala/com/mesosphere/cosmos/model/InstallRequest.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/InstallRequest.scala
@@ -3,20 +3,27 @@ package com.mesosphere.cosmos.model
 import io.circe.JsonObject
 
 case class InstallRequest(
-  name: String,
-  version: Option[String] = None,
+  packageName: String,
+  packageVersion: Option[String] = None,
   options: Option[JsonObject] = None,
-  appId: Option[String] = None
+  appId: Option[AppId] = None
 )
+
+case class InstallResponse(
+  packageName: String,
+  packageVersion: String,
+  appId: AppId
+)
+
 case class UninstallRequest(
-  name: String,
-  appId: Option[String],
+  packageName: String,
+  appId: Option[AppId],
   all: Option[Boolean]
 )
 
 case class UninstallResponse(results: List[UninstallResult])
 case class UninstallResult(
-  name: String,
-  appId: String,
+  packageName: String,
+  appId: AppId,
   version: Option[String]
 )

--- a/src/main/scala/com/mesosphere/cosmos/model/mesos/master/Master.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/mesos/master/Master.scala
@@ -1,5 +1,7 @@
 package com.mesosphere.cosmos.model.mesos.master
 
+import com.mesosphere.cosmos.model.AppId
+
 //todo: flush out
 case class MasterState(
   frameworks: List[Framework]
@@ -15,7 +17,7 @@ case class MesosFrameworkTearDownResponse()
 case class MarathonAppResponse(app: MarathonApp)
 case class MarathonAppsResponse(apps: List[MarathonApp])
 case class MarathonApp(
-  id: String,
+  id: AppId,
   labels: Map[String, String],
   uris: List[String] /*TODO: uri type*/
 )

--- a/src/test/scala/com/mesosphere/cosmos/model/AppIdSpec.scala
+++ b/src/test/scala/com/mesosphere/cosmos/model/AppIdSpec.scala
@@ -1,0 +1,28 @@
+package com.mesosphere.cosmos.model
+
+import cats.data.Xor
+import com.mesosphere.cosmos.UnitSpec
+import com.netaporter.uri.dsl._
+import io.circe.parse._
+import io.circe.syntax._
+import io.circe.Json
+
+final class AppIdSpec extends UnitSpec {
+
+  private[this] val relative: String = "cassandra/dcos"
+  private[this] val absolute: String = s"/$relative"
+
+  "AppId tests" in {
+    assertResult(absolute)(AppId(absolute).toString)
+    assertResult(absolute)(AppId(relative).toString)
+
+    assertResult(AppId(absolute))(AppId(relative))
+    assertResult(AppId(absolute).hashCode)(AppId(relative).hashCode)
+
+    assertResult(Json.string(absolute))(AppId(relative).asJson)
+    assertResult(Xor.Right(AppId(absolute)))(decode[AppId](relative.asJson.noSpaces))
+
+    assertResult("cassandra" / "dcos")(AppId(relative).toUri)
+  }
+
+}


### PR DESCRIPTION
This relates to #70 and #101. I've defined an `InstallResponse` case class that matches the spec for the package install endpoint.

In the process I introduced a common `Logging` trait and an `AppId` value class which ensures app IDs like `cassandra/dcos` and `/cassandra/dcos` are treated equivalently.
