### PR TITLE
Update Package List logic

### DIFF
--- a/src/main/scala/com/mesosphere/cosmos/model/Installation.scala
+++ b/src/main/scala/com/mesosphere/cosmos/model/Installation.scala
@@ -2,5 +2,5 @@ package com.mesosphere.cosmos.model
 
 case class Installation(
   appId: AppId,
-  packageInformation: Option[InstalledPackageInformation]
+  packageInformation: InstalledPackageInformation
 )


### PR DESCRIPTION
New fallback to reading package info from marathon.json if the package's repo is no longer present.

Fixes #251 
