### PR TITLE
The package list endpoint no longer fails on packages with deleted repos

### DIFF
--- a/src/it/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
+++ b/src/it/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
@@ -1,0 +1,125 @@
+package com.mesosphere.cosmos
+
+import java.util.UUID
+
+import cats.data.Xor
+import com.mesosphere.cosmos.circe.Decoders._
+import com.mesosphere.cosmos.circe.Encoders._
+import com.mesosphere.cosmos.http.MediaTypes
+import com.mesosphere.cosmos.model._
+import com.mesosphere.cosmos.repository.DefaultRepositories
+import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
+import org.scalatest.concurrent.Eventually
+import org.scalatest.{AppendedClues, FreeSpec, Inside}
+
+final class PackageListIntegrationSpec
+  extends FreeSpec with Inside with AppendedClues with Eventually {
+
+  import PackageListIntegrationSpec._
+
+  val apiClient = CosmosIntegrationTestClient.CosmosClient
+
+  // These tests may be better implemented as focused unit tests
+  // There's a bunch of setup and teardown infrastructure here which complicates the control flow
+  // Until then, if you need to understand the code, ask @cruhland (says @BenWhitehead)
+
+  "The package list endpoint" - {
+    "responds with repo and package data for packages whose repositories are in the repo list" in {
+      withInstalledPackage("helloworld") { installResponse =>
+        withInstalledPackageInListResponse(installResponse) { case Some(Installation(_, Some(_))) =>
+          // Success
+        }
+      }
+    }
+  }
+
+  "Issue #251: Package list should include packages whose repositories have been removed" in {
+    withInstalledPackage("helloworld") { installResponse =>
+      withDeletedRepository(helloWorldRepository) {
+        withInstalledPackageInListResponse(installResponse) { case Some(Installation(_, None)) =>
+          // Success
+        }
+      }
+    }
+  }
+
+  private[this] def withInstalledPackage(packageName: String)(f: InstallResponse => Unit): Unit = {
+    val Xor.Right(installResponse) = apiClient.callEndpoint[InstallRequest, InstallResponse](
+      "package/install",
+      InstallRequest(packageName, appId = Some(AppId(UUID.randomUUID().toString))),
+      MediaTypes.InstallRequest,
+      MediaTypes.InstallResponse
+    ) withClue "when installing package"
+
+    try {
+      assertResult(packageName)(installResponse.packageName)
+      f(installResponse)
+    } finally {
+      val actualUninstall = apiClient.callEndpoint[UninstallRequest, UninstallResponse](
+        "package/uninstall",
+        UninstallRequest(installResponse.packageName, appId = Some(installResponse.appId), all = None),
+        MediaTypes.UninstallRequest,
+        MediaTypes.UninstallResponse
+      ) withClue "when uninstalling package"
+
+      inside (actualUninstall) {
+        case Xor.Right(UninstallResponse(List(UninstallResult(uninstalledPackageName, appId, Some(packageVersion), _)))) =>
+          assertResult(installResponse.appId)(appId)
+          assertResult(installResponse.packageName)(uninstalledPackageName)
+          assertResult(installResponse.packageVersion)(packageVersion)
+      }
+    }
+  }
+
+  private[this] def withDeletedRepository(repository: PackageRepository)(action: => Unit): Unit = {
+    val actualDelete = apiClient.callEndpoint[PackageRepositoryDeleteRequest, PackageRepositoryDeleteResponse](
+      "package/repository/delete",
+      PackageRepositoryDeleteRequest(name = Some(repository.name)),
+      MediaTypes.PackageRepositoryDeleteRequest,
+      MediaTypes.PackageRepositoryDeleteResponse
+    ) withClue "when deleting repo"
+
+    try {
+      assertResult(Xor.Right(None)) {
+        actualDelete.map(_.repositories.find(_.name == repository.name))
+      }
+
+      action
+    } finally {
+      val actualAdd = apiClient.callEndpoint[PackageRepositoryAddRequest, PackageRepositoryAddResponse](
+        "package/repository/add",
+        PackageRepositoryAddRequest(repository.name, repository.uri),
+        MediaTypes.PackageRepositoryAddRequest,
+        MediaTypes.PackageRepositoryAddResponse
+      ) withClue "when restoring deleted repo"
+
+      inside(actualAdd) { case Xor.Right(PackageRepositoryAddResponse(repositories)) =>
+        inside(repositories.find(_.name == repository.name)) { case Some(addedRepository) =>
+          assertResult(repository)(addedRepository)
+        }
+      }
+    }
+  }
+
+  private[this] def withInstalledPackageInListResponse(installResponse: InstallResponse)(
+    pf: PartialFunction[Option[Installation], Unit]
+  ): Unit = {
+    val actualList = apiClient.callEndpoint[ListRequest, ListResponse](
+      "package/list",
+      ListRequest(),
+      MediaTypes.ListRequest,
+      MediaTypes.ListResponse
+    ) withClue "when listing installed packages"
+
+    inside (actualList) { case Xor.Right(ListResponse(packages)) =>
+      inside (packages.find(_.appId == installResponse.appId)) { pf }
+    }
+  }
+
+}
+
+object PackageListIntegrationSpec {
+
+  private val Some(helloWorldRepository) = DefaultRepositories().getOrThrow.find(_.name == "Hello World")
+
+}

