### PR TITLE
Clean up TODOs and other leftovers from PR #175

### DIFF
--- a/src/it/scala/com/mesosphere/cosmos/CosmosSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/CosmosSpec.scala
@@ -1,9 +1,5 @@
 package com.mesosphere.cosmos
 
-import java.io.IOException
-import java.nio.file.attribute.BasicFileAttributes
-import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
-
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import com.twitter.app.{FlagParseException, FlagUsageError, Flags}
@@ -50,31 +46,6 @@ trait CosmosSpec extends Matchers with TableDrivenPropertyChecks {
 
   protected[this] final def requestBuilder(endpointPath: String): RequestBuilder[Yes, Nothing] = {
     RequestBuilder().url(s"http://localhost:$servicePort/$endpointPath")
-  }
-
-  protected[this] final def withTempDirectory(f: Path => Unit): Unit = {
-    val tempDir = Files.createTempDirectory("cosmos")
-    try { f(tempDir) } finally {
-      val visitor = new SimpleFileVisitor[Path] {
-
-        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
-          Files.delete(file)
-          FileVisitResult.CONTINUE
-        }
-
-        override def postVisitDirectory(dir: Path, e: IOException): FileVisitResult = {
-          Option(e) match {
-            case Some(failure) => throw failure
-            case _ =>
-              Files.delete(dir)
-              FileVisitResult.CONTINUE
-          }
-        }
-
-      }
-
-      val _ = Files.walkFileTree(tempDir, visitor)
-    }
   }
 
 }

--- a/src/it/scala/com/mesosphere/cosmos/IntegrationSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/IntegrationSpec.scala
@@ -7,9 +7,6 @@ import com.twitter.finagle.http.{Request, Response}
 import io.finch.test.ServiceIntegrationSuite
 import org.scalatest.fixture
 
-import com.mesosphere.cosmos.repository.PackageSourcesStorage
-import com.mesosphere.cosmos.repository.Repository
-
 abstract class IntegrationSpec
   extends fixture.FlatSpec
   with ServiceIntegrationSuite
@@ -17,7 +14,7 @@ abstract class IntegrationSpec
 
   def createService: Service[Request, Response] = {
     val marathonPackageRunner = new MarathonPackageRunner(adminRouter)
-    val sourcesStorage = PackageSourcesStorage.constUniverse(universeUri)
+    val sourcesStorage = IntegrationTests.constUniverse(universeUri)
 
     val tempDir = Files.createTempDirectory("cosmos-integration")
     tempDir.toFile.deleteOnExit

--- a/src/it/scala/com/mesosphere/cosmos/IntegrationTests.scala
+++ b/src/it/scala/com/mesosphere/cosmos/IntegrationTests.scala
@@ -1,0 +1,62 @@
+package com.mesosphere.cosmos
+
+import java.io.IOException
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
+
+import com.mesosphere.cosmos.model.PackageRepository
+import com.mesosphere.cosmos.repository.PackageSourcesStorage
+import com.netaporter.uri.Uri
+import com.twitter.util.Future
+
+/** Utilities for integration tests. In an object so that they must be referenced explicitly or
+  * imported, *not* mixed in.
+  */
+private object IntegrationTests {
+
+  private[cosmos] final def withTempDirectory(f: Path => Unit): Unit = {
+    val tempDir = Files.createTempDirectory("cosmos")
+    try { f(tempDir) } finally {
+      val visitor = new SimpleFileVisitor[Path] {
+
+        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+          Files.delete(file)
+          FileVisitResult.CONTINUE
+        }
+
+        override def postVisitDirectory(dir: Path, e: IOException): FileVisitResult = {
+          Option(e) match {
+            case Some(failure) => throw failure
+            case _ =>
+              Files.delete(dir)
+              FileVisitResult.CONTINUE
+          }
+        }
+
+      }
+
+      val _ = Files.walkFileTree(tempDir, visitor)
+    }
+  }
+
+  private[cosmos] def constUniverse(uri: Uri): PackageSourcesStorage = new PackageSourcesStorage {
+
+    val read: Future[List[PackageRepository]] = {
+      Future.value(List(PackageRepository("Universe", uri)))
+    }
+
+    val readCache: Future[List[PackageRepository]] = {
+      Future.value(List(PackageRepository("Universe", uri)))
+    }
+
+    def add(index: Int, packageRepository: PackageRepository): Future[List[PackageRepository]] = {
+      Future.exception(new UnsupportedOperationException)
+    }
+
+    def delete(name: Option[String], uri: Option[Uri]): Future[List[PackageRepository]] = {
+      Future.exception(new UnsupportedOperationException)
+    }
+
+  }
+
+}

