### PR TITLE
When listing repositories, show errors for any that are not version 2.x

### DIFF
--- a/src/it/scala/com/mesosphere/cosmos/IntegrationTests.scala
+++ b/src/it/scala/com/mesosphere/cosmos/IntegrationTests.scala
@@ -4,7 +4,7 @@ import java.io.IOException
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.{FileVisitResult, Files, Path, SimpleFileVisitor}
 
-import com.mesosphere.cosmos.model.PackageRepository
+import com.mesosphere.cosmos.model.{PackageRepository, RepositoryDescriptor, RepositoryMetadata}
 import com.mesosphere.cosmos.repository.PackageSourcesStorage
 import com.netaporter.uri.Uri
 import com.twitter.util.Future
@@ -57,6 +57,10 @@ private object IntegrationTests {
       Future.exception(new UnsupportedOperationException)
     }
 
+  }
+
+  private[cosmos] implicit final class RepositoryMetadataOps(val r: RepositoryMetadata) extends AnyVal {
+    def toDescriptor: RepositoryDescriptor = RepositoryDescriptor(r.name, r.uri)
   }
 
 }

--- a/src/it/scala/com/mesosphere/cosmos/UniversePackageCacheSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/UniversePackageCacheSpec.scala
@@ -1,0 +1,32 @@
+package com.mesosphere.cosmos
+
+import java.nio.file.NoSuchFileException
+
+import com.netaporter.uri.Uri
+import org.scalatest.FreeSpec
+
+final class UniversePackageCacheSpec extends FreeSpec {
+
+  import UniversePackageCacheSpec._
+
+  "A UniversePackageCache" - {
+    "when close() is called before the bundle has been downloaded" - {
+      "should not throw an exception" in {
+        IntegrationTests.withTempDirectory { dataDir =>
+          val cache = UniversePackageCache(CacheName, CacheUri, dataDir)
+
+          cache.close()
+        }
+      }
+    }
+  }
+
+}
+
+object UniversePackageCacheSpec {
+
+  private val CacheName: String = "Universe"
+  private val CacheUri: Uri =
+    Uri.parse("https://github.com/mesosphere/universe/archive/cli-test-4.zip")
+
+}

--- a/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -2,14 +2,18 @@ package com.mesosphere.cosmos
 
 import java.nio.file.Path
 
+import com.mesosphere.cosmos.circe.Decoders._
+import com.mesosphere.cosmos.circe.Encoders._
+import com.mesosphere.cosmos.handler._
+import com.mesosphere.cosmos.http.MediaTypes
+import com.mesosphere.cosmos.model._
+import com.mesosphere.cosmos.repository.{PackageSourcesStorage, ZooKeeperStorage}
 import com.netaporter.uri.Uri
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.exp.Multipart.FileUpload
 import com.twitter.finagle.http.{Request, Response, Status}
 import com.twitter.finagle.stats.{NullStatsReceiver, StatsReceiver}
-import com.twitter.util.Await
-import com.twitter.util.Future
-import com.twitter.util.Try
+import com.twitter.util.{Future, Try}
 import io.circe.Json
 import io.circe.syntax.EncoderOps
 import io.finch._
@@ -17,14 +21,6 @@ import io.finch.circe._
 import io.github.benwhitehead.finch.FinchServer
 import org.apache.curator.framework.CuratorFrameworkFactory
 import org.apache.curator.retry.ExponentialBackoffRetry
