### PR TITLE
Fix #154 package list should relax appid input

### DIFF
--- a/src/main/scala/com/mesosphere/cosmos/model/ListRequest.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/ListRequest.scala
@@ -2,5 +2,5 @@ package com.mesosphere.cosmos.model
 
 case class ListRequest(
   packageName: Option[String] = None,
-  appId: Option[String] = None
+  appId: Option[AppId] = None
 )


### PR DESCRIPTION
Fix package list so that we allow the user to pass appid that don't
containt a starting '/'.
