### PR TITLE
Add http Proxy Support

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/ConnectionDetails.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/ConnectionDetails.scala
@@ -1,0 +1,3 @@
+package com.mesosphere.cosmos
+
+private[cosmos] case class ConnectionDetails(host: String, port: Int, tls: Boolean = false)

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -217,6 +217,8 @@ object Cosmos extends FinchServer {
     implicit val stats = statsReceiver.scope("cosmos")
     import com.netaporter.uri.dsl._
 
+    HttpProxySupport.configureProxySupport()
+
     val ar = Try(dcosUri())
       .map { dh =>
         val dcosHost: String = Uris.stripTrailingSlash(dh)

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
@@ -1,0 +1,171 @@
+package com.mesosphere.cosmos
+
+import java.net.Authenticator.RequestorType
+import java.net.{Authenticator, PasswordAuthentication}
+
+import com.netaporter.uri.Uri
+
+import scala.collection.JavaConverters._
+
+private[cosmos] object HttpProxySupport {
+
+  private[this] val HttpProxyHost = "http.proxyHost"
+  private[this] val HttpProxyPort = "http.proxyPort"
+  private[this] val HttpsProxyHost = "https.proxyHost"
+  private[this] val HttpsProxyPort = "https.proxyPort"
+  private[this] val HttpProxyNoHosts = "http.nonProxyHosts"
+
+  private[cosmos] case class ProxyEnvVariables(httpProxyUri: Option[Uri], httpsProxyUri: Option[Uri], noProxy: Option[String])
+
+  /**
+    * Goes through the process of setting up the JVM to allow HTTP(s) requests to go through a proxy
+    * <p>
+    * Priority of where proxy information is resolved:
+    * <ul>
+    *   <li>
+    *     HTTP Proxy Host
+    *     <ol>
+    *       <li>Java system property `http.proxyHost`</li>
+    *       <li>Environment Variable `http_proxy`</li>
+    *       <li>Environment Variable `HTTP_PROXY`</li>
+    *     </ol>
+    *   </li>
+    *   <li>
+    *     HTTP Proxy Port
+    *     <ol>
+    *       <li>Java system property `http.proxyPort`</li>
+    *       <li>Environment Variable `http_proxy`</li>
+    *       <li>Environment Variable `HTTP_PROXY`</li>
+    *     </ol>
+    *     If either `http_proxy` or `HTTP_PROXY` are used and a port is not part of the URI, the standard default ports
+    *     will be used as a fallback. Namely http will be port 80 https will be port 443
+    *   </li>
+    *   <li>
+    *     HTTP User name and password
+    *     <ol>
+    *       <li>Environment Variable `http_proxy`</li>
+    *       <li>Environment Variable `HTTP_PROXY`</li>
+    *     </ol>
+    *   </li>
+    *
+    *   <li>
+    *     HTTPS Proxy Host
+    *     <ol>
+    *       <li>Java system property `https.proxyHost`</li>
+    *       <li>Environment Variable `https_proxy`</li>
+    *       <li>Environment Variable `HTTPS_PROXY`</li>
+    *     </ol>
+    *   </li>
+    *   <li>
+    *     HTTPS Proxy Port
+    *     <ol>
+    *       <li>Java system property `https.proxyPort`</li>
+    *       <li>Environment Variable `https_proxy`</li>
+    *       <li>Environment Variable `HTTPS_PROXY`</li>
+    *     </ol>
+    *     If either `http_proxy` or `HTTP_PROXY` are used and a port is not part of the URI, the standard default ports
+    *     will be used as a fallback. Namely http will be port 80 https will be port 443
+    *   </li>
+    *   <li>
+    *     HTTPS User name and password
+    *     <ol>
+    *       <li>Environment Variable `https_proxy`</li>
+    *       <li>Environment Variable `HTTPS_PROXY`</li>
+    *     </ol>
+    *   </li>
+    *   <li>
+    *     Hosts to exclude from proxying (HTTP and HTTPS)
+    *     <ol>
+    *       <li>Java system property `http.nonProxyHosts`</li>
+    *       <li>Environment Variable `no_proxy`</li>
+    *     </ol>
+    *   </li>
+    * </ul>
+    *
+    * <p>
+    *
+    * The format of environment variables is expected to be in the form of a URI:
+    * `http[s]://[user:pass@]host[:port]`
+    *
+    * @see [[https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html#Proxies]]
+    */
+  def configureProxySupport(): Unit = {
+    val proxyEnvVariables = extractProxyEnvVariables(sys.env)
+    initProxyConfig(proxyEnvVariables, Authenticator.setDefault)
+  }
+
+  private[cosmos] def extractProxyEnvVariables(env: Map[String, String]): ProxyEnvVariables = {
+    val e = envVar(env) _
+    val httpProxy = e("http_proxy")
+    val httpsProxy = e("https_proxy")
+    val noProxy = e("no_proxy")
+    val httpProxyUri = httpProxy.map(Uri.parse)
+    val httpsProxyUri = httpsProxy.map(Uri.parse)
+    ProxyEnvVariables(httpProxyUri, httpsProxyUri, noProxy)
+  }
+
+  private[cosmos] def initProxyConfig(proxyEnvVariables: ProxyEnvVariables, setAuthenticator: Authenticator => Unit): Unit = {
+    val ProxyEnvVariables(httpProxyUri, httpsProxyUri, noProxy) = proxyEnvVariables
+
+    initHttpProxyProperties(httpProxyUri, HttpProxyHost, HttpProxyPort)
+    initHttpProxyProperties(httpsProxyUri, HttpsProxyHost, HttpsProxyPort)
+    initNoProxyProperties(noProxy)
+
+    val authenticator = new CosmosHttpProxyPasswordAuthenticator(proxyEnvVariables)
+    setAuthenticator(authenticator)
+  }
+
+  private[cosmos] def initHttpProxyProperties(proxyUri: Option[Uri], hostProperty: String, portProperty: String): Unit = {
+    proxyUri
+      .flatMap(Uris.extractHostAndPort(_).toOption)
+      .foreach {
+        case ConnectionDetails(h, p, tls) =>
+          if (System.getProperty(hostProperty) == null) {
+            System.setProperty(hostProperty, h)
+          }
+          if (System.getProperty(portProperty) == null) {
+            System.setProperty(portProperty, p.toString)
+          }
+      }
+  }
+
+  private[cosmos] def initNoProxyProperties(noProxy: Option[String]): Unit = {
+    noProxy
+      .foreach {
+        case pattern =>
+          if (System.getProperty(HttpProxyNoHosts) == null) {
+            System.setProperty(HttpProxyNoHosts, pattern)
+          }
+      }
+  }
+
+  private[this] def envVar(env: Map[String, String])(name: String): Option[String] = {
+    env.get(name.toLowerCase)
+      .orElse(env.get(name.toUpperCase))
+  }
+
+  private[cosmos] class CosmosHttpProxyPasswordAuthenticator(proxyEnvVariables: ProxyEnvVariables) extends Authenticator {
+    override def getPasswordAuthentication: PasswordAuthentication = {
+      if (getRequestorType == RequestorType.PROXY) {
+        val protocol = getRequestingURL.getProtocol
+        val uriOpt = protocol match {
+          case "https" =>
+            proxyEnvVariables.httpsProxyUri
+          case "http" =>
+            proxyEnvVariables.httpProxyUri
+          case _ => None
+        }
+
+        val passAuth = uriOpt.flatMap {
+          case Uri(_, Some(user), Some(pass), _, _, _, _, _) =>
+            Some(new PasswordAuthentication(user, pass.toCharArray))
+          case _ => None
+        }
+
+        passAuth.getOrElse(super.getPasswordAuthentication)
+      } else {
+        super.getPasswordAuthentication
+      }
+    }
+  }
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Services.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Services.scala
@@ -2,6 +2,7 @@ package com.mesosphere.cosmos
 
 import java.net.InetSocketAddress
 
+import com.mesosphere.cosmos.Uris._
 import com.netaporter.uri.Uri
 import com.twitter.finagle.client.Transporter
 import com.twitter.finagle.http.{Request, Response}
@@ -41,20 +42,6 @@ object Services {
       new ConnectionExceptionHandler(serviceName) andThen cBuilder.newService(s"$hostname:$port", serviceName)
     }
   }
-
-  private[cosmos] def extractHostAndPort(uri: Uri): Try[ConnectionDetails] = Try {
-    (uri.scheme, uri.host, uri.port) match {
-      case (Some("https"), Some(h), p) => ConnectionDetails(h, p.getOrElse(443), tls = true)
-      case (Some("http"), Some(h), p) => ConnectionDetails(h, p.getOrElse(80), tls = false)
-      case (_, _, _) => throw err(uri.toString)
-    }
-  }
-
-  private def err(actual: String): Throwable = {
-    new IllegalArgumentException(s"Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual '$actual'")
-  }
-
-  private[cosmos] case class ConnectionDetails(host: String, port: Int, tls: Boolean = false)
 
   private[this] class ConnectionExceptionHandler(serviceName: String) extends SimpleFilter[Request, Response] {
     override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Uris.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Uris.scala
@@ -1,8 +1,17 @@
 package com.mesosphere.cosmos
 
 import com.netaporter.uri.Uri
+import com.twitter.util.Try
 
 object Uris {
+
+  def extractHostAndPort(uri: Uri): Try[ConnectionDetails] = Try {
+    (uri.scheme, uri.host, uri.port) match {
+      case (Some("https"), Some(h), p) => ConnectionDetails(h, p.getOrElse(443), tls = true)
+      case (Some("http"), Some(h), p) => ConnectionDetails(h, p.getOrElse(80), tls = false)
+      case (_, _, _) => throw err(uri.toString)
+    }
+  }
 
   def stripTrailingSlash(uri: Uri): String = {
     val uriString = uri.toString
@@ -11,6 +20,10 @@ object Uris {
     } else {
       uriString
     }
+  }
+
+  private def err(actual: String): Throwable = {
+    new IllegalArgumentException(s"Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual '$actual'")
   }
 
 }

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/HttpProxySupportSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/HttpProxySupportSpec.scala
@@ -1,0 +1,231 @@
+package com.mesosphere.cosmos
+
+import java.net.{Authenticator, URI, URL}
+import java.net.Authenticator.RequestorType
+
+import com.mesosphere.cosmos.HttpProxySupport.{CosmosHttpProxyPasswordAuthenticator, ProxyEnvVariables}
+import org.scalatest.FreeSpec
+import com.netaporter.uri.dsl._
+
+class HttpProxySupportSpec extends FreeSpec {
+
+  "HttpProxySupport should" - {
+
+    "allow proxy configuration for" - {
+
+      "HTTP" - {
+
+        "respects http.proxyHost and http.proxyPort" in {
+          System.setProperty("http.proxyHost", "host")
+          System.setProperty("http.proxyPort", "port")
+          HttpProxySupport.initHttpProxyProperties(Some("http://localhost:3128"), "http.proxyHost", "http.proxyPort")
+          assertResult("host")(System.getProperty("http.proxyHost"))
+          assertResult("port")(System.getProperty("http.proxyPort"))
+          clearSystemProperty("http.proxyHost")
+          clearSystemProperty("http.proxyPort")
+        }
+
+        "http.proxyHost and http.proxyPort will be set if not previously set" in {
+          HttpProxySupport.initHttpProxyProperties(Some("http://localhost:3128"), "http.proxyHost", "http.proxyPort")
+          assertResult("localhost")(System.getProperty("http.proxyHost"))
+          assertResult("3128")(System.getProperty("http.proxyPort"))
+          clearSystemProperty("http.proxyHost")
+          clearSystemProperty("http.proxyPort")
+        }
+
+        "will use http_proxy before HTTP_PROXY" in {
+          val env = Map(
+            "http_proxy" -> "http://localhost:3128",
+            "HTTP_PROXY" -> "http://hostlocal:8213"
+          )
+          val vars = HttpProxySupport.extractProxyEnvVariables(env)
+          assertResult(ProxyEnvVariables(Some("http://localhost:3128"), None, None))(vars)
+        }
+
+        "will use HTTP_PROXY if http_proxy not present" in {
+          val env = Map(
+            "HTTP_PROXY" -> "http://hostlocal:8213"
+          )
+          val vars = HttpProxySupport.extractProxyEnvVariables(env)
+          assertResult(ProxyEnvVariables(Some("http://hostlocal:8213"), None, None))(vars)
+        }
+        
+      }
+
+      "HTTPS" - {
+
+        "respects https.proxyHost and https.proxyPort" in {
+          System.setProperty("https.proxyHost", "host")
+          System.setProperty("https.proxyPort", "port")
+          HttpProxySupport.initHttpProxyProperties(Some("https://localhost:3128"), "https.proxyHost", "https.proxyPort")
+          assertResult("host")(System.getProperty("https.proxyHost"))
+          assertResult("port")(System.getProperty("https.proxyPort"))
+          clearSystemProperty("https.proxyHost")
+          clearSystemProperty("https.proxyPort")
+        }
+
+        "https.proxyHost and https.proxyPort will be set if not previously set" in {
+          HttpProxySupport.initHttpProxyProperties(Some("https://localhost:3128"), "https.proxyHost", "https.proxyPort")
+          assertResult("localhost")(System.getProperty("https.proxyHost"))
+          assertResult("3128")(System.getProperty("https.proxyPort"))
+          clearSystemProperty("https.proxyHost")
+          clearSystemProperty("https.proxyPort")
+        }
+
+        "will use https_proxy before HTTPS_PROXY" in {
+          val env = Map(
+            "https_proxy" -> "http://localhost:3128",
+            "HTTPS_PROXY" -> "http://hostlocal:8213"
+          )
+          val vars = HttpProxySupport.extractProxyEnvVariables(env)
+          assertResult(ProxyEnvVariables(None, Some("http://localhost:3128"), None))(vars)
+        }
+
+        "will use HTTPS_PROXY if https_proxy not present" in {
+          val env = Map(
+            "HTTPS_PROXY" -> "http://hostlocal:8213"
+          )
+          val vars = HttpProxySupport.extractProxyEnvVariables(env)
+          assertResult(ProxyEnvVariables(None, Some("http://hostlocal:8213"), None))(vars)
+        }
+
+      }
+
+      "No Proxy" - {
+
+        "respects http.nonProxyHosts" in {
+          System.setProperty("http.nonProxyHosts", "*.google.com")
+          HttpProxySupport.initNoProxyProperties(Some("something"))
+          assertResult("*.google.com")(System.getProperty("http.nonProxyHosts"))
+          clearSystemProperty("http.nonProxyHosts")
+        }
+
+        "sets http.nonProxyHosts from env variable" in {
+          HttpProxySupport.initNoProxyProperties(Some("something"))
+          assertResult("something")(System.getProperty("http.nonProxyHosts"))
+          clearSystemProperty("http.nonProxyHosts")
+        }
+
+        "will use no_proxy before NO_PROXY" in {
+          val env = Map(
+            "no_proxy" -> "no_proxy_val",
+            "NO_PROXY" -> "val_proxy_no"
+          )
+          val vars = HttpProxySupport.extractProxyEnvVariables(env)
+          assertResult(ProxyEnvVariables(None, None, Some("no_proxy_val")))(vars)
+        }
+
+        "will use NO_PROXY if no_proxy is not set" in {
+          val env = Map(
+            "NO_PROXY" -> "val_proxy_no"
+          )
+          val vars = HttpProxySupport.extractProxyEnvVariables(env)
+          assertResult(ProxyEnvVariables(None, None, Some("val_proxy_no")))(vars)
+        }
+
+      }
+      
+      "Proxy Credentials" - {
+
+        val vars = ProxyEnvVariables(Some("http://localhost:3128"), Some("http://hostlocal:8213"), Some("no_proxy_vals"))
+        val authVars = ProxyEnvVariables(Some("http://test:testtest@localhost:3128"), Some("http://foo:bar@hostlocal:8213"), Some("no_proxy_vals"))
+
+        "can be set from http_proxy, https_proxy and no_proxy" in {
+          var authenticatorSet = false
+          val setAuthenticator = (a: Authenticator) => { authenticatorSet = true }
+
+          HttpProxySupport.initProxyConfig(vars, setAuthenticator)
+
+          assertResult("localhost")(System.getProperty("http.proxyHost"))
+          assertResult("3128")(System.getProperty("http.proxyPort"))
+          assertResult("hostlocal")(System.getProperty("https.proxyHost"))
+          assertResult("8213")(System.getProperty("https.proxyPort"))
+          assertResult("no_proxy_vals")(System.getProperty("http.nonProxyHosts"))
+          assert(authenticatorSet)
+
+          clearSystemProperty("http.proxyHost")
+          clearSystemProperty("http.proxyPort")
+          clearSystemProperty("http.nonProxyHosts")
+          clearSystemProperty("https.proxyHost")
+          clearSystemProperty("https.proxyPort")
+          Authenticator.setDefault(null)
+        }
+
+        "are used in Authenticator (http)" - {
+          val auth = new CosmosHttpProxyPasswordAuthenticator(authVars) {
+            override def getRequestorType: RequestorType = RequestorType.PROXY
+            override def getRequestingURL: URL = URI.create("http://someplace:123").toURL
+          }
+
+          val authentication = auth.getPasswordAuthentication
+
+          assert(authentication != null)
+          assertResult("test")(authentication.getUserName)
+          assertResult("testtest".toCharArray)(authentication.getPassword)
+
+        }
+
+        "are used in Authenticator (https)" - {
+          val auth = new CosmosHttpProxyPasswordAuthenticator(authVars) {
+            override def getRequestorType: RequestorType = RequestorType.PROXY
+            override def getRequestingURL: URL = URI.create("https://someplace:123").toURL
+          }
+
+          val authentication = auth.getPasswordAuthentication
+
+          assert(authentication != null)
+          assertResult("foo")(authentication.getUserName)
+          assertResult("bar".toCharArray)(authentication.getPassword)
+        }
+
+        "are not provided when non http or https" in {
+          val auth = new CosmosHttpProxyPasswordAuthenticator(authVars) {
+            override def getRequestorType: RequestorType = RequestorType.PROXY
+            override def getRequestingURL: URL = URI.create("ftp://someplace:123").toURL
+          }
+
+          val authentication = auth.getPasswordAuthentication
+          assert(authentication == null)
+        }
+
+        "are not provided when requestorType is not proxy" in {
+          val auth = new CosmosHttpProxyPasswordAuthenticator(authVars) {
+            override def getRequestorType: RequestorType = RequestorType.SERVER
+          }
+
+          val authentication = auth.getPasswordAuthentication
+          assert(authentication == null)
+        }
+
+        "are not provided when no user:pass in url" in {
+          val auth = new CosmosHttpProxyPasswordAuthenticator(vars) {
+            override def getRequestorType: RequestorType = RequestorType.PROXY
+            override def getRequestingURL: URL = URI.create("https://someplace:123").toURL
+          }
+
+          val authentication = auth.getPasswordAuthentication
+          assert(authentication == null)
+        }
+
+        "are not provided when no pass in url" in {
+          val vars = ProxyEnvVariables(Some("http://bill@localhost:3128"), Some("http://alice@hostlocal:8213"), Some("no_proxy_vals"))
+          val auth = new CosmosHttpProxyPasswordAuthenticator(vars) {
+            override def getRequestorType: RequestorType = RequestorType.PROXY
+            override def getRequestingURL: URL = URI.create("https://someplace:123").toURL
+          }
+
+          val authentication = auth.getPasswordAuthentication
+          assert(authentication == null)
+        }
+
+      }
+
+    }
+
+  }
+
+  private[this] def clearSystemProperty(name: String): Unit = {
+    val _ = System.clearProperty(name)
+  }
+
+}

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/ServicesSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/ServicesSpec.scala
@@ -1,9 +1,8 @@
 package com.mesosphere.cosmos
 
-import com.mesosphere.cosmos.Services.ConnectionDetails
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.http._
-import com.twitter.util.{Await, Return, Throw}
+import com.twitter.util.{Await, Return}
 import org.scalatest.FreeSpec
 
 final class ServicesSpec extends FreeSpec {
@@ -27,47 +26,5 @@ final class ServicesSpec extends FreeSpec {
       }
     }
 
-    "extractHostAndPort should" - {
-      "succeed for" - {
-        "http://domain" in {
-          assertResult(Return(ConnectionDetails("domain", 80, tls = false)))(Services.extractHostAndPort("http://domain"))
-        }
-        "https://domain" in {
-          assertResult(Return(ConnectionDetails("domain", 443, tls = true)))(Services.extractHostAndPort("https://domain"))
-        }
-        "http://domain:8080" in {
-          assertResult(Return(ConnectionDetails("domain", 8080, tls = false)))(Services.extractHostAndPort("http://domain:8080"))
-        }
-        "http://sub.domain" in {
-          assertResult(Return(ConnectionDetails("sub.domain", 80, tls = false)))(Services.extractHostAndPort("http://sub.domain"))
-        }
-        "https://sub.domain" in {
-          assertResult(Return(ConnectionDetails("sub.domain", 443, tls = true)))(Services.extractHostAndPort("https://sub.domain"))
-        }
-        "http://10.0.0.1" in {
-          assertResult(Return(ConnectionDetails("10.0.0.1", 80, tls = false)))(Services.extractHostAndPort("http://10.0.0.1"))
-        }
-        "https://10.0.0.1" in {
-          assertResult(Return(ConnectionDetails("10.0.0.1", 443, tls = true)))(Services.extractHostAndPort("https://10.0.0.1"))
-        }
-      }
-      "fail for" - {
-        "domain" in {
-          val Throw(err) = Services.extractHostAndPort("domain")
-          val expectedMessage = "Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual '/domain'"
-          assertResult(expectedMessage)(err.getMessage)
-        }
-        "domain:8080" in {
-          val Throw(err) = Services.extractHostAndPort("domain:8080")
-          val expectedMessage = "Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual '/domain:8080'"
-          assertResult(expectedMessage)(err.getMessage)
-        }
-        "ftp://domain" in {
-          val Throw(err) = Services.extractHostAndPort("ftp://domain")
-          val expectedMessage = "Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual 'ftp://domain'"
-          assertResult(expectedMessage)(err.getMessage)
-        }
-      }
-    }
   }
 }

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/UrisSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/UrisSpec.scala
@@ -1,0 +1,52 @@
+package com.mesosphere.cosmos
+
+import com.netaporter.uri.dsl._
+import com.twitter.util.{Return, Throw}
+import org.scalatest.FreeSpec
+
+class UrisSpec extends FreeSpec {
+
+  "extractHostAndPort should" - {
+    "succeed for" - {
+      "http://domain" in {
+        assertResult(Return(ConnectionDetails("domain", 80, tls = false)))(Uris.extractHostAndPort("http://domain"))
+      }
+      "https://domain" in {
+        assertResult(Return(ConnectionDetails("domain", 443, tls = true)))(Uris.extractHostAndPort("https://domain"))
+      }
+      "http://domain:8080" in {
+        assertResult(Return(ConnectionDetails("domain", 8080, tls = false)))(Uris.extractHostAndPort("http://domain:8080"))
+      }
+      "http://sub.domain" in {
+        assertResult(Return(ConnectionDetails("sub.domain", 80, tls = false)))(Uris.extractHostAndPort("http://sub.domain"))
+      }
+      "https://sub.domain" in {
+        assertResult(Return(ConnectionDetails("sub.domain", 443, tls = true)))(Uris.extractHostAndPort("https://sub.domain"))
+      }
+      "http://10.0.0.1" in {
+        assertResult(Return(ConnectionDetails("10.0.0.1", 80, tls = false)))(Uris.extractHostAndPort("http://10.0.0.1"))
+      }
+      "https://10.0.0.1" in {
+        assertResult(Return(ConnectionDetails("10.0.0.1", 443, tls = true)))(Uris.extractHostAndPort("https://10.0.0.1"))
+      }
+    }
+    "fail for" - {
+      "domain" in {
+        val Throw(err) = Uris.extractHostAndPort("domain")
+        val expectedMessage = "Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual '/domain'"
+        assertResult(expectedMessage)(err.getMessage)
+      }
+      "domain:8080" in {
+        val Throw(err) = Uris.extractHostAndPort("domain:8080")
+        val expectedMessage = "Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual '/domain:8080'"
+        assertResult(expectedMessage)(err.getMessage)
+      }
+      "ftp://domain" in {
+        val Throw(err) = Uris.extractHostAndPort("ftp://domain")
+        val expectedMessage = "Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual 'ftp://domain'"
+        assertResult(expectedMessage)(err.getMessage)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Cosmos will use proxy config (if present) for fetching repository zip files.

If cosmos is started and the environment variables `http_proxy`, `https_proxy`, `no_proxy` are set, they will be read and used to configure the process for retrieving repository zips.

Fixes #278
