### PR TITLE
Fail requests that attempt to use repositories initialized from bad data

### DIFF
--- a/src/main/scala/com/mesosphere/cosmos/UniversePackageCache.scala
+++ b/src/main/scala/com/mesosphere/cosmos/UniversePackageCache.scala
@@ -151,12 +151,8 @@ final class UniversePackageCache private (
     updateMutex.acquireAndRun {
       // TODO: How often we check should be configurable
       if (lastModified.get().plusMinutes(1).isBefore(LocalDateTime.now())) {
-        val path = updateUniverseCache()
-
-        // Update the last modified date
-        lastModified.set(LocalDateTime.now())
-
-        path
+        updateUniverseCache()
+          .onSuccess { _ => lastModified.set(LocalDateTime.now()) }
       } else {
         /* We don't need to fetch the latest package information; just return the current
          * information.


### PR DESCRIPTION
Test cases:
- A repository URI that resolves to non-Zip-encoded data
- A repository URI that resolves to Zip-encoded files with the wrong
  layout

Fixes #219.
