### PR TITLE
Fix #37 Implement universe cache lifecycle

### DIFF
--- a/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -27,7 +27,7 @@ final class PackageDescribeSpec extends FreeSpec with CosmosSpec {
   "The package describe endpoint" - {
     "don't install if specified version is not found"/*TODO: Copy paste test name */ in {
       val _ = withTempDirectory { universeDir =>
-        val universeCache = Await.result(UniversePackageCache(UniverseUri, universeDir))
+        val universeCache = UniversePackageCache(UniverseUri, universeDir)
 
         runService(packageCache = universeCache) { apiClient =>
           forAll (PackageDummyVersionsTable) { (packageName, packageVersion) =>
@@ -44,7 +44,7 @@ final class PackageDescribeSpec extends FreeSpec with CosmosSpec {
 
     "can successfully describe helloworld from Universe" in {
       val _ = withTempDirectory { universeDir =>
-        val universeCache = Await.result(UniversePackageCache(UniverseUri, universeDir))
+        val universeCache = UniversePackageCache(UniverseUri, universeDir)
 
         runService(packageCache = universeCache) { apiClient =>
           apiClient.describeHelloworld()
@@ -55,7 +55,7 @@ final class PackageDescribeSpec extends FreeSpec with CosmosSpec {
 
     "can successfully describe all versions from Universe" in {
       val _ = withTempDirectory { universeDir =>
-        val universeCache = Await.result(UniversePackageCache(UniverseUri, universeDir))
+        val universeCache = UniversePackageCache(UniverseUri, universeDir)
 
         runService(packageCache = universeCache) { apiClient =>
           forAll (PackageVersionsTable) { (packageName, versions) =>

--- a/src/it/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
@@ -127,7 +127,7 @@ final class PackageInstallSpec extends FreeSpec with BeforeAndAfterAll with Cosm
 
     "don't install if specified version is not found" in {
       val _ = withTempDirectory { universeDir =>
-        val universeCache = Await.result(UniversePackageCache(UniverseUri, universeDir))
+        val universeCache = UniversePackageCache(UniverseUri, universeDir)
 
         runService(packageCache = universeCache) { apiClient =>
           forAll (PackageDummyVersionsTable) { (packageName, packageVersion) =>
@@ -149,7 +149,7 @@ final class PackageInstallSpec extends FreeSpec with BeforeAndAfterAll with Cosm
 
     "can successfully install packages from Universe" in {
       val _ = withTempDirectory { universeDir =>
-        val universeCache = Await.result(UniversePackageCache(UniverseUri, universeDir))
+        val universeCache = UniversePackageCache(UniverseUri, universeDir)
 
         runService(packageCache = universeCache) { apiClient =>
           forAll (UniversePackagesTable) { (expectedResponse, forceVersion, uriSet, labelsOpt) =>
@@ -172,7 +172,7 @@ final class PackageInstallSpec extends FreeSpec with BeforeAndAfterAll with Cosm
 
     "supports custom app IDs" in {
       val _ = withTempDirectory { universeDir =>
-        val universeCache = Await.result(UniversePackageCache(UniverseUri, universeDir))
+        val universeCache = UniversePackageCache(UniverseUri, universeDir)
 
         runService(packageCache = universeCache) { apiClient =>
           val expectedResponse = InstallResponse("cassandra", "0.2.0-1", AppId("custom-app-id"))
@@ -211,7 +211,7 @@ final class PackageInstallSpec extends FreeSpec with BeforeAndAfterAll with Cosm
         ErrorResponse("JsonSchemaMismatch", "Options JSON failed validation", Some(errorData))
 
       val _ = withTempDirectory { universeDir =>
-        val universeCache = Await.result(UniversePackageCache(UniverseUri, universeDir))
+        val universeCache = UniversePackageCache(UniverseUri, universeDir)
 
         runService(packageCache = universeCache) { apiClient =>
           val appId = AppId("chronos-bad-json")

--- a/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -23,7 +23,7 @@ final class PackageSearchSpec extends FreeSpec with CosmosSpec {
   "The package search endpoint" - {
     "can successfully find packages" in {
       val _ = withTempDirectory { universeDir =>
-        val universeCache = Await.result(UniversePackageCache(UniverseUri, universeDir))
+        val universeCache = UniversePackageCache(UniverseUri, universeDir)
 
         runService(packageCache = universeCache) { apiClient =>
           forAll (PackageSearchTable) { (query, expectedResponse) =>
@@ -39,7 +39,7 @@ final class PackageSearchSpec extends FreeSpec with CosmosSpec {
 
     "can successfully find packages by regex match" in {
       val _ = withTempDirectory { universeDir =>
-        val universeCache = Await.result(UniversePackageCache(UniverseUri, universeDir))
+        val universeCache = UniversePackageCache(UniverseUri, universeDir)
 
         runService(packageCache = universeCache) { apiClient =>
           forAll (PackageSearchRegexTable) { (query, expectedResponse) =>

--- a/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -176,7 +176,7 @@ object Cosmos extends FinchServer {
 
       val universeBundle = universeBundleUri()
       val universeDir = universeCacheDir()
-      val packageCache = Await.result(UniversePackageCache(universeBundle, universeDir))
+      val packageCache = UniversePackageCache(universeBundle, universeDir)
       val marathonPackageRunner = new MarathonPackageRunner(adminRouter)
 
       val cosmos = new Cosmos(

--- a/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -14,7 +14,6 @@ sealed abstract class CosmosError(causedBy: Throwable = null /*java compatibilit
   def status: Status = Status.BadRequest
 
   def getData: Option[JsonObject] = None
-
 }
 
 case class PackageNotFound(packageName: String) extends CosmosError
@@ -33,7 +32,7 @@ case class MarathonBadGateway(marathonStatus: Status) extends CosmosError {
   override val status = Status.BadGateway
 }
 case class IndexNotFound(repoUri: Uri) extends CosmosError
-case class RepositoryNotFound() extends CosmosError
+case class RepositoryNotFound(repoUri: Uri) extends CosmosError
 
 case class MarathonAppMetadataError(note: String) extends CosmosError
 case class MarathonAppDeleteError(appId: AppId) extends CosmosError

--- a/src/main/scala/com/mesosphere/cosmos/PackageCache.scala
+++ b/src/main/scala/com/mesosphere/cosmos/PackageCache.scala
@@ -1,7 +1,9 @@
 package com.mesosphere.cosmos
 
-import com.mesosphere.cosmos.model._
+import com.netaporter.uri.dsl.stringToUri
 import com.twitter.util.Future
+
+import com.mesosphere.cosmos.model._
 
 /** A repository of packages that can be installed on DCOS. */
 trait PackageCache {
@@ -42,7 +44,7 @@ object PackageCache {
     }
 
     def getRepoIndex: Future[UniverseIndex] = {
-      Future.exception(RepositoryNotFound())
+      Future.exception(RepositoryNotFound("http://example.com/universe.zip"))
     }
 
     def getPackageIndex(packageName: String): Future[PackageInfo] = {

--- a/src/main/scala/com/mesosphere/cosmos/Services.scala
+++ b/src/main/scala/com/mesosphere/cosmos/Services.scala
@@ -12,6 +12,10 @@ import com.twitter.util.Try
 
 object Services {
   def adminRouterClient(uri: Uri): Try[Service[Request, Response]] = {
+    httpClient("adminRouter", uri)
+  }
+
+  def httpClient(serviceName: String, uri: Uri): Try[Service[Request, Response]] = {
     extractHostAndPort(uri) map { case ConnectionDetails(hostname, port, tls) =>
       val cBuilder = tls match {
         case false =>
@@ -25,7 +29,7 @@ object Services {
             .configured(Transporter.TLSHostname(Some(hostname)))
       }
 
-      cBuilder.newService(s"$hostname:$port", "adminRouter")
+      cBuilder.newService(s"$hostname:$port", serviceName)
     }
   }
 

--- a/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -106,8 +106,8 @@ object Encoders {
       s"Received response status code ${marathonStatus.code} from Marathon"
     case IndexNotFound(repoUri) =>
       s"Index file missing for repo [$repoUri]"
-    case RepositoryNotFound() =>
-      "No repository found"
+    case RepositoryNotFound(repoUri) =>
+      s"No repository found [$repoUri]"
     case MarathonAppMetadataError(note) => note
     case MarathonAppDeleteError(appId) =>
       s"Error while deleting marathon app '$appId'"

--- a/src/test/scala/com/mesosphere/cosmos/MemoryPackageCache.scala
+++ b/src/test/scala/com/mesosphere/cosmos/MemoryPackageCache.scala
@@ -1,7 +1,9 @@
 package com.mesosphere.cosmos
 
-import com.mesosphere.cosmos.model._
+import com.netaporter.uri.dsl.stringToUri
 import com.twitter.util.Future
+
+import com.mesosphere.cosmos.model._
 
 /** A package cache that stores all package information in memory. Useful for testing.
   *
@@ -34,7 +36,7 @@ final case class MemoryPackageCache(packages: Map[String, PackageFiles]) extends
   }
 
   def getRepoIndex: Future[UniverseIndex] = {
-    Future.exception(RepositoryNotFound())
+    Future.exception(RepositoryNotFound("http://example.com/universe.zip"))
   }
 
   def getPackageIndex(


### PR DESCRIPTION
This change includes the following improvements:
1. We automatically update the local cache on every request if the cache
   is older than one minutes. This is currently not configurable. We will
   make it configurable once we add support for changing configuration to
   Cosmos.
2. Change the constructor for the universe cache so that it return a
   sync value and not an async value. We have moved all of the async
   operation fo the public methods of PackageCache.
3. Better handle the creation of the local universe directory. This
   commit first create a temporary directory in the same local cache
   directory and atomically moves it to a directory name after base64
   encoded url for the universe repo/source.
4. Updating the local cache is serialized using an AsyncMutex. This
   guarrantes that we only do at most one HTTP against Universe per minute.
5. Added Apache commos-io for their implementation of recurse delete of
   directories.