--- a/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -4,12 +4,12 @@ import java.nio.file.Path
 
 import cats.data.Xor
 import cats.data.Xor.Right
+import com.mesosphere.cosmos.IntegrationTests.{constUniverse, withTempDirectory}
 import com.mesosphere.cosmos.circe.Decoders._
 import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.MediaTypes
 import com.mesosphere.cosmos.model._
 import com.mesosphere.cosmos.model.thirdparty.marathon.{MarathonApp, MarathonAppContainer, MarathonAppContainerDocker}
-import com.mesosphere.cosmos.repository.PackageSourcesStorage
 import com.mesosphere.cosmos.repository.Repository
 import com.mesosphere.universe._
 import com.netaporter.uri.Uri
@@ -76,7 +76,7 @@ final class PackageDescribeSpec extends FreeSpec with CosmosSpec {
     f: DescribeTestAssertionDecorator => Unit
   ): Unit = {
     val marathonPackageRunner = new MarathonPackageRunner(adminRouter)
-    val sourcesStorage = PackageSourcesStorage.constUniverse(universeUri)
+    val sourcesStorage = constUniverse(universeUri)
     val service = Cosmos(adminRouter, marathonPackageRunner, sourcesStorage, universeDir).service
     val server = Http.serve(s":$servicePort", service)
     val client = Http.newService(s"127.0.0.1:$servicePort")

--- a/src/it/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
@@ -5,12 +5,12 @@ import java.util.{Base64, UUID}
 
 import cats.data.Xor
 import cats.data.Xor.Right
+import com.mesosphere.cosmos.IntegrationTests.{constUniverse, withTempDirectory}
 import com.mesosphere.cosmos.circe.Decoders._
 import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.MediaTypes
 import com.mesosphere.cosmos.model._
 import com.mesosphere.cosmos.model.thirdparty.marathon.{MarathonApp, MarathonAppContainer, MarathonAppContainerDocker}
-import com.mesosphere.cosmos.repository.PackageSourcesStorage
 import com.mesosphere.cosmos.repository.Repository
 import com.mesosphere.universe.{PackageDetails, PackageDetailsVersion, PackageFiles, PackagingVersion}
 import com.netaporter.uri.Uri
@@ -235,7 +235,7 @@ final class PackageInstallSpec extends FreeSpec with BeforeAndAfterAll with Cosm
     } getOrElse adminRouter
     // these two imports provide the implicit DecodeRequest instances needed to instantiate Cosmos
     val marathonPackageRunner = new MarathonPackageRunner(ar)
-    val sourcesStorage = PackageSourcesStorage.constUniverse(universeUri)
+    val sourcesStorage = constUniverse(universeUri)
     val service = Cosmos(ar, marathonPackageRunner, sourcesStorage, universeDir).service
     val server = Http.serve(s":$servicePort", service)
     val client = Http.newService(s"127.0.0.1:$servicePort")

--- a/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -3,11 +3,11 @@ package com.mesosphere.cosmos
 import java.nio.file.Path
 
 import cats.data.Xor.Right
+import com.mesosphere.cosmos.IntegrationTests.{constUniverse, withTempDirectory}
 import com.mesosphere.cosmos.circe.Decoders._
 import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.MediaTypes
 import com.mesosphere.cosmos.model._
-import com.mesosphere.cosmos.repository.PackageSourcesStorage
 import com.mesosphere.cosmos.repository.Repository
 import com.mesosphere.universe.{PackageDetailsVersion, ReleaseVersion, UniverseIndexEntry}
 import com.netaporter.uri.Uri