-
-import com.mesosphere.cosmos.circe.Decoders._
-import com.mesosphere.cosmos.circe.Encoders._
-import com.mesosphere.cosmos.handler._
-import com.mesosphere.cosmos.http.MediaTypes
-import com.mesosphere.cosmos.model._
-import com.mesosphere.cosmos.repository.PackageSourcesStorage
-import com.mesosphere.cosmos.repository.ZooKeeperStorage
 
 private[cosmos] final class Cosmos(
   uninstallHandler: EndpointHandler[UninstallRequest, UninstallResponse],
@@ -295,7 +291,7 @@ object Cosmos extends FinchServer {
       new PackageDescribeHandler(repositories),
       new ListVersionsHandler(repositories),
       new ListHandler(adminRouter, uri => repositories.getRepository(uri)),
-      new PackageRepositoryListHandler(sourcesStorage),
+      new PackageRepositoryListHandler(repositories),
       new PackageRepositoryAddHandler(sourcesStorage),
       new PackageRepositoryDeleteHandler(sourcesStorage),
       CapabilitiesHandler()

--- a/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -4,11 +4,11 @@ import cats.data.{Ior, NonEmptyList}
 import com.mesosphere.cosmos.http.MediaType
 import com.mesosphere.cosmos.model.AppId
 import com.mesosphere.cosmos.model.thirdparty.marathon.MarathonError
-import com.mesosphere.universe.PackageDetailsVersion
+import com.mesosphere.universe.{PackageDetailsVersion, UniverseVersion}
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http.Status
-import io.circe.{JsonObject, Json}
 import io.circe.syntax._
+import io.circe.{Json, JsonObject}
 import org.jboss.netty.handler.codec.http.HttpMethod
 
 sealed abstract class CosmosError(causedBy: Throwable = null /*java compatibility*/) extends RuntimeException(causedBy) {
@@ -21,7 +21,7 @@ sealed abstract class CosmosError(causedBy: Throwable = null /*java compatibilit
 case class PackageNotFound(packageName: String) extends CosmosError
 case class VersionNotFound(packageName: String, packageVersion: PackageDetailsVersion) extends CosmosError
 case class EmptyPackageImport() extends CosmosError
-case class PackageFileMissing(packageName: String, cause: Throwable = null) extends CosmosError(cause)
+case class PackageFileMissing(fileName: String, cause: Throwable = null) extends CosmosError(cause)
 case class PackageFileNotJson(fileName: String, parseError: String) extends CosmosError
 case class PackageFileSchemaMismatch(fileName: String) extends CosmosError
 case class PackageAlreadyInstalled() extends CosmosError {
@@ -90,3 +90,5 @@ case class ConcurrentAccess(causedBy: Throwable) extends CosmosError(causedBy)
 final case class RepoNameOrUriMissing() extends CosmosError
 
 case class RepositoryAlreadyPresent(nameOrUri: Ior[String, Uri]) extends CosmosError
+
+case class UnsupportedRepositoryVersion(version: UniverseVersion) extends CosmosError

--- a/src/main/scala/com/mesosphere/cosmos/MultiRepository.scala
+++ b/src/main/scala/com/mesosphere/cosmos/MultiRepository.scala
@@ -2,18 +2,11 @@ package com.mesosphere.cosmos
 
 import java.nio.file.Path
 
+import com.mesosphere.cosmos.model.RepositoryMetadata
+import com.mesosphere.cosmos.repository.{PackageCollection, PackageSourcesStorage, Repository}
+import com.mesosphere.universe.{PackageDetailsVersion, PackageFiles, UniverseIndexEntry}
 import com.netaporter.uri.Uri
 import com.twitter.util.Future
-import com.twitter.util.Return
-import com.twitter.util.Throw
-import com.twitter.util.Try
-
-import com.mesosphere.cosmos.repository.PackageCollection
-import com.mesosphere.cosmos.repository.PackageSourcesStorage
-import com.mesosphere.cosmos.repository.Repository
-import com.mesosphere.universe.PackageDetailsVersion
-import com.mesosphere.universe.PackageFiles
-import com.mesosphere.universe.UniverseIndexEntry
 
 final class MultiRepository (
   packageRepositoryStorage: PackageSourcesStorage,
@@ -86,12 +79,16 @@ final class MultiRepository (
     }
   }
 
+  private[cosmos] def repositoryMetadata(): Future[List[RepositoryMetadata]] = {
+    repositories().map(_.map(_.metadata))
+  }
+
   private def repositories(): Future[List[UniversePackageCache]] = {
     packageRepositoryStorage.readCache().map { repositories =>
       val oldRepositories: Map[Uri, UniversePackageCache] = cachedRepositories
       val result = repositories.map { repository =>
         oldRepositories.get(repository.uri).getOrElse(
-          UniversePackageCache(repository.uri, universeDir)
+          UniversePackageCache(repository.name, repository.uri, universeDir)
         )
       }
 

--- a/src/main/scala/com/mesosphere/cosmos/handler/PackageRepositoryListHandler.scala
+++ b/src/main/scala/com/mesosphere/cosmos/handler/PackageRepositoryListHandler.scala
@@ -1,14 +1,14 @@
 package com.mesosphere.cosmos.handler
 
+import com.mesosphere.cosmos.MultiRepository
 import com.mesosphere.cosmos.http.{MediaType, MediaTypes}
 import com.mesosphere.cosmos.model._
-import com.mesosphere.cosmos.repository.PackageSourcesStorage
 import com.twitter.util.Future
 import io.circe.Encoder
 import io.finch.DecodeRequest
 
 private[cosmos] final class PackageRepositoryListHandler(
-  sourcesStorage: PackageSourcesStorage
+  multiRepository: MultiRepository
 )(implicit
   decoder: DecodeRequest[PackageRepositoryListRequest],
   encoder: Encoder[PackageRepositoryListResponse]
@@ -18,6 +18,6 @@ private[cosmos] final class PackageRepositoryListHandler(
   override val produces: MediaType = MediaTypes.PackageRepositoryListResponse
 
   override def apply(req: PackageRepositoryListRequest): Future[PackageRepositoryListResponse] = {
-    sourcesStorage.read().map(PackageRepositoryListResponse(_))
+    multiRepository.repositoryMetadata().map(PackageRepositoryListResponse(_))
   }
 }

--- a/src/main/scala/com/mesosphere/cosmos/model/PackageRepository.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/PackageRepository.scala
@@ -2,4 +2,13 @@ package com.mesosphere.cosmos.model
 
 import com.netaporter.uri.Uri
 
-case class PackageRepository(name: String, uri: Uri)
+trait PackageRepository {
+  def name: String
+  def uri: Uri
+}
+
+object PackageRepository {
+
+  def apply(name: String, uri: Uri): PackageRepository = RepositoryDescriptor(name, uri)
+
+}

--- a/src/main/scala/com/mesosphere/cosmos/model/PackageRepositoryListResponse.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/PackageRepositoryListResponse.scala
@@ -1,3 +1,3 @@
 package com.mesosphere.cosmos.model
 
-case class PackageRepositoryListResponse(repositories: Seq[PackageRepository])
+case class PackageRepositoryListResponse(repositories: Seq[RepositoryMetadata])

--- a/src/main/scala/com/mesosphere/cosmos/model/RepositoryDescriptor.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/RepositoryDescriptor.scala
@@ -1,0 +1,5 @@
+package com.mesosphere.cosmos.model
+
+import com.netaporter.uri.Uri
+
+case class RepositoryDescriptor(name: String, uri: Uri) extends PackageRepository

--- a/src/main/scala/com/mesosphere/cosmos/model/RepositoryMetadata.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/RepositoryMetadata.scala
@@ -1,0 +1,6 @@
+package com.mesosphere.cosmos.model
+
+import com.netaporter.uri.Uri
+
+case class RepositoryMetadata(name: String, uri: Uri, state: RepositoryState)
+  extends PackageRepository

--- a/src/main/scala/com/mesosphere/cosmos/model/RepositoryState.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/RepositoryState.scala
@@ -1,0 +1,8 @@
+package com.mesosphere.cosmos.model
+
+import com.mesosphere.cosmos.ErrorResponse
+
+sealed trait RepositoryState
+case object Healthy extends RepositoryState
+case object Unused extends RepositoryState
+case class Unhealthy(reason: ErrorResponse) extends RepositoryState


### PR DESCRIPTION
Attempting to use a repository that is not version 2.x will
result in a failed request.

UniversePackageCache.close() will no longer throw an exception if some
files that it is attempting to delete are not present; a test now ensures
this behavior.

Fixes #209.
