### PR TITLE
Improve error reporting for repository Zip download

### DIFF
--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
@@ -157,16 +157,10 @@ final class PackageRepositorySpec
       val bogusRepository = PackageRepository("bogus", Uri.parse(uriText))
       assertAdd(defaultRepos :+ bogusRepository, bogusRepository)
 
-      val expectedMsg = s"URI for repository [${bogusRepository.name}] is invalid: ${bogusRepository.uri}"
-
       eventually {
-        assertResult(expectedMsg) {
-          val response = searchPackages(SearchRequest(None))
-          assertResult(Status.BadRequest)(response.status)
-          val Xor.Right(err) = decode[ErrorResponse](response.contentString)
-          val repo = err.message
-          repo
-        }
+        val response = searchPackages(SearchRequest(None))
+        assertResult(Status.BadRequest)(response.status)
+        assert(decode[ErrorResponse](response.contentString).isRight)
       }
     }
   }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -96,8 +96,23 @@ case class RepositoryAddIndexOutOfBounds(attempted: Int, max: Int) extends Cosmo
 case class UnsupportedRepositoryVersion(version: UniverseVersion) extends CosmosError
 case class UnsupportedRepositoryUri(uri: Uri) extends CosmosError
 
-case class InvalidRepositoryUri(repository: PackageRepository, causedBy: Throwable)
-  extends CosmosError(causedBy)
+case class RepositoryUriSyntax(
+  repository: PackageRepository,
+  causedBy: Throwable
+) extends CosmosError(causedBy) {
+  override def getData: Option[JsonObject] = {
+    Some(JsonObject.singleton("cause", causedBy.getMessage.asJson))
+  }
+}
+
+case class RepositoryUriConnection(
+  repository: PackageRepository,
+  causedBy: Throwable
+) extends CosmosError(causedBy) {
+  override def getData: Option[JsonObject] = {
+    Some(JsonObject.singleton("cause", causedBy.getMessage.asJson))
+  }
+}
 
 case class RepositoryNotPresent(nameOrUri: Ior[String, Uri]) extends CosmosError {
   override def getData: Option[JsonObject] = {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -242,8 +242,10 @@ object Encoders {
     case UnsupportedRepositoryVersion(version) => s"Repository version [$version] is not supported"
     case UnsupportedRepositoryUri(uri) => s"Repository URI [$uri] uses an unsupported scheme. " +
       "Only http and https are supported"
-    case InvalidRepositoryUri(repository, _) =>
-      s"URI for repository [${repository.name}] is invalid: ${repository.uri}"
+    case RepositoryUriSyntax(repository, _) =>
+      s"URI for repository [${repository.name}] has invalid syntax: ${repository.uri}"
+    case RepositoryUriConnection(repository, _) =>
+      s"Could not access data at URI for repository [${repository.name}]: ${repository.uri}"
     case RepositoryNotPresent(nameOrUri) =>
       nameOrUri match {
         case Ior.Both(n, u) => s"Neither repository name [$n] nor URI [$u] are present in the list"

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/test/TestUtil.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/test/TestUtil.scala
@@ -1,0 +1,29 @@
+package com.mesosphere.cosmos.test
+
+import java.io.IOException
+import java.nio.file._
+import java.nio.file.attribute.BasicFileAttributes
+
+object TestUtil {
+
+  def deleteRecursively(path: Path): Unit = {
+    val visitor = new SimpleFileVisitor[Path] {
+      override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+        Files.delete(file)
+        FileVisitResult.CONTINUE
+      }
+
+      override def postVisitDirectory(dir: Path, e: IOException): FileVisitResult = {
+        Option(e) match {
+          case Some(failure) => throw failure
+          case _ =>
+            Files.delete(dir)
+            FileVisitResult.CONTINUE
+        }
+      }
+    }
+
+    val _ = Files.walkFileTree(path, visitor)
+  }
+
+}


### PR DESCRIPTION
Replace the `CosmosError` subclass `InvalidRepositoryUri` with
`RepositoryUriSyntax` and `RepositoryUriConnection`. The JSON
encodings of these new types include the message from the
`Throwable` cause of the error, to further assist with diagnosis.

To facilitate unit testing, the `UniversePackageCache` method
`updateUniverseCache` was moved to the companion object, allowing
it to be tested without creating an instance of a cache. This allowed
most of the tests to be written without use of the filesystem.

Fixes #299.
