### PR TITLE
add 'v1' to list endpoint for consistency

### DIFF
--- a/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -104,7 +104,7 @@ private[cosmos] final class Cosmos(
       }
     }
 
-    post("package" / "list" ? body.as[ListRequest])(respond _)
+    post("v1" / "package" / "list" ? body.as[ListRequest])(respond _)
   }
 
   val service: Service[Request, Response] = {


### PR DESCRIPTION
We can remove all the "v1"'s from requests at once.
