### PR TITLE
Add new class EndpointHandler[Req, Rep]

### DIFF
--- a/src/it/scala/com/mesosphere/cosmos/ErrorResponseSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/ErrorResponseSpec.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor
+import com.mesosphere.cosmos.http.MediaTypes
 import com.twitter.io.Buf
 import com.twitter.finagle.http.Status
 import io.circe.parse._
@@ -15,6 +16,7 @@ class ErrorResponseSpec extends IntegrationSpec {
     val response = service(post)
 
     assertResult(Status.BadRequest)(response.status)
+    assertResult(MediaTypes.ErrorResponse.show)(response.headerMap("Content-Type"))
     val Xor.Right(err) = decode[ErrorResponse](response.contentString)
     val msg = err.errors.head.message
     assert(msg.contains("body"))

--- a/src/it/scala/com/mesosphere/cosmos/IntegrationSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/IntegrationSpec.scala
@@ -14,6 +14,9 @@ abstract class IntegrationSpec
     val adminRouterUri = adminRouterHost
     val dcosClient = Services.adminRouterClient(adminRouterUri).get
     val adminRouter = new AdminRouter(adminRouterUri, dcosClient)
+    // these two imports provide the implicit DecodeRequest instances needed to instantiate Cosmos
+    import io.circe.generic.auto._
+    import io.finch.circe._
     new Cosmos(PackageCache.empty, new MarathonPackageRunner(adminRouter), new UninstallHandler(adminRouter)).service
   }
 

--- a/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -2,6 +2,7 @@ package com.mesosphere.cosmos
 
 import cats.data.Xor
 import cats.data.Xor.Right
