### PR TITLE
Update MarathonAppContainerDocker to set `network` as optional.

### DIFF
--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/model/thirdparty/marathon/MarathonAppContainerDocker.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/model/thirdparty/marathon/MarathonAppContainerDocker.scala
@@ -1,3 +1,3 @@
 package com.mesosphere.cosmos.model.thirdparty.marathon
 
-case class MarathonAppContainerDocker(image: String, network: String)
+case class MarathonAppContainerDocker(image: String, network: Option[String])

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -164,7 +164,7 @@ private object PackageDescribeSpec extends TableDrivenPropertyChecks {
     mem = 512,
     instances = 1,
     cmd = Some("python3 -m http.server {{port}}"),
-    container = Some(MarathonAppContainer("DOCKER", Some(MarathonAppContainerDocker("python:3", "HOST")))),
+    container = Some(MarathonAppContainer("DOCKER", Some(MarathonAppContainerDocker("python:3", Some("HOST"))))),
     labels = Map.empty,
     uris = List.empty
   )

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -288,7 +288,7 @@ private object PackageInstallIntegrationSpec extends Matchers with TableDrivenPr
         `type` = "DOCKER",
         docker = Some(MarathonAppContainerDocker(
           image = s"python:$pythonVersion",
-          network = "HOST"
+          network = Some("HOST")
         ))
       )),
       labels = Map("test-id" -> UUID.randomUUID().toString),


### PR DESCRIPTION
The `network` field of Container in the marathon app definition is optional, object schema has been updated as such.

Result of #288 being logged.
