### PR TITLE
Factor out PackageCacheSynchronizer from UniversePackageCache

### DIFF
--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/EmptyRepository.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/EmptyRepository.scala
@@ -9,7 +9,7 @@ import com.twitter.util.Future
 /** Useful when a repository is not needed or should not be used. */
 object EmptyRepository extends Repository {
 
-  override def repository: PackageRepository = throw new UnsupportedOperationException()
+  override def uri: Uri = throw new UnsupportedOperationException()
 
   override def getPackageByPackageVersion(
     packageName: String,

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/FilesystemPackageMetadataStore.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/FilesystemPackageMetadataStore.scala
@@ -1,0 +1,19 @@
+package com.mesosphere.cosmos
+
+import java.nio.file.{Files, NoSuchFileException, Path}
+
+import com.twitter.util.Try
+
+object FilesystemPackageMetadataStore extends PackageMetadataStore {
+
+  def readFile(path: Path): Option[Array[Byte]] = {
+    Try(Some(Files.readAllBytes(path)))
+      .handle {
+        case e: NoSuchFileException => None
+        // TODO: This is not the correct error. We return None if the file doesn't exists.
+        case e => throw new PackageFileMissing(path.toString, e)
+      }
+      .get()
+  }
+
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
@@ -5,8 +5,6 @@ import java.net.{Authenticator, PasswordAuthentication}
 
 import com.netaporter.uri.Uri
 
-import scala.collection.JavaConverters._
-
 private[cosmos] object HttpProxySupport {
 
   private[this] val HttpProxyHost = "http.proxyHost"

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/MultiRepository.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/MultiRepository.scala
@@ -12,7 +12,7 @@ final class MultiRepository (
   packageRepositoryStorage: PackageSourcesStorage,
   universeDir: Path
 ) extends PackageCollection {
-  @volatile private[this] var cachedRepositories = Map.empty[Uri, UniversePackageCache]
+  @volatile private[this] var cachedRepositories = Map.empty[Uri, Repository with AutoCloseable]
 
   override def getPackageByPackageVersion(
     packageName: String,
@@ -73,20 +73,18 @@ final class MultiRepository (
 
   def getRepository(uri: Uri): Future[Option[Repository]] = {
    repositories().map { repositories =>
-      repositories.find(_.universeBundle == uri)
+      repositories.find(_.uri == uri)
     }
   }
 
-  private def repositories(): Future[List[UniversePackageCache]] = {
+  private def repositories(): Future[List[Repository]] = {
     packageRepositoryStorage.readCache().map { repositories =>
-      val oldRepositories: Map[Uri, UniversePackageCache] = cachedRepositories
+      val oldRepositories = cachedRepositories
       val result = repositories.map { repository =>
-        oldRepositories.getOrElse(repository.uri, UniversePackageCache(repository, universeDir))
+        oldRepositories.getOrElse(repository.uri, new PackageCacheSynchronizer(repository, universeDir))
       }
 
-      val newRepositories: Map[Uri, UniversePackageCache] = result.map(repository =>
-          (repository.universeBundle, repository)
-      ).toMap
+      val newRepositories = result.map(repository => (repository.uri, repository)).toMap
 
       // Clean any repository that is not used anymore
       (oldRepositories -- newRepositories.keys).foreach { case (_, value) =>

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/PackageCacheSynchronizer.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/PackageCacheSynchronizer.scala
@@ -1,0 +1,194 @@
+package com.mesosphere.cosmos
+
+import java.net.{MalformedURLException, UnknownHostException}
+import java.nio.file._
+import java.time.LocalDateTime
+import java.util.Base64
+import java.util.concurrent.atomic.AtomicReference
+import java.util.zip.ZipInputStream
+
+import com.mesosphere.cosmos.model.{PackageRepository, SearchResult}
+import com.mesosphere.cosmos.repository.Repository
+import com.mesosphere.universe.{PackageDetailsVersion, PackageFiles, ReleaseVersion, UniverseIndexEntry}
+import com.netaporter.uri.Uri
+import com.twitter.concurrent.AsyncMutex
+import com.twitter.io.{Charsets, Files => TwitterFiles}
+import com.twitter.util.{Future, Try}
+
+private[cosmos] final class PackageCacheSynchronizer(repository: PackageRepository, universeDir: Path)
+  extends Repository with AutoCloseable {
+
+  import PackageCacheSynchronizer._
+
+  override def uri: Uri = repository.uri
+
+  override def getPackageByPackageVersion(
+    packageName: String,
+    packageVersion: Option[PackageDetailsVersion]
+  ): Future[PackageFiles] = {
+    mostRecentCache().flatMap(_.getPackageByPackageVersion(packageName, packageVersion))
+  }
+
+  override def getPackageByReleaseVersion(
+    packageName: String,
+    releaseVersion: ReleaseVersion
+  ): Future[PackageFiles] = {
+    mostRecentCache().flatMap(_.getPackageByReleaseVersion(packageName, releaseVersion))
+  }
+
+  override def getPackageIndex(packageName: String): Future[UniverseIndexEntry] = {
+    mostRecentCache().flatMap(_.getPackageIndex(packageName))
+  }
+
+  override def search(queryOpt: Option[String]): Future[List[SearchResult]] = {
+    mostRecentCache().flatMap(_.search(queryOpt))
+  }
+
+  override def close(): Unit = {
+    // Note: The order is very important!!
+
+    val symlinkBundlePath = universeDir.resolve(base64(repository.uri))
+
+    // Remember the old bundle path so we can delete it later
+    val bundlePath = readSymbolicLink(symlinkBundlePath)
+
+    // Delete the bundle directory
+    bundlePath.foreach { p =>
+      //TODO: This needs to be more robust to handle potential lingering symlinks
+      Files.delete(symlinkBundlePath)  // work around until https://github.com/mesosphere/cosmos/issues/246 is fixed
+      // Delete the symbolic link
+      TwitterFiles.delete(p.toFile)
+    }
+  }
+
+  // This mutex serializes updates to the local package cache
+  private[this] val updateMutex = new AsyncMutex()
+
+  private[this] val lastModified = new AtomicReference(LocalDateTime.MIN)
+
+  private[this] val cache = new AtomicReference[UniversePackageCache]()
+
+  private[this] def mostRecentCache(): Future[UniversePackageCache] = {
+    updateMutex.acquireAndRun {
+      // TODO: How often we check should be configurable
+      if (lastModified.get().plusMinutes(1).isBefore(LocalDateTime.now())) {
+        updateUniverseCache()
+          .onSuccess { newCache =>
+            lastModified.set(LocalDateTime.now())
+            cache.set(newCache)
+          }
+      } else {
+        Future.value(cache.get())
+      }
+    }
+  }
+
+  private[this] def updateUniverseCache(): Future[UniversePackageCache] = {
+    Future(repository.uri.toURI.toURL.openStream())
+      .handle {
+        case e @ (_: IllegalArgumentException | _: MalformedURLException | _: UnknownHostException) =>
+          throw new InvalidRepositoryUri(repository, e)
+      }
+      .map { bundleStream =>
+        try {
+          val path = extractBundle(
+            new ZipInputStream(bundleStream),
+            repository.uri,
+            universeDir
+          )
+
+          // TODO: The path will always be the same, since it contains a symlink; eventually
+          // it might be better to use a different path each time, so that clients see a
+          // consistent snapshot of the repo, instead of one that could change underneath them
+          UniversePackageCache(repository.uri, path, FilesystemPackageMetadataStore)
+        } finally {
+          bundleStream.close()
+        }
+      }
+  }
+
+}
+
+object PackageCacheSynchronizer {
+
+  private def base64(universeBundle: Uri): String = {
+    Base64.getUrlEncoder().encodeToString(
+      universeBundle.toString.getBytes(Charsets.Utf8)
+    )
+  }
+
+  private def extractBundle(
+    bundle: ZipInputStream,
+    universeBundle: Uri,
+    universeDir: Path
+  ): Path = {
+
+    val entries = Iterator.continually(Option(bundle.getNextEntry()))
+      .takeWhile(_.isDefined)
+      .flatten
+
+    val tempDir = Files.createTempDirectory(universeDir, "repository")
+    tempDir.toFile.deleteOnExit()
+
+    try {
+      // Copy all of the entry to a temporary folder
+      entries.foreach { entry =>
+        val entryPath = Paths.get(entry.getName)
+
+        // Skip the root directory
+        if (entryPath.getNameCount > 1) {
+          val tempEntryPath = tempDir
+            .resolve(entryPath.subpath(1, entryPath.getNameCount))
+
+          if (entry.isDirectory) {
+            Files.createDirectory(tempEntryPath)
+          } else {
+            Files.copy(bundle, tempEntryPath)
+          }
+        }
+      }
+
+      // Move the symblic to the temp directory to the actual universe directory...
+      val bundlePath = universeDir.resolve(base64(universeBundle))
+      val newBundlePath = universeDir.resolve(base64(universeBundle) + ".new")
+
+      // Remember the old bundle path so we can delete it later
+      val oldBundlePath = readSymbolicLink(bundlePath)
+
+      // Create new symbolic link to the new bundle directory
+      Files.createSymbolicLink(newBundlePath, tempDir)
+
+      // Atomic move of the temporary directory
+      val path = Files.move(
+        newBundlePath,
+        bundlePath,
+        StandardCopyOption.ATOMIC_MOVE,
+        StandardCopyOption.REPLACE_EXISTING
+      )
+
+      // Delete the old bundle directory
+      oldBundlePath.foreach { p => TwitterFiles.delete(p.toFile) }
+
+      path
+    } catch {
+      case e: Exception =>
+        // Only delete directory on failures because we want to keep it around on success.
+        TwitterFiles.delete(tempDir.toFile)
+        throw e
+    }
+  }
+
+  private def readSymbolicLink(path: Path): Option[Path] = {
+    Try(Files.readSymbolicLink(path))
+      .map { path =>
+        Some(path)
+      }
+      .handle {
+        case e: NoSuchFileException =>
+          // this is okay, we expect the link to not be there the first time
+          None
+      }
+      .get
+  }
+
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/PackageMetadataStore.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/PackageMetadataStore.scala
@@ -1,0 +1,35 @@
+package com.mesosphere.cosmos
+
+import java.nio.file.Path
+
+import cats.data.Xor
+import com.twitter.io.Charsets
+import io.circe.Json
+import io.circe.parse._
+
+trait PackageMetadataStore {
+
+  def readFile(path: Path): Option[Array[Byte]]
+
+}
+
+object PackageMetadataStore {
+
+  implicit final class PackageMetadataStoreOps(val ms: PackageMetadataStore) extends AnyVal {
+
+    def readUtf8File(path: Path): Option[String] = {
+      ms.readFile(path).map(new String(_, Charsets.Utf8))
+    }
+
+    def parseJsonFile(path: Path): Option[Json] = {
+      readUtf8File(path).map { content =>
+        parse(content) match {
+          case Xor.Left(err) => throw PackageFileNotJson(path.getFileName.toString, err.message)
+          case Xor.Right(json) => json
+        }
+      }
+    }
+
+  }
+
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/UniversePackageCache.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/UniversePackageCache.scala
@@ -1,14 +1,7 @@
 package com.mesosphere.cosmos
 
-import java.net.{MalformedURLException, UnknownHostException}
 import java.nio.file._
-import java.time.LocalDateTime
-import java.util.Base64
-import java.util.concurrent.atomic.AtomicReference
-import java.util.zip.ZipInputStream
 
-import cats.data.Validated.{Invalid, Valid}
-import cats.data.Xor.{Left, Right}
 import cats.data._
 import cats.std.list._           // allows for traversU in verifySchema
 import cats.std.option._
@@ -16,14 +9,11 @@ import cats.syntax.apply._       // provides |@|
 import cats.syntax.option._
 import cats.syntax.traverse._
 import com.mesosphere.cosmos.circe.Decoders._
-import com.mesosphere.cosmos.model.{PackageRepository, SearchResult}
+import com.mesosphere.cosmos.model.SearchResult
 import com.mesosphere.cosmos.repository.Repository
 import com.mesosphere.universe._
 import com.netaporter.uri.Uri
-import com.twitter.concurrent.AsyncMutex
-import com.twitter.io.{Charsets, Files => TwitterFiles}
-import com.twitter.util.{Future, Try}
-import io.circe.parse._
+import com.twitter.util.Future
 import io.circe.{Decoder, Json}
 
 import scala.util.matching.Regex
@@ -31,25 +21,21 @@ import scala.util.matching.Regex
 /** Stores packages from the Universe GitHub repository in the local filesystem.
   */
 final class UniversePackageCache private (
-  override val repository: PackageRepository,
-  universeDir: Path
-) extends Repository with AutoCloseable {
+  override val uri: Uri,
+  repoDir: Path,
+  universeIndex: UniverseIndex,
+  packageMetadataStore: PackageMetadataStore
+) extends Repository {
 
   import UniversePackageCache._
-
-  // This mutex serializes updates to the local package cache
-  private[this] val updateMutex = new AsyncMutex()
-
-  private[this] val lastModified = new AtomicReference(LocalDateTime.MIN)
 
   override def getPackageByPackageVersion(
     packageName: String,
     packageVersion: Option[PackageDetailsVersion]
   ): Future[PackageFiles] = {
-    mostRecentBundle().map { case (bundleDir, universeIndex) =>
-      val repoDir = repoDirectory(bundleDir)
-      val packageDir = getPackagePath(repoDir, universeIndex, packageName, packageVersion)
-      readPackageFiles(universeBundle, packageDir)
+    Future {
+      val packageDir = getPackagePath(packageName, packageVersion)
+      readPackageFiles(packageDir)
     }
   }
 
@@ -57,197 +43,141 @@ final class UniversePackageCache private (
     packageName: String,
     releaseVersion: ReleaseVersion
   ): Future[PackageFiles] = {
-    mostRecentBundle().map { case (bundleDir, _) =>
-      val packageDir = getPackageReleasePath(repoDirectory(bundleDir), packageName, releaseVersion)
-      readPackageFiles(universeBundle, packageDir)
+    Future {
+      val packageDir = getPackageReleasePath(packageName, releaseVersion)
+      readPackageFiles(packageDir)
     }
   }
 
   override def getPackageIndex(packageName: String): Future[UniverseIndexEntry] = {
-    mostRecentBundle().map { case (bundleDir, universeIndex) =>
-      universeIndex.getPackages.getOrElse(packageName, throw PackageNotFound(packageName))
-    }
+    Future(universeIndex.getPackages.getOrElse(packageName, throw PackageNotFound(packageName)))
   }
 
   override def search(queryOpt: Option[String]): Future[List[SearchResult]] = {
-    mostRecentBundle().map { case (bundleDir, universeIndex) =>
-      UniversePackageCache.search(bundleDir, universeIndex, queryOpt)
-    }
-  }
-
-  override def close(): Unit = {
-    // Note: The order is very important!!
-
-    val symlinkBundlePath = universeDir.resolve(base64(universeBundle))
-
-    // Remember the old bundle path so we can delete it later
-    val bundlePath = readSymbolicLink(symlinkBundlePath)
-
-    // Delete the bundle directory
-    bundlePath.foreach { p =>
-      //TODO: This needs to be more robust to handle potential lingering symlinks
-      Files.delete(symlinkBundlePath)  // work around until https://github.com/mesosphere/cosmos/issues/246 is fixed
-      // Delete the symbolic link
-      TwitterFiles.delete(p.toFile)
-    }
-  }
-
-  def universeBundle: Uri = repository.uri
-
-  private[this] def mostRecentBundle(): Future[(Path, UniverseIndex)] = {
-    synchronizedUpdate().map { bundlePath =>
-      val indexFile = repoDirectory(bundlePath).resolve(Paths.get("meta", "index.json"))
-
-      val repoIndex = parseJsonFile(indexFile)
-        .toRightXor(new IndexNotFound(universeBundle))
-        .flatMap { index =>
-          index.as[UniverseIndex].leftMap(_ => PackageFileSchemaMismatch("index.json"))
+    Future {
+      searchIndex(queryOpt)
+        .map { indexEntry =>
+          val resources = packageResources(indexEntry.name)
+          searchResult(indexEntry, resources.images)
         }
-        .valueOr(err => throw err)
-
-      val repoVersion = repoIndex.version
-      if (repoVersion.toString.startsWith("2.")) {
-        (bundlePath, repoIndex)
-      } else {
-        throw new UnsupportedRepositoryVersion(repoVersion)
-      }
     }
   }
 
-  private[this] def synchronizedUpdate(): Future[Path] = {
-    updateMutex.acquireAndRun {
-      // TODO: How often we check should be configurable
-      if (lastModified.get().plusMinutes(1).isBefore(LocalDateTime.now())) {
-        updateUniverseCache()
-          .onSuccess { _ => lastModified.set(LocalDateTime.now()) }
-      } else {
-        /* We don't need to fetch the latest package information; just return the current
-         * information.
-         */
-        Future(universeDir.resolve(base64(universeBundle)))
-      }
-    }
-  }
-
-  private[this] def updateUniverseCache(): Future[Path] = {
-    Future(universeBundle.toURI.toURL.openStream())
-      .handle {
-        case e @ (_: IllegalArgumentException | _: MalformedURLException | _: UnknownHostException) =>
-          throw new InvalidRepositoryUri(repository, e)
-      }
-      .map { bundleStream =>
-        try {
-          extractBundle(
-            new ZipInputStream(bundleStream),
-            universeBundle,
-            universeDir
-          )
-        } finally {
-          bundleStream.close()
+  // return path of specified version, or latest if version not specified
+  private[this] def getPackagePath(packageName: String, packageVersion: Option[PackageDetailsVersion]): Path = {
+    universeIndex.getPackages.get(packageName) match {
+      case None => throw PackageNotFound(packageName)
+      case Some(packageInfo) =>
+        val version = packageVersion.getOrElse(packageInfo.currentVersion)
+        packageInfo.versions.get(version) match {
+          case None => throw VersionNotFound(packageName, version)
+          case Some(revision) =>
+            val packagePath = getPackageReleasePath(packageName, revision)
+            repoDir.resolve(packagePath)
         }
-      }
+    }
   }
 
-  private[this] def base64(universeBundle: Uri): String = {
-    Base64.getUrlEncoder().encodeToString(
-      universeBundle.toString.getBytes(Charsets.Utf8)
+  private[this] def getPackageReleasePath(packageName: String, releaseVersion: ReleaseVersion): Path = {
+    repoDir.resolve(
+      Paths.get(
+        "packages",
+        packageName.charAt(0).toUpper.toString,
+        packageName,
+        releaseVersion.toString
+      )
     )
   }
 
-  private[this] def extractBundle(
-    bundle: ZipInputStream,
-    universeBundle: Uri,
-    universeDir: Path
-  ): Path = {
+  private[this] def readPackageFiles(packageDir: Path): PackageFiles = {
 
-    val entries = Iterator.continually(Option(bundle.getNextEntry()))
-      .takeWhile(_.isDefined)
-      .flatten
+    val packageJson = packageMetadataStore.parseJsonFile(
+      packageDir.resolve("package.json")
+    ).getOrElse {
+      throw PackageFileMissing("package.json")
+    }
+    val mustache = packageMetadataStore.readUtf8File(
+      packageDir.resolve("marathon.json.mustache")
+    ).getOrElse {
+      throw PackageFileMissing("marathon.json.mustache")
+    }
 
-    val tempDir = Files.createTempDirectory(universeDir, "repository")
-    tempDir.toFile.deleteOnExit()
-
-    try {
-      // Copy all of the entry to a temporary folder
-      entries.foreach { entry =>
-        val entryPath = Paths.get(entry.getName)
-
-        // Skip the root directory
-        if (entryPath.getNameCount > 1) {
-          val tempEntryPath = tempDir
-            .resolve(entryPath.subpath(1, entryPath.getNameCount))
-
-          if (entry.isDirectory) {
-            Files.createDirectory(tempEntryPath)
-          } else {
-            Files.copy(bundle, tempEntryPath)
-          }
-        }
+    val packageDefValid = verifySchema[PackageDetails](packageJson, "package.json")
+    val resourceDefValid = decodeJsonFile[Resource](packageDir, "resource.json").toValidated.toValidatedNel
+    val commandJsonValid = decodeJsonFile[Command](packageDir, "command.json").toValidated.toValidatedNel
+    val configJsonObject = packageMetadataStore.parseJsonFile(packageDir.resolve("config.json"))
+      .traverseU { json =>
+        json
+          .asObject
+          .toValidNel[CosmosError](PackageFileSchemaMismatch("config.json"))
       }
 
-      // Move the symblic to the temp directory to the actual universe directory...
-      val bundlePath = universeDir.resolve(base64(universeBundle))
-      val newBundlePath = universeDir.resolve(base64(universeBundle) + ".new")
+    (packageDefValid |@| resourceDefValid |@| commandJsonValid |@| configJsonObject)
+      .map { (packageDef, resourceDef, commandJson, configJson) =>
+        PackageFiles(
+          packageDir.getFileName.toString,
+          uri,
+          packageDef,
+          mustache,
+          commandJson,
+          configJson,
+          resourceDef
+        )
+      }
+      .toXor
+      .valueOr(err => throw NelErrors(err))
+  }
 
-      // Remember the old bundle path so we can delete it later
-      val oldBundlePath = readSymbolicLink(bundlePath)
-
-      // Create new symbolic link to the new bundle directory
-      Files.createSymbolicLink(newBundlePath, tempDir)
-
-      // Atomic move of the temporary directory
-      val path = Files.move(
-        newBundlePath,
-        bundlePath,
-        StandardCopyOption.ATOMIC_MOVE,
-        StandardCopyOption.REPLACE_EXISTING
-      )
-
-      // Delete the old bundle directory
-      oldBundlePath.foreach { p => TwitterFiles.delete(p.toFile) }
-
-      path
-    } catch {
-      case e: Exception =>
-      // Only delete directory on failures because we want to keep it around on success.
-      TwitterFiles.delete(tempDir.toFile)
-      throw e
+  private[this] def searchIndex(queryOpt: Option[String]): List[UniverseIndexEntry] = {
+    queryOpt match {
+      case None => universeIndex.packages
+      case Some(query) =>
+        if (query.contains("*")) {
+          val regex = getRegex(query)
+          universeIndex.packages.filter(searchRegexInPackageIndex(_, regex))
+        } else {
+          universeIndex.packages.filter(searchPackageIndex(_, query.toLowerCase()))
+        }
     }
   }
 
-  private[this] def readSymbolicLink(path: Path): Option[Path] = {
-    Try(Files.readSymbolicLink(path))
-      .map { path =>
-        Some(path)
-      }
-      .handle {
-        case e: NoSuchFileException =>
-          // this is okay, we expect the link to not be there the first time
-          None
-      }
-      .get
+  private[this] def packageResources(packageName: String): Resource = {
+    val packageDir = getPackagePath(packageName, packageVersion = None)
+    decodeJsonFile[Resource](packageDir, "resource.json")
+      .valueOr(err => throw err)
+      .getOrElse(Resource())
+  }
+
+  private[this] def decodeJsonFile[A : Decoder](
+    packageDir: Path,
+    fileName: String
+  ): Xor[CosmosError, Option[A]] = {
+    packageMetadataStore.parseJsonFile(packageDir.resolve(fileName)).traverseU { json =>
+      json.as[A].leftMap(_ => PackageFileSchemaMismatch(fileName))
+    }
   }
 
 }
 
 object UniversePackageCache {
 
-  def apply(repository: PackageRepository, dataDir: Path): UniversePackageCache = {
-    new UniversePackageCache(repository, dataDir)
-  }
+  def apply(uri: Uri, dataDir: Path, packageMetadataStore: PackageMetadataStore): UniversePackageCache = {
+    val repoDir = dataDir.resolve("repo")
+    val indexFile = repoDir.resolve(Paths.get("meta", "index.json"))
 
-  private[cosmos] def search(
-    bundleDir: Path,
-    universeIndex: UniverseIndex,
-    queryOpt: Option[String]
-  ): List[SearchResult] = {
-    val repoDir = repoDirectory(bundleDir)
-
-    searchIndex(universeIndex.packages, queryOpt)
-      .map { indexEntry =>
-        val resources = packageResources(repoDir, universeIndex, indexEntry.name)
-        searchResult(indexEntry, resources.images)
+    val repoIndex = packageMetadataStore.parseJsonFile(indexFile)
+      .toRightXor(new IndexNotFound(uri))
+      .flatMap { index =>
+        index.as[UniverseIndex].leftMap(_ => PackageFileSchemaMismatch("index.json"))
       }
+      .valueOr(err => throw err)
+
+    val repoVersion = repoIndex.version
+    if (repoVersion.toString.startsWith("2.")) {
+      new UniversePackageCache(uri, repoDir, repoIndex, packageMetadataStore)
+    } else {
+      throw new UnsupportedRepositoryVersion(repoVersion)
+    }
   }
 
   private[cosmos] def searchResult(indexEntry: UniverseIndexEntry, images: Option[Images]): SearchResult = {
@@ -263,163 +193,23 @@ object UniversePackageCache {
     )
   }
 
-  private[cosmos] def repoDirectory(bundleDir: Path) = bundleDir.resolve("repo")
-
-  private[this] def searchIndex(
-    entries: List[UniverseIndexEntry],
-    queryOpt: Option[String]
-  ): List[UniverseIndexEntry] = {
-    queryOpt match {
-      case None => entries
-      case Some(query) =>
-        if (query.contains("*")) {
-          val regex = getRegex(query)
-          entries.filter(searchRegexInPackageIndex(_, regex))
-        } else {
-          entries.filter(searchPackageIndex(_, query.toLowerCase()))
-        }
-    }
-  }
-
-  private[this] def searchRegexInPackageIndex(index: UniverseIndexEntry, regex: Regex): Boolean = {
+  private def searchRegexInPackageIndex(index: UniverseIndexEntry, regex: Regex): Boolean = {
     regex.findFirstIn(index.name).isDefined ||
       regex.findFirstIn(index.description).isDefined ||
       index.tags.exists(regex.findFirstIn(_).isDefined)
   }
 
-  private[this] def searchPackageIndex(index: UniverseIndexEntry, query: String): Boolean= {
+  private def searchPackageIndex(index: UniverseIndexEntry, query: String): Boolean= {
     index.name.toLowerCase().contains(query) ||
       index.description.toLowerCase().contains(query) ||
       index.tags.exists(_.toLowerCase().contains(query))
   }
 
-  private[this] def getRegex(query: String): Regex = {
+  private def getRegex(query: String): Regex = {
     s"""^${query.replaceAll("\\*", ".*")}$$""".r
   }
 
-  private[cosmos] def packageResources(
-    repoDir: Path,
-    universeIndex: UniverseIndex,
-    packageName: String
-  ): Resource = {
-    val packageDir = getPackagePath(repoDir, universeIndex, packageName, packageVersion = None)
-    parseAndVerify[Resource](packageDir, "resource.json")
-      .valueOr(err => throw err)
-      .getOrElse(Resource())
-  }
-
-  private[this] def parseAndVerify[A : Decoder](
-    packageDir: Path,
-    fileName: String
-  ): Xor[CosmosError, Option[A]] = {
-    parseJsonFile(packageDir.resolve(fileName)).traverseU { json =>
-      json.as[A].leftMap(_ => PackageFileSchemaMismatch(fileName))
-    }
-  }
-
-  // return path of specified version, or latest if version not specified
-  private def getPackagePath(
-    repository: Path,
-    universeIndex: UniverseIndex,
-    packageName: String,
-    packageVersion: Option[PackageDetailsVersion]
-  ): Path = {
-    universeIndex.getPackages.get(packageName) match {
-      case None => throw PackageNotFound(packageName)
-      case Some(packageInfo) =>
-        val version = packageVersion.getOrElse(packageInfo.currentVersion)
-        packageInfo.versions.get(version) match {
-          case None => throw VersionNotFound(packageName, version)
-          case Some(revision) =>
-            getPackageReleasePath(repository, packageName, revision)
-            val packagePath = Paths.get(
-              "packages",
-              packageName.charAt(0).toUpper.toString,
-              packageName,
-              revision.toString)
-            repository.resolve(packagePath)
-        }
-    }
-  }
-
-  private def getPackageReleasePath(
-    repoDir: Path,
-    packageName: String,
-    releaseVersion: ReleaseVersion
-  ): Path = {
-    repoDir.resolve(
-      Paths.get(
-        "packages",
-        packageName.charAt(0).toUpper.toString,
-        packageName,
-        releaseVersion.toString
-      )
-    )
-  }
-
-  private def readPackageFiles(universeBundle: Uri, packageDir: Path): PackageFiles = {
-
-    val packageJson = parseJsonFile(
-      packageDir.resolve("package.json")
-    ).getOrElse {
-      throw PackageFileMissing("package.json")
-    }
-    val mustache = readFile(
-      packageDir.resolve("marathon.json.mustache")
-    ).getOrElse {
-      throw PackageFileMissing("marathon.json.mustache")
-    }
-
-    val packageDefValid = verifySchema[PackageDetails](packageJson, "package.json")
-    val resourceDefValid = parseAndVerify[Resource](packageDir, "resource.json").toValidated.toValidatedNel
-    val commandJsonValid = parseAndVerify[Command](packageDir, "command.json").toValidated.toValidatedNel
-    val configJsonObject = parseJsonFile(packageDir.resolve("config.json"))
-      .traverseU { json =>
-        json
-          .asObject
-          .toValidNel[CosmosError](PackageFileSchemaMismatch("config.json"))
-      }
-
-    (packageDefValid |@| resourceDefValid |@| commandJsonValid |@| configJsonObject)
-      .map { (packageDef, resourceDef, commandJson, configJson) =>
-        PackageFiles(
-          packageDir.getFileName.toString,
-          universeBundle,
-          packageDef,
-          mustache,
-          commandJson,
-          configJson,
-          resourceDef
-        )
-      }
-      .toXor
-      .valueOr(err => throw NelErrors(err))
-  }
-
-  private def parseJsonFile(file: Path): Option[Json] = {
-    readFile(file).map { content =>
-      parse(content) match {
-        case Left(err) => throw PackageFileNotJson(file.getFileName.toString, err.message)
-        case Right(json) => json
-      }
-    }
-  }
-
-  private[this] def readFile(path: Path): Option[String] = {
-    if (path.toFile.exists()) {
-      try {
-        Some(new String(Files.readAllBytes(path), Charsets.Utf8))
-      } catch {
-        case e: Throwable =>
-          // TODO: This is not the correct error. We return None if the file doesn't exists.
-          throw new PackageFileMissing(path.toString, e)
-      }
-    } else {
-      None
-    }
-  }
-
-  private[this] def verifySchema[A: Decoder](
+  private def verifySchema[A: Decoder](
     json: Json,
     packageFileName: String
   ): ValidatedNel[CosmosError, A] = {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/Repository.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/Repository.scala
@@ -1,13 +1,13 @@
 package com.mesosphere.cosmos.repository
 
-import com.mesosphere.cosmos.model.PackageRepository
 import com.mesosphere.universe._
+import com.netaporter.uri.Uri
 import com.twitter.util.Future
 
 /** A repository of packages that can be installed on DCOS. */
 trait Repository extends PackageCollection {
 
-  def repository: PackageRepository
+  def uri: Uri
 
   def getPackageByReleaseVersion(
     packageName: String,

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/MemoryPackageCache.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/MemoryPackageCache.scala
@@ -3,6 +3,7 @@ package com.mesosphere.cosmos
 import com.mesosphere.cosmos.model.{PackageRepository, SearchResult}
 import com.mesosphere.cosmos.repository.Repository
 import com.mesosphere.universe._
+import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl.stringToUri
 import com.twitter.util.Future
 
@@ -12,7 +13,7 @@ import com.twitter.util.Future
   */
 final case class MemoryPackageCache(packages: Map[String, PackageFiles]) extends Repository {
 
-  override def repository: PackageRepository = throw new UnsupportedOperationException()
+  override def uri: Uri = throw new UnsupportedOperationException()
 
   override def getPackageByPackageVersion(
     packageName: String,


### PR DESCRIPTION
The new class is responsible for keeping the repository files
synchronized on the local file system. UniversePackageCache is now
only responsible for performing repository operations within a
static directory.

Fixes #275.