+import com.mesosphere.cosmos.http.EndpointHandler
 import com.mesosphere.cosmos.model._
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http._
@@ -71,10 +72,13 @@ final class PackageDescribeSpec extends FreeSpec with CosmosSpec {
   )(
     f: DescribeTestAssertionDecorator => Unit
   ): Unit = {
+    // these two imports provide the implicit DecodeRequest instances needed to instantiate Cosmos
+    import io.circe.generic.auto._
+    import io.finch.circe._
     val service = new Cosmos(
       packageCache,
       new MarathonPackageRunner(adminRouter),
-      (r : UninstallRequest) => { Future.value(UninstallResponse(Nil)) }
+      EndpointHandler.const(UninstallResponse(Nil))
     ).service
     val server = Http.serve(s":$servicePort", service)
     val client = Http.newService(s"127.0.0.1:$servicePort")

--- a/src/it/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
@@ -221,6 +221,9 @@ final class PackageInstallSpec extends FreeSpec with BeforeAndAfterAll with Cosm
     f: ApiTestAssertionDecorator => Unit
   ): Unit = {
     val adminRouter = new AdminRouter(adminRouterHost, dcosClient)
+    // these two imports provide the implicit DecodeRequest instances needed to instantiate Cosmos
+    import io.circe.generic.auto._
+    import io.finch.circe._
     val service = new Cosmos(packageCache, new MarathonPackageRunner(adminRouter), new UninstallHandler(adminRouter)).service
     val server = Http.serve(s":$servicePort", service)
     val client = Http.newService(s"127.0.0.1:$servicePort")
@@ -285,10 +288,10 @@ private object PackageInstallSpec extends CosmosSpec {
     ("cassandra", "foobar")
   )
 
-  private def getPackageInfo(appId: String): Future[PackageInfo] = {
+  private def getPackageInfo(appId: String): Future[ExpectedPackageInfo] = {
     adminRouter.getApp(appId)
       .map { appResp =>
-        PackageInfo(appResp.app.uris, appResp.app.labels)
+        ExpectedPackageInfo(appResp.app.uris, appResp.app.labels)
       }
   }
 
@@ -466,7 +469,7 @@ private sealed trait PostInstallState
 private case object Installed extends PostInstallState
 private case object Unchanged extends PostInstallState
 
-case class PackageInfo(uris: List[String], labels: Map[String, String])
+case class ExpectedPackageInfo(uris: List[String], labels: Map[String, String])
 
 case class StandardLabels(
   packageMetadata: Json,

--- a/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor.Right
+import com.mesosphere.cosmos.http.EndpointHandler
 import com.mesosphere.cosmos.model._
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http._
@@ -58,10 +59,13 @@ final class PackageSearchSpec extends FreeSpec with CosmosSpec {
   )(
     f: SearchTestAssertionDecorator => Unit
   ): Unit = {
+    // these two imports provide the implicit DecodeRequest instances needed to instantiate Cosmos
+    import io.circe.generic.auto._
+    import io.finch.circe._
     val service = new Cosmos(
       packageCache,
       new MarathonPackageRunner(adminRouter),
-      (r : UninstallRequest) => { Future.value(UninstallResponse(Nil)) }
+      EndpointHandler.const(UninstallResponse(Nil))
     ).service
     val server = Http.serve(s":$servicePort", service)
     val client = Http.newService(s"127.0.0.1:$servicePort")

--- a/src/it/scala/com/mesosphere/cosmos/UninstallHandlerSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/UninstallHandlerSpec.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos
 
 import java.nio.file.Files
-
+import com.mesosphere.cosmos.http.MediaTypes
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status}
@@ -46,11 +46,14 @@ final class UninstallHandlerSpec extends IntegrationSpec {
     //TODO: Assert framework starts up
 
     val uninstallRequest = requestBuilder("v1/package/uninstall")
+      .setHeader("Accept", MediaTypes.UninstallResponse.show)
+      .setHeader("Content-Type", MediaTypes.UninstallRequest.show)
       .buildPost(Buf.Utf8("""{"name":"cassandra"}"""))
     val uninstallResponse = service(uninstallRequest)
     val uninstallResponseBody = uninstallResponse.contentString
     logger.info("uninstallResponseBody = {}", uninstallResponseBody)
     assertResult(Status.Ok)(uninstallResponse.status)
+    assertResult(MediaTypes.UninstallResponse.show)(uninstallResponse.headerMap("Content-Type"))
   }
 
 }

--- a/src/main/scala/com/mesosphere/cosmos/UninstallHandler.scala
+++ b/src/main/scala/com/mesosphere/cosmos/UninstallHandler.scala
@@ -1,12 +1,19 @@
 package com.mesosphere.cosmos
 
+import com.mesosphere.cosmos.http.{MediaTypes, EndpointHandler}
 import com.mesosphere.cosmos.model.{UninstallResult, UninstallRequest, UninstallResponse}
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.http.Status
 import com.twitter.util.Future
+import io.circe.Encoder
+import io.finch.DecodeRequest
 
 private[cosmos] final class UninstallHandler(adminRouter: AdminRouter)
-  extends Function[UninstallRequest, Future[UninstallResponse]] {
+  (implicit bodyDecoder: DecodeRequest[UninstallRequest], encoder: Encoder[UninstallResponse])
+  extends EndpointHandler[UninstallRequest, UninstallResponse] {
+
+  val accepts = MediaTypes.UninstallRequest
+  val produces = MediaTypes.UninstallResponse
 
   private type FwIds = List[String]
 

--- a/src/main/scala/com/mesosphere/cosmos/http/EndpointHandler.scala
+++ b/src/main/scala/com/mesosphere/cosmos/http/EndpointHandler.scala
@@ -1,0 +1,55 @@
+package com.mesosphere.cosmos.http
+
+import FinchExtensions._
+import com.twitter.util.Future
+import io.circe.{Encoder, Printer}
+import io.finch._
+
+import scala.reflect.ClassTag
+
+abstract class EndpointHandler[Request, Response]
+(implicit
+  decoder: DecodeRequest[Request],
+  requestClassTag: ClassTag[Request],
+  encoder: Encoder[Response],
+  responseClassTag: ClassTag[Response]
+)
+  extends Function[Request, Future[Response]] {
+  def accepts: MediaType
+  def produces: MediaType
+
+  // This field HAS to be lazy, otherwise a NullPointerException will be thrown on class initialization
+  // because the description provided by `beTheExpectedType` is eagerly evaluated.
+  final lazy val reader: RequestReader[Request] = for {
+    accept <- header("Accept").as[MediaType].should(beTheExpectedType(produces))
+    contentType <- header("Content-Type").as[MediaType].should(beTheExpectedType(accepts))
+    req <- body.as[Request]
+  } yield req
+
+  private val printer: Printer = Printer.noSpaces.copy(dropNullKeys = true, preserveOrder = true)
+  lazy val encodeResponseType: EncodeResponse[Response] =
+    EncodeResponse.fromString[Response](produces.show, produces.parameters.flatMap(_.get("charset"))) { response =>
+      printer.pretty(encoder(response))
+    }
+
+}
+
+object EndpointHandler {
+
+  /**
+    * Create an endpoint that will always return `resp` regardless of what request is sent to it.  Really only useful
+    * for bootstrapping tests.
+    */
+  def const[Request, Response](resp: Response)(implicit
+    decoder: DecodeRequest[Request],
+    requestClassTag: ClassTag[Request],
+    encoder: Encoder[Response],
+    responseClassTag: ClassTag[Response]
+  ): EndpointHandler[Request, Response] = {
+    new EndpointHandler[Request, Response] {
+      val accepts = MediaType.applicationJson
+      val produces = MediaType.applicationJson
+      override def apply(v1: Request): Future[Response] = Future.value(resp)
+    }
+  }
+}

--- a/src/main/scala/com/mesosphere/cosmos/http/MediaType.scala
+++ b/src/main/scala/com/mesosphere/cosmos/http/MediaType.scala
@@ -1,0 +1,61 @@
+package com.mesosphere.cosmos.http
+
+import com.twitter.util.Try
+
+
+case class MediaTypeSubType(value: String, suffix: Option[String] = None)
+object MediaTypeSubType {
+  def parse(s: String): MediaTypeSubType = {
+    s.split('+').toList match {
+      case v :: suffix :: Nil => new MediaTypeSubType(v.toLowerCase, Some(suffix.toLowerCase))
+      case v :: Nil => new MediaTypeSubType(v.toLowerCase, None)
+      case _ => throw new IllegalStateException(s"Unable to parse suffix from sub-type for value: '$s'")
+    }
+  }
+}
+
+/**
+  * https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
+  *
+  */
+case class MediaType(
+  `type`: String,
+  subType: MediaTypeSubType,
+  parameters: Option[Map[String, String]] = None
+) {
+
+  def show: String = {
+    val t = subType match {
+      case MediaTypeSubType(st, Some(suf)) =>
+        s"${`type`}/$st+$suf"
+      case MediaTypeSubType(st, None) =>
+        s"${`type`}/$st"
+    }
+    val p = parameters match {
+      case Some(ps) =>
+        ps.toVector.map { case (key, value) => s"$key=$value" } mkString(start = ";", sep = ";", end = "")
+      case None =>
+        ""
+    }
+
+    t + p
+  }
+}
+
+
+object MediaType {
+  val applicationJson = MediaType("application", MediaTypeSubType("json"), Some(Map("charset" -> "utf-8")))
+
+  def unapply(s: String): Option[MediaType] = {
+    parse(s).toOption
+  }
+
+  def apply(t: String, st: String): MediaType = {
+    MediaType(t, MediaTypeSubType(st))
+  }
+
+  def parse(s: String): Try[MediaType] = {
+    MediaTypeParser.parse(s)
+  }
+
+}

--- a/src/main/scala/com/mesosphere/cosmos/http/MediaTypeParser.scala
+++ b/src/main/scala/com/mesosphere/cosmos/http/MediaTypeParser.scala
@@ -1,0 +1,44 @@
+package com.mesosphere.cosmos.http
+
+import java.util
+
+import com.google.common.collect.Multimaps
+import com.google.common.net.{MediaType => GMediaType}
+import com.twitter.util.Try
+
+import scala.collection.JavaConversions._
+
+case class MediaTypeParseError(msg: String, cause: Throwable) extends RuntimeException(msg, cause)
+
+object MediaTypeParser {
+
+  def parse(s: String): Try[MediaType] = {
+    Try {
+      GMediaType.parse(s)
+    }
+      .map { mediaType =>
+        val parameters = mediaType.parameters()
+        val params = if (parameters.isEmpty) {
+          None
+        } else {
+          Some(
+            Multimaps.asMap(parameters).toMap
+              .map { case (key: String, v: util.List[String]) =>
+                key.toLowerCase -> v.toList.head
+              }
+          )
+        }
+        MediaType(
+          `type` = mediaType.`type`().toLowerCase,
+          subType = MediaTypeSubType.parse(mediaType.subtype()),
+          parameters = params
+        )
+      }
+      .handle {
+        case iae: IllegalArgumentException =>
+          throw new MediaTypeParseError(s"Unable to parse MediaType for input: '$s'", iae)
+        case ise: IllegalStateException =>
+          throw new MediaTypeParseError(s"Unable to parse MediaType for input: '$s'", ise)
+      }
+  }
+}

--- a/src/main/scala/com/mesosphere/cosmos/http/MediaTypes.scala
+++ b/src/main/scala/com/mesosphere/cosmos/http/MediaTypes.scala
@@ -1,0 +1,15 @@
+package com.mesosphere.cosmos.http
+
+object MediaTypes {
+  private[this] def vnd(kind: String): MediaType =
+    MediaType(
+      "application",
+      MediaTypeSubType(s"vnd.dcos.cosmos.$kind", Some("json")),
+      Some(Map("charset" -> "utf-8", "version" -> "v1"))
+    )
+
+  val UninstallRequest = vnd("uninstall-request")
+  val UninstallResponse = vnd("uninstall-response")
+  val ErrorResponse = vnd("error")
+
+}

--- a/src/test/scala/com/mesosphere/cosmos/UserOptionsSpec.scala
+++ b/src/test/scala/com/mesosphere/cosmos/UserOptionsSpec.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor
+import com.mesosphere.cosmos.http.EndpointHandler
 import com.mesosphere.cosmos.model._
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http.RequestBuilder
@@ -48,10 +49,13 @@ final class UserOptionsSpec extends UnitSpec {
         val packageCache = MemoryPackageCache(packages)
         val packageRunner = new RecordingPackageRunner
 
+        // these two imports provide the implicit DecodeRequest instances needed to instantiate Cosmos
+        import io.circe.generic.auto._
+        import io.finch.circe._
         val cosmos = new Cosmos(
           packageCache,
           packageRunner,
-          (r : UninstallRequest) => { Future.value(UninstallResponse(Nil)) }
+          EndpointHandler.const(UninstallResponse(Nil))
         )
         val request = RequestBuilder()
           .url("http://dummy.cosmos.host/v1/package/install")

--- a/src/test/scala/com/mesosphere/cosmos/http/FinchExtensionsSpec.scala
+++ b/src/test/scala/com/mesosphere/cosmos/http/FinchExtensionsSpec.scala
@@ -1,0 +1,69 @@
+package com.mesosphere.cosmos.http
+
+import com.twitter.util.Try
+import org.scalatest.FreeSpec
+
+import scala.language.implicitConversions
+
+class FinchExtensionsSpec extends FreeSpec {
+
+  "beTheExpectedType(MediaType) should" - {
+    "pass for" - {
+      "type/subtype & type/subtype" in {
+        shouldSucceed("type/subtype", "type/subtype")
+      }
+
+      "type/subtype+suffix & type/subtype+suffix" in {
+        shouldSucceed("type/subtype+suffix", "type/subtype+suffix")
+      }
+
+      "type/subtype;k=v & type/subtype;k=v" in  {
+        shouldSucceed("type/subtype;k=v", "type/subtype;k=v")
+      }
+
+      "type/subtype;charset=utf-8 & type/subtype;charset=utf-8" in {
+        shouldSucceed("type/subtype;charset=utf-8", "type/subtype;charset=utf-8")
+      }
+
+      "type/subtype & type/subtype;charset=utf-8" in {
+        shouldSucceed("type/subtype", "type/subtype;charset=utf-8")
+      }
+
+      "type/subtype;charset=utf-8 & type/subtype;charset=utf-8;foo=bar" in {
+        shouldSucceed("type/subtype;charset=utf-8", "type/subtype;charset=utf-8;foo=bar")
+      }
+    }
+
+    "fail for" - {
+      "type/subtype+suffix & type/subtype" in {
+        shouldFail("type/subtype+suffix", "type/subtype")
+      }
+
+      "type/subtype & type/subtype+suffix" in {
+        shouldFail("type/subtype", "type/subtype+suffix")
+      }
+
+      "type/subtype;charset=utf-8 & type/subtype" in {
+        shouldFail("type/subtype;charset=utf-8", "type/subtype")
+      }
+
+      "type/subtype;charset=utf-8 & type/subtype;foo=bar" in {
+        shouldFail("type/subtype;charset=utf-8", "type/subtype;foo=bar")
+      }
+    }
+  }
+
+  private[this] def shouldSucceed(expected: Try[MediaType], actual: Try[MediaType]): Unit = {
+    assertMatch(expected, actual, shouldPass = true)
+  }
+  private[this] def shouldFail(expected: Try[MediaType], actual: Try[MediaType]): Unit = {
+    assertMatch(expected, actual, shouldPass = false)
+  }
+  private[this] def assertMatch(expected: Try[MediaType], actual: Try[MediaType], shouldPass: Boolean): Unit = {
+    assert(FinchExtensions.beTheExpectedType(expected.get())(actual.get()) == shouldPass)
+  }
+
+  private[this] implicit def stringToMediaType(s: String): Try[MediaType] = {
+    MediaType.parse(s)
+  }
+}

--- a/src/test/scala/com/mesosphere/cosmos/http/MediaTypeSpec.scala
+++ b/src/test/scala/com/mesosphere/cosmos/http/MediaTypeSpec.scala
@@ -1,0 +1,75 @@
+package com.mesosphere.cosmos.http
+
+import com.twitter.util.Return
+import org.scalatest.FreeSpec
+
+class MediaTypeSpec extends FreeSpec {
+
+  "MediaType.parse(string) should" -  {
+    "parse basic type" in  {
+      val Return(t) = MediaType.parse("text/html")
+      assertResult("text/html")(t.show)
+    }
+
+    "parse with suffix" in  {
+      val Return(t) = MediaType.parse("""image/svg+xml""")
+      assertResult("image")(t.`type`)
+      assertResult("svg")(t.subType.value)
+      assertResult(Some("xml"))(t.subType.suffix)
+      assertResult("""image/svg+xml""")(t.show)
+    }
+
+    "parse parameters" in  {
+      val Return(t) = MediaType.parse("""text/html; charset=utf-8; foo=bar""")
+      assertResult("text")(t.`type`)
+      assertResult("html")(t.subType.value)
+      assertResult(Some(Map(
+        "charset" -> "utf-8",
+        "foo" -> "bar"
+      )))(t.parameters)
+    }
+
+    "lower-case type" in  {
+      val Return(t) = MediaType.parse("""IMAGE/SVG+XML""")
+      assertResult("""image/svg+xml""")(t.show)
+    }
+
+    "lower-case parameter names" in  {
+      val Return(t) = MediaType.parse("""text/html; Charset=utf-8""")
+      assertResult("text")(t.`type`)
+      assertResult("html")(t.subType.value)
+      assertResult(Some(Map(
+        "charset" -> "utf-8"
+      )))(t.parameters)
+    }
+
+    "parse a vendor type" in {
+      val Return(t) = MediaType.parse("application/vnd.dcos.cosmos.uninstall-request+json; charset=utf-8; version=v1")
+      assertResult(MediaTypes.UninstallRequest)(t)
+    }
+
+    "unquote parameter values" in  {
+      val Return(t) = MediaType.parse("""text/html; charset="utf-8"""")
+      assertResult("text")(t.`type`)
+      assertResult("html")(t.subType.value)
+      assertResult(Some(Map(
+        "charset" -> "utf-8"
+      )))(t.parameters)
+    }
+  }
+
+  "A MediaType should show correctly" - {
+    "text/html" in {
+      assertResult("text/html")(MediaType("text", MediaTypeSubType("html")).show)
+    }
+    "application/xhtml+xml" in {
+      assertResult("application/xhtml+xml")(MediaType("application", MediaTypeSubType("xhtml", Some("xml"))).show)
+    }
+    "application/vnd.mesosphere.dcos.custom-request+json" in {
+      assertResult("application/vnd.mesosphere.dcos.custom-request+json")(
+        MediaType("application", MediaTypeSubType("vnd.mesosphere.dcos.custom-request", Some("json"))).show
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
Add new class EndpointHandler[Req, Rep] that provides enforcement of the
Content-Type and Accept type headers. Each EndpointHandler defines the
type of it's input and output and contains a corresponding
RequestReader[Req] that will ensure the headers are set correspondingly
for requests sent to the endpoint.

Responses will also have a custom Content-Type set corresponding to the
type of the response. This can be used to correlate responses to schemas
as well as informing client how the data should be interprited.

For any "error response" (http 4xx or 5xx) the Content-Type will
correspond with the CosmosError type.

fixes #14 
