### PR TITLE
Fix #63 by returning JSON schema validation messages in error responses

### DIFF
--- a/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -4,6 +4,8 @@ import cats.data.NonEmptyList
 import com.mesosphere.cosmos.model.AppId
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http.Status
+import io.circe.Json
+import io.circe.syntax._
 
 sealed trait CosmosError extends RuntimeException {
 
@@ -31,7 +33,7 @@ sealed trait CosmosError extends RuntimeException {
       case MarathonAppNotFound(appId) => s"Unable to locate service with marathon appId: '$appId'"
       case CirceError(cerr) => cerr.getMessage
       case MesosRequestError(note) => note
-      case JsonSchemaMismatch() => "Options JSON failed validation"
+      case JsonSchemaMismatch(_) => "Options JSON failed validation"
 
       // TODO(jose): Looking at the code these are all recursive!
       case uct @ UnsupportedContentType(_, _) => uct.toString
@@ -40,11 +42,11 @@ sealed trait CosmosError extends RuntimeException {
       case mfi @ MultipleFrameworkIds(_, _) => mfi.toString
       case me @ MultipleError(_) => me.toString
       case NelErrors(nelE) => nelE.toString
-      case JsonSchemaMismatch() => "Options JSON failed validation"
       case FileUploadError(msg) => msg
-      case NelErrors(nelE) => nelE.toString
     }
   }
+
+  def getData: Json = Json.obj()
 
 }
 
@@ -82,6 +84,8 @@ case class MultipleFrameworkIds(frameworkName: String, ids: List[String]) extend
 case class MultipleError(errs: List[CosmosError]) extends CosmosError
 case class NelErrors(errs: NonEmptyList[CosmosError]) extends CosmosError //TODO: Cleanup
 
-case class JsonSchemaMismatch() extends CosmosError
+case class JsonSchemaMismatch(errors: Iterable[Json]) extends CosmosError {
+  override def getData: Json = errors.asJson
+}
 
 case class FileUploadError(message: String) extends CosmosError { override val status = Status.NotImplemented }

--- a/src/main/scala/com/mesosphere/cosmos/ErrorResponse.scala
+++ b/src/main/scala/com/mesosphere/cosmos/ErrorResponse.scala
@@ -6,7 +6,7 @@ case class ErrorResponse(errors: List[ErrorResponseEntry])
 case class ErrorResponseEntry(
   `type`: String,
   message: String,
-  data: JsonObject = JsonObject.empty
+  data: Json = Json.obj()
 )
 
 object ErrorResponse {
@@ -14,7 +14,7 @@ object ErrorResponse {
     new ErrorResponse(List(singleError))
   }
 
-  def apply(`type`: String, message: String, data: JsonObject = JsonObject.empty): ErrorResponse = {
+  def apply(`type`: String, message: String, data: Json = Json.obj()): ErrorResponse = {
     apply(ErrorResponseEntry(`type`, message, data))
   }
 

--- a/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -66,7 +66,7 @@ object Encoders {
     case Error.RequestErrors(ts) =>
       ts.flatMap(exceptionErrorResponse).toList
     case ce: CosmosError =>
-      List(ErrorResponseEntry(ce.getClass.getSimpleName, ce.getMessage))
+      List(ErrorResponseEntry(ce.getClass.getSimpleName, ce.getMessage, ce.getData))
     case t: Throwable =>
       List(ErrorResponseEntry("unhandled_exception", t.getMessage))
   }

--- a/src/main/scala/com/mesosphere/cosmos/jsonschema/JsonSchemaValidation.scala
+++ b/src/main/scala/com/mesosphere/cosmos/jsonschema/JsonSchemaValidation.scala
@@ -4,14 +4,18 @@ import cats.data.Xor
 import com.fasterxml.jackson.databind.JsonNode
 import com.github.fge.jsonschema.main.JsonSchemaFactory
 import com.mesosphere.cosmos.jsonschema.Jackson._
-import io.circe.{JsonObject, Json}
+import io.circe.syntax._
+import io.circe.{Json, JsonObject}
+
+import scala.collection.JavaConverters._
 
 private[cosmos] object JsonSchemaValidation {
 
-  private[cosmos] def matchesSchema(document: JsonObject, schema: JsonObject): Boolean = {
+  private[cosmos] def matchesSchema(document: JsonObject, schema: JsonObject): Iterable[Json] = {
     matchesSchema(Json.fromJsonObject(document), Json.fromJsonObject(schema))
   }
-  private[cosmos] def matchesSchema(document: Json, schema: Json): Boolean = {
+
+  private[cosmos] def matchesSchema(document: Json, schema: Json): Iterable[Json] = {
     val Xor.Right(documentNode) = document.as[JsonNode]
     val Xor.Right(schemaNode) = schema.as[JsonNode]
 
@@ -19,7 +23,12 @@ private[cosmos] object JsonSchemaValidation {
       .byDefault()
       .getValidator
       .validate(schemaNode, documentNode)
-      .isSuccess
+      .asScala
+      .map { message =>
+        val jacksonJson = message.asJson
+        val circeJson = jacksonJson.asJson
+        circeJson
+      }
   }
 
 }


### PR DESCRIPTION
The JsonSchemaMismatch error type now stores an Iterable[Json] of
schema validation messages. These messages provide detailed information
that will allow users to find and fix schema violations in their package
options JSON.

To return the messages in the response, a getData method is defined on
CosmosError, and defaults to returning an empty JSON object. Subclasses
of CosmosError can override this method to supply custom error data.
