### PR TITLE
Fix #197 Clean repository responses

### DIFF
--- a/src/it/scala/com/mesosphere/cosmos/PackageSourcesIntegrationSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageSourcesIntegrationSpec.scala
@@ -87,7 +87,7 @@ private object PackageSourcesIntegrationSpec extends CosmosSpec {
       PackageRepositoryListRequest(),
       MediaTypes.PackageRepositoryListRequest,
       MediaTypes.PackageRepositoryListResponse
-    ).sources
+    ).repositories
   }
 
   private def addSource(

--- a/src/main/scala/com/mesosphere/cosmos/model/PackageRepositoryAddResponse.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/PackageRepositoryAddResponse.scala
@@ -1,3 +1,3 @@
 package com.mesosphere.cosmos.model
 
-case class PackageRepositoryAddResponse(sources: Seq[PackageRepository])
+case class PackageRepositoryAddResponse(repositories: Seq[PackageRepository])

--- a/src/main/scala/com/mesosphere/cosmos/model/PackageRepositoryDeleteResponse.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/PackageRepositoryDeleteResponse.scala
@@ -1,3 +1,3 @@
 package com.mesosphere.cosmos.model
 
-case class PackageRepositoryDeleteResponse(sources: Seq[PackageRepository])
+case class PackageRepositoryDeleteResponse(repositories: Seq[PackageRepository])

--- a/src/main/scala/com/mesosphere/cosmos/model/PackageRepositoryListResponse.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/PackageRepositoryListResponse.scala
@@ -1,3 +1,3 @@
 package com.mesosphere.cosmos.model
 
-case class PackageRepositoryListResponse(sources: Seq[PackageRepository])
+case class PackageRepositoryListResponse(repositories: Seq[PackageRepository])


### PR DESCRIPTION
The field name for all of those responses should be "repositories"
instead of "sources".
