### PR TITLE
Include all CosmosError subclass arguments in "data" field of response

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -19,6 +19,16 @@ sealed abstract class CosmosError(causedBy: Throwable = null /*java compatibilit
   def status: Status = Status.BadRequest
 
   def getData: Option[JsonObject] = {
+    /* Circe encodes sum types like CosmosError into JSON as follows:
+     * {
+     *   "PackageNotFound": {
+     *     "packageName": "cassandra"
+     *   }
+     * }
+     *
+     * For this method, we just want the field values, so the code below extracts the nested object
+     * from the JSON that Circe generates.
+     */
     this.asJson
       .asObject
       .flatMap(_.values.headOption)

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -144,8 +144,9 @@ object Encoders {
   implicit val encodeStatus: Encoder[Status] = Encoder.encodeInt.contramap(_.code)
   implicit val encodeCirceError: Encoder[CirceError] = encodeThrowable.contramap(identity)
 
-  implicit val encodeMediaTypeSubType: Encoder[MediaTypeSubType] =
+  implicit val encodeMediaTypeSubType: Encoder[MediaTypeSubType] = {
     deriveFor[MediaTypeSubType].encoder
+  }
 
   implicit val encodeMediaType: Encoder[MediaType] = deriveFor[MediaType].encoder
   implicit val encodeHttpMethod: Encoder[HttpMethod] = Encoder.encodeString.contramap(_.getName)
@@ -172,7 +173,7 @@ object Encoders {
         Some(JsonObject.singleton("errors", details))
       )
     case ce: CosmosError =>
-      ErrorResponse(ce.getClass.getSimpleName, msgForCosmosError(ce), Some(ce.getData))
+      ErrorResponse(ce.getClass.getSimpleName, msgForCosmosError(ce), ce.getData)
     case t: Throwable =>
       ErrorResponse("unhandled_exception", t.getMessage)
   }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -144,12 +144,7 @@ object Encoders {
   }
 
   implicit val encodeStatus: Encoder[Status] = Encoder.encodeInt.contramap(_.code)
-
-  implicit val encodeMediaTypeSubType: Encoder[MediaTypeSubType] = {
-    deriveFor[MediaTypeSubType].encoder
-  }
-
-  implicit val encodeMediaType: Encoder[MediaType] = deriveFor[MediaType].encoder
+  implicit val encodeMediaType: Encoder[MediaType] = Encoder.encodeString.contramap(_.show)
   implicit val encodeHttpMethod: Encoder[HttpMethod] = Encoder.encodeString.contramap(_.getName)
 
   implicit def encodeIor[A, B](implicit

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
@@ -1,13 +1,13 @@
 package com.mesosphere.cosmos.circe
 
 import cats.data.Xor
+import com.mesosphere.cosmos._
 import com.mesosphere.cosmos.model.{AppId, PackageRepository}
-import com.mesosphere.cosmos.{ErrorResponse, RepositoryUriConnection, RepositoryUriSyntax}
 import com.mesosphere.universe.Images
 import com.netaporter.uri.Uri
 import io.circe.parse._
 import io.circe.syntax._
-import io.circe.{Decoder, Json, JsonObject}
+import io.circe.{Decoder, Json, JsonObject, ParsingFailure}
 import org.scalatest.FreeSpec
 
 class EncodersDecodersSpec extends FreeSpec {
@@ -76,6 +76,50 @@ class EncodersDecodersSpec extends FreeSpec {
       val Xor.Right(roundTripError) = error.asJson.as[ErrorResponse]
       assertResult(errorType)(roundTripError.`type`)
       assertResult(Some(JsonObject.singleton("cause", cause.asJson)))(roundTripError.data)
+    }
+  }
+
+  "Throwable fields are dropped from encoded objects" - {
+    val throwable = new RuntimeException("BOOM!")
+
+    "PackageFileMissing" in {
+      assertThrowableDropped(PackageFileMissing(packageName = "kafka", cause = throwable), "cause")
+    }
+
+    "CirceError" in {
+      assertThrowableDropped(CirceError(cerr = ParsingFailure("failed", throwable)), "cerr")
+    }
+
+    "ServiceUnavailable" in {
+      val error = ServiceUnavailable(serviceName = "mesos", causedBy = throwable)
+      assertThrowableDropped(error, "causedBy")
+    }
+
+    "IncompleteUninstall" in {
+      val error = IncompleteUninstall(packageName = "spark", causedBy = throwable)
+      assertThrowableDropped(error, "causedBy")
+    }
+
+    "ConcurrentAccess" in {
+      assertThrowableDropped(ConcurrentAccess(causedBy = throwable), "causedBy")
+    }
+
+    "RepositoryUriSyntax" in {
+      val repo = PackageRepository("Universe", Uri.parse("universe/repo"))
+      val error = RepositoryUriSyntax(repository = repo, causedBy = throwable)
+      assertThrowableDropped(error, "causedBy")
+    }
+
+    "RepositoryUriConnection" in {
+      val repo = PackageRepository("Universe", Uri.parse("universe/repo"))
+      val error = RepositoryUriConnection(repository = repo, causedBy = throwable)
+      assertThrowableDropped(error, "causedBy")
+    }
+
+    def assertThrowableDropped[A <: CosmosError with Product](error: A, throwableFieldName: String): Unit = {
+      val encodedFields = error.getData.getOrElse(JsonObject.empty)
+      assert(!encodedFields.contains(throwableFieldName))
+      assertResult(error.productArity - 1)(encodedFields.size)
     }
   }
 

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
@@ -116,10 +116,13 @@ class EncodersDecodersSpec extends FreeSpec {
       assertThrowableDropped(error, "causedBy")
     }
 
-    def assertThrowableDropped[A <: CosmosError with Product](error: A, throwableFieldName: String): Unit = {
+    def assertThrowableDropped[A <: CosmosError with Product](
+      error: A,
+      throwableFieldNames: String*
+    ): Unit = {
       val encodedFields = error.getData.getOrElse(JsonObject.empty)
-      assert(!encodedFields.contains(throwableFieldName))
-      assertResult(error.productArity - 1)(encodedFields.size)
+      throwableFieldNames.foreach(name => assert(!encodedFields.contains(name), name))
+      assertResult(error.productArity - throwableFieldNames.size)(encodedFields.size)
     }
   }
 

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
@@ -75,7 +75,11 @@ class EncodersDecodersSpec extends FreeSpec {
 
       val Xor.Right(roundTripError) = error.asJson.as[ErrorResponse]
       assertResult(errorType)(roundTripError.`type`)
-      assertResult(Some(JsonObject.singleton("cause", cause.asJson)))(roundTripError.data)
+      val expectedData = JsonObject.fromMap(Map(
+        "causedBy" -> cause.asJson,
+        "repository" -> Map("name" -> "repo", "uri" -> "http://example.com").asJson
+      ))
+      assertResult(Some(expectedData))(roundTripError.data)
     }
   }
 

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
@@ -75,11 +75,7 @@ class EncodersDecodersSpec extends FreeSpec {
 
       val Xor.Right(roundTripError) = error.asJson.as[ErrorResponse]
       assertResult(errorType)(roundTripError.`type`)
-      val expectedData = JsonObject.fromMap(Map(
-        "causedBy" -> cause.asJson,
-        "repository" -> Map("name" -> "repo", "uri" -> "http://example.com").asJson
-      ))
-      assertResult(Some(expectedData))(roundTripError.data)
+      assertResult(Some(JsonObject.singleton("cause", cause.asJson)))(roundTripError.data)
     }
   }
 

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/http/MediaTypeSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/http/MediaTypeSpec.scala
@@ -1,6 +1,9 @@
 package com.mesosphere.cosmos.http
 
+import com.mesosphere.cosmos.circe.Encoders._
 import com.twitter.util.Return
+import io.circe.Json
+import io.circe.syntax._
 import org.scalatest.FreeSpec
 
 class MediaTypeSpec extends FreeSpec {
@@ -70,6 +73,12 @@ class MediaTypeSpec extends FreeSpec {
         MediaType("application", MediaTypeSubType("vnd.dcos.custom-request", Some("json"))).show
       )
     }
+  }
+
+  "A MediaType should use show for encoding" in {
+    val subType = MediaTypeSubType("vnd.dcos.custom-request", Some("json"))
+    val mediaType = MediaType("application", subType)
+    assertResult(Json.string("application/vnd.dcos.custom-request+json"))(mediaType.asJson)
   }
 
 }


### PR DESCRIPTION
Provides a default implementation of CosmosError.getData which uses
generated Circe Encoders to create a JSON representation of any
instance. Subclasses can still override the default if needed.

Fixes #312.