### PR TITLE
Support repo Zip files without directory entries

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/ZooKeeperStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/ZooKeeperStorage.scala
@@ -69,7 +69,7 @@ private[cosmos] final class ZooKeeperStorage(
           Future(decodeData(bytes))
         case None =>
           readCacheStats.counter("miss").incr
-          create(DefaultRepos)
+          read()
       }
     }
   }


### PR DESCRIPTION
We ensure that each file in the Zip has all of its parent directories
created before copying it to the filesystem.

Fixes #250.