### PR TITLE
Update integration tests to use a fixed copy of Universe

### DIFF
--- a/cosmos-server/src/it/resources/default-repositories.json
+++ b/cosmos-server/src/it/resources/default-repositories.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Universe",
-    "uri": "https://universe.mesosphere.com/repo"
+    "uri": "https://downloads.mesosphere.io/universe/8c6767862b9af434349f79b2405db1a7b3680325.zip"
   },
   {
     "name": "Hello World",

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -66,6 +66,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
       "Build high performance applications using a convenient SQL-like query language or JavaScript extensions.",
     framework = true,
     tags = List("arangodb", "NoSQL", "database", "framework"),
+    promoted = Some(true),
     images = Some(Images(
       iconSmall = "https://raw.githubusercontent.com/arangodb/arangodb-dcos/master/icons/arangodb_small.png",
       iconMedium = "https://raw.githubusercontent.com/arangodb/arangodb-dcos/master/icons/arangodb_medium.png",
@@ -84,6 +85,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
     description = "Apache Cassandra running on Apache Mesos",
     framework = true,
     tags = List("data", "database", "nosql"),
+    promoted = Some(true),
     images = Some(Images(
       iconSmall = "https://downloads.mesosphere.com/cassandra-mesos/assets/cassandra-small.png",
       iconMedium = "https://downloads.mesosphere.com/cassandra-mesos/assets/cassandra-medium.png",


### PR DESCRIPTION
This will make the tests more stable by insulating them from changes in the contents of universe itself.

Update PackageSearchSpec to mark arango and cassandra as "promoted"