@@ -60,7 +60,7 @@ final class PackageSearchSpec extends FreeSpec with CosmosSpec {
     f: SearchTestAssertionDecorator => Unit
   ): Unit = {
     val marathonPackageRunner = new MarathonPackageRunner(adminRouter)
-    val sourcesStorage = PackageSourcesStorage.constUniverse(universeUri)
+    val sourcesStorage = constUniverse(universeUri)
     val service = Cosmos(adminRouter, marathonPackageRunner, sourcesStorage, universeDir).service
     val server = Http.serve(s":$servicePort", service)
     val client = Http.newService(s"127.0.0.1:$servicePort")

--- a/src/it/scala/com/mesosphere/cosmos/PackageSourcesIntegrationSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageSourcesIntegrationSpec.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor
+import com.mesosphere.cosmos.IntegrationTests.withTempDirectory
 import com.mesosphere.cosmos.circe.Decoders._
 import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.{MediaType, MediaTypes}

--- a/src/it/scala/com/mesosphere/cosmos/repository/EmptyRepository.scala
+++ b/src/it/scala/com/mesosphere/cosmos/repository/EmptyRepository.scala
@@ -1,0 +1,33 @@
+package com.mesosphere.cosmos.repository
+
+import com.mesosphere.cosmos.{PackageNotFound, RepositoryNotFound}
+import com.mesosphere.universe.{PackageDetailsVersion, PackageFiles, ReleaseVersion, UniverseIndexEntry}
+import com.netaporter.uri.Uri
+import com.twitter.util.Future
+
+/** Useful when a repository is not needed or should not be used. */
+object EmptyRepository extends Repository {
+
+  override def getPackageByPackageVersion(
+    packageName: String,
+    packageVersion: Option[PackageDetailsVersion]
+  ): Future[PackageFiles] = {
+    Future.exception(PackageNotFound(packageName))
+  }
+
+  override def getPackageByReleaseVersion(
+    packageName: String,
+    releaseVersion: ReleaseVersion
+  ): Future[PackageFiles] = {
+    Future.exception(PackageNotFound(packageName))
+  }
+
+  override def getPackageIndex(packageName: String): Future[UniverseIndexEntry] = {
+    Future.exception(PackageNotFound(packageName))
+  }
+
+  override def search(query: Option[String]): Future[List[UniverseIndexEntry]] = {
+    Future.exception(RepositoryNotFound(Uri.parse("http://example.com/universe.zip")))
+  }
+
+}

--- a/src/it/scala/com/mesosphere/cosmos/repository/PackageSourceSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/repository/PackageSourceSpec.scala
@@ -32,12 +32,6 @@ final class PackageSourceSpec extends UnitSpec with ZooKeeperFixture {
     }
   }
 
-  // TODO cruhland list-sources: Test for missing ZooKeeper package-sources/v1 node
-  // TODO cruhland list-sources: Test for invalid JSON data for package-sources
-  // TODO cruhland list-sources: Test for URIs with invalid syntax in the package sources list
-  // TODO cruhland list-sources: Test for URIs that don't resolve to repo bundles in the sources list
-  // TODO cruhland list-sources: Test for sources that don't have distinct names
-
   "Add source endpoint" in {
     withZooKeeperClient { client =>
       val sourcesStorage = new ZooKeeperStorage(client, SourceVersion2x.uri)
@@ -55,9 +49,6 @@ final class PackageSourceSpec extends UnitSpec with ZooKeeperFixture {
       }
     }
   }
-
-  // TODO cruhland add-source: Test for failure on concurrent update
-  // TODO cruhland add-source: Test for failure on ZK node missing, or other ZK error
 
   "Delete source endpoint" in {
     withZooKeeperClient { client =>
@@ -114,12 +105,6 @@ private[cosmos] object PackageSourceSpec extends UnitSpec {
         List(SourceCliTest4, SourceMesosphere, SourceExample, SourceVersion2x)))
   )
 
-  // TODO cruhland: Adding sources with duplicate names
-  // TODO cruhland: Adding sources with duplicate URIs
-  // TODO cruhland: Adding sources at indices outside the list boundaries
-  // TODO cruhland: Adding names or URIs with invalid values
-  // TODO cruhland: Adding URIs that don't resolve
-
   private val PackageRepositoryDeleteScenarios = Table(
     ("starting value", "delete scenario"),
     (List(SourceVersion2x), List(DeleteSourceAssertion(deleteRequestByName(SourceVersion2x), Nil))),
@@ -141,10 +126,6 @@ private[cosmos] object PackageSourceSpec extends UnitSpec {
         DeleteSourceAssertion(deleteRequestByUri(SourceMesosphere), List(SourceVersion2x)),
         DeleteSourceAssertion(deleteRequestByUri(SourceVersion2x), Nil)))
   )