--- a/src/it/scala/com/mesosphere/cosmos/repository/EmptyRepository.scala
+++ b/src/it/scala/com/mesosphere/cosmos/repository/EmptyRepository.scala
@@ -1,5 +1,6 @@
 package com.mesosphere.cosmos.repository
 
+import com.mesosphere.cosmos.model.PackageRepository
 import com.mesosphere.cosmos.{PackageNotFound, RepositoryNotFound}
 import com.mesosphere.universe.{PackageDetailsVersion, PackageFiles, ReleaseVersion, UniverseIndexEntry}
 import com.netaporter.uri.Uri
@@ -7,6 +8,8 @@ import com.twitter.util.Future
 
 /** Useful when a repository is not needed or should not be used. */
 object EmptyRepository extends Repository {
+
+  override def repository: PackageRepository = throw new UnsupportedOperationException()
 
   override def getPackageByPackageVersion(
     packageName: String,

--- a/src/main/scala/com/mesosphere/cosmos/MultiRepository.scala
+++ b/src/main/scala/com/mesosphere/cosmos/MultiRepository.scala
@@ -20,7 +20,7 @@ final class MultiRepository (
     /* Fold over all the results in order and ignore PackageNotFound and VersionNotFound errors.
      * We have found our answer when we find a PackageFile or a generic exception.
      */
-    repositories.flatMap { repositories =>
+    repositories().flatMap { repositories =>
       Future.collect {
         repositories.map { repository =>
           repository.getPackageByPackageVersion(packageName, packageVersion)
@@ -45,7 +45,7 @@ final class MultiRepository (
     /* Fold over all the results in order and ignore PackageNotFound errors.
      * We have found our answer when we find a UniverseIndexEntry or a generic exception.
      */
-    repositories.flatMap { repositories =>
+    repositories().flatMap { repositories =>
       Future.collect {
         repositories.map { repository =>
           repository.getPackageIndex(packageName)
@@ -61,7 +61,7 @@ final class MultiRepository (
   }
 
   override def search(query: Option[String]): Future[List[UniverseIndexEntry]] = {
-    repositories.flatMap { repositories =>
+    repositories().flatMap { repositories =>
       Future.collect {
         repositories.map { repository =>
           repository.search(query)
@@ -70,11 +70,9 @@ final class MultiRepository (
     }
   }
 
-  def getRepository(uri: Uri): Future[Repository] = {
-   repositories.map { repositories =>
-      repositories.find { repository =>
-        repository.universeBundle == uri
-      } getOrElse(throw RepositoryNotFound(uri))
+  def getRepository(uri: Uri): Future[Option[Repository]] = {
+   repositories().map { repositories =>
+      repositories.find(_.universeBundle == uri)
     }
   }
 

--- a/src/main/scala/com/mesosphere/cosmos/UniversePackageCache.scala
+++ b/src/main/scala/com/mesosphere/cosmos/UniversePackageCache.scala
@@ -31,7 +31,7 @@ import scala.util.matching.Regex
 /** Stores packages from the Universe GitHub repository in the local filesystem.
   */
 final class UniversePackageCache private (
-  repository: PackageRepository,
+  override val repository: PackageRepository,
   universeDir: Path
 ) extends Repository with AutoCloseable {
   // This mutex serializes updates to the local package cache

--- a/src/main/scala/com/mesosphere/cosmos/model/Installation.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/Installation.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.cosmos.model
 
 case class Installation(
-  appId: String,
-  packageInformation: InstalledPackageInformation
+  appId: AppId,
+  packageInformation: Option[InstalledPackageInformation]
 )

--- a/src/main/scala/com/mesosphere/cosmos/repository/Repository.scala
+++ b/src/main/scala/com/mesosphere/cosmos/repository/Repository.scala
@@ -1,10 +1,13 @@
 package com.mesosphere.cosmos.repository
 
+import com.mesosphere.cosmos.model.PackageRepository
 import com.mesosphere.universe._
 import com.twitter.util.Future
 
 /** A repository of packages that can be installed on DCOS. */
 trait Repository extends PackageCollection {
+
+  def repository: PackageRepository
 
   def getPackageByReleaseVersion(
     packageName: String,

--- a/src/test/scala/com/mesosphere/cosmos/MemoryPackageCache.scala
+++ b/src/test/scala/com/mesosphere/cosmos/MemoryPackageCache.scala
@@ -1,16 +1,18 @@
 package com.mesosphere.cosmos
 
+import com.mesosphere.cosmos.model.PackageRepository
+import com.mesosphere.cosmos.repository.Repository
+import com.mesosphere.universe._
 import com.netaporter.uri.dsl.stringToUri
 import com.twitter.util.Future
-
-import com.mesosphere.universe._
-import com.mesosphere.cosmos.repository.Repository
 
 /** A package cache that stores all package information in memory. Useful for testing.
   *
   * @param packages the contents of the cache: package data indexed by package name
   */
 final case class MemoryPackageCache(packages: Map[String, PackageFiles]) extends Repository {
+
+  override def repository: PackageRepository = throw new UnsupportedOperationException()
 
   override def getPackageByPackageVersion(
     packageName: String,


### PR DESCRIPTION
Instead, it includes them in the list, but with reduced information,
since the repository containing that information is not available.

Fixes #251.
