### PR TITLE
Remove PackageDefinition.images field

### DIFF
--- a/src/it/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
@@ -317,8 +317,7 @@ private object PackageInstallSpec extends CosmosSpec {
       preInstallNotes = None,
       postInstallNotes = None,
       postUninstallNotes = None,
-      licenses = None,
-      images = None
+      licenses = None
     )
 
     val resource = Resource(

--- a/src/main/scala/com/mesosphere/cosmos/model/Universe.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/Universe.scala
@@ -15,10 +15,7 @@ case class PackageDefinition(
   preInstallNotes: Option[String] = None,
   postInstallNotes: Option[String] = None,
   postUninstallNotes: Option[String] = None,
-  licenses: Option[List[License]] = None,
-  // This is only here to support adding images to the DCOS_PACKAGE_METADATA Marathon label
-  // GitHub issue #57 will decide whether to keep this here
-  images: Option[Images] = None
+  licenses: Option[List[License]] = None
 )
 
 case class Container(

--- a/src/test/scala/com/mesosphere/cosmos/MemoryPackageCache.scala
+++ b/src/test/scala/com/mesosphere/cosmos/MemoryPackageCache.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.cosmos
 
-import com.mesosphere.cosmos.model.{DescribeRequest, PackageInfo, PackageFiles, UniverseIndex}
+import com.mesosphere.cosmos.model.{DescribeRequest, PackageFiles, PackageInfo, UniverseIndex}
 import com.twitter.util.Future
 import io.circe.Json
 import io.finch._


### PR DESCRIPTION
It was previously added for convenience in generating the package
metadata Marathon label. As a result, our JSON encoder was including
the images field in the JSON it generated for the package definition.
This was in violation of the spec.