-
-  // TODO cruhland: Deleting source that is not present
-  // TODO cruhland: Delete source request with neither name nor URI
-  // TODO cruhland: Delete source request with name and URI
 
   private[this] def addRequest(
     source: PackageRepository,

--- a/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -25,7 +25,6 @@ import com.mesosphere.cosmos.http.MediaTypes
 import com.mesosphere.cosmos.model._
 import com.mesosphere.cosmos.repository.PackageSourcesStorage
 import com.mesosphere.cosmos.repository.ZooKeeperStorage
-import com.mesosphere.cosmos.repository.Repository
 
 private[cosmos] final class Cosmos(
   uninstallHandler: EndpointHandler[UninstallRequest, UninstallResponse],

--- a/src/main/scala/com/mesosphere/cosmos/repository/PackageSourcesStorage.scala
+++ b/src/main/scala/com/mesosphere/cosmos/repository/PackageSourcesStorage.scala
@@ -14,25 +14,3 @@ private[cosmos] trait PackageSourcesStorage {
 
   def delete(name: Option[String], uri: Option[Uri]): Future[List[PackageRepository]]
 }
-
-private[cosmos] object PackageSourcesStorage {
-
-  private[cosmos] def constUniverse(uri: Uri): PackageSourcesStorage = new PackageSourcesStorage {
-
-    val read: Future[List[PackageRepository]] = {
-      Future.value(List(PackageRepository("Universe", uri)))
-    }
-
-    val readCache: Future[List[PackageRepository]] = {
-      Future.value(List(PackageRepository("Universe", uri)))
-    }
-
-    def add(index: Int, packageRepository: PackageRepository): Future[List[PackageRepository]] = {
-      Future.exception(new UnsupportedOperationException)
-    }
-
-    def delete(name: Option[String], uri: Option[Uri]): Future[List[PackageRepository]] = {
-      Future.exception(new UnsupportedOperationException)
-    }
-  }
-}

--- a/src/main/scala/com/mesosphere/cosmos/repository/Repository.scala
+++ b/src/main/scala/com/mesosphere/cosmos/repository/Repository.scala
@@ -1,11 +1,7 @@
 package com.mesosphere.cosmos.repository
 
-import com.netaporter.uri.dsl.stringToUri
-import com.twitter.util.Future
-
 import com.mesosphere.universe._
-import com.mesosphere.cosmos.PackageNotFound
-import com.mesosphere.cosmos.RepositoryNotFound
+import com.twitter.util.Future
 
 /** A repository of packages that can be installed on DCOS. */
 trait Repository extends PackageCollection {
@@ -14,33 +10,4 @@ trait Repository extends PackageCollection {
     packageName: String,
     releaseVersion: ReleaseVersion
   ): Future[PackageFiles]
-}
-
-object Repository {
-
-  /** Useful when a cache is not needed or should not be used. */
-  object empty extends Repository {
-
-    override def getPackageByPackageVersion(
-      packageName: String,
-      packageVersion: Option[PackageDetailsVersion]
-    ): Future[PackageFiles] = {
-      Future.exception(PackageNotFound(packageName))
-    }
-
-    override def getPackageByReleaseVersion(
-      packageName: String,
-      releaseVersion: ReleaseVersion
-    ): Future[PackageFiles] = {
-      Future.exception(PackageNotFound(packageName))
-    }
-
-    override def getPackageIndex(packageName: String): Future[UniverseIndexEntry] = {
-      Future.exception(PackageNotFound(packageName))
-    }
-
-    override def search(query: Option[String]): Future[List[UniverseIndexEntry]] = {
-      Future.exception(RepositoryNotFound("http://example.com/universe.zip"))
-    }
-  }
 }


### PR DESCRIPTION
- Issues filed for TODOs so they won't be lost.
- Test utilities moved out of mixins and into standalone objects.
