### PR TITLE
Improve PackageFileSchemaMismatch error to pass along the error that caused it

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -9,7 +9,7 @@ import com.mesosphere.universe.{PackageDetailsVersion, UniverseVersion}
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http.Status
 import io.circe.syntax._
-import io.circe.{Json, JsonObject}
+import io.circe.{DecodingFailure, Json, JsonObject}
 import org.jboss.netty.handler.codec.http.HttpMethod
 
 import scala.util.control.NoStackTrace
@@ -43,7 +43,11 @@ case class VersionNotFound(packageName: String, packageVersion: PackageDetailsVe
 case class EmptyPackageImport() extends CosmosError
 case class PackageFileMissing(packageName: String, cause: Throwable = null) extends CosmosError(cause)
 case class PackageFileNotJson(fileName: String, parseError: String) extends CosmosError
-case class PackageFileSchemaMismatch(fileName: String) extends CosmosError
+case class PackageFileSchemaMismatch(fileName: String, decodingFailure: DecodingFailure) extends CosmosError {
+  override def getData: Option[JsonObject] = {
+    Some(JsonObject.singleton("errorMessage", decodingFailure.getMessage().asJson))
+  }
+}
 case class PackageAlreadyInstalled() extends CosmosError {
   override val status = Status.Conflict
 }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/UniversePackageCache.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/UniversePackageCache.scala
@@ -103,7 +103,7 @@ final class UniversePackageCache private (
       val repoIndex = parseJsonFile(indexFile)
         .toRightXor(new IndexNotFound(universeBundle))
         .flatMap { index =>
-          index.as[UniverseIndex].leftMap(PackageFileSchemaMismatch("index.json", _))
+          index.as[UniverseIndex].leftMap(failure => PackageFileSchemaMismatch("index.json", failure))
         }
         .valueOr(err => throw err)
 
@@ -327,7 +327,7 @@ object UniversePackageCache {
     fileName: String
   ): Xor[CosmosError, Option[A]] = {
     parseJsonFile(packageDir.resolve(fileName)).traverseU { json =>
-      json.as[A].leftMap(e => PackageFileSchemaMismatch(fileName, e))
+      json.as[A].leftMap(failure => PackageFileSchemaMismatch(fileName, failure))
     }
   }
 
@@ -439,7 +439,7 @@ object UniversePackageCache {
   ): ValidatedNel[CosmosError, A] = {
     json
       .as[A]
-      .leftMap(PackageFileSchemaMismatch(packageFileName, _))
+      .leftMap(failure => PackageFileSchemaMismatch(packageFileName, failure))
       .toValidated
       .toValidatedNel
   }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -229,7 +229,7 @@ object Encoders {
       s"Package file [$fileName] not found"
     case PackageFileNotJson(fileName, parseError) =>
       s"Package file [$fileName] is not JSON: $parseError"
-    case PackageFileSchemaMismatch(fileName) =>
+    case PackageFileSchemaMismatch(fileName, _) =>
       s"Package file [$fileName] does not match schema"
     case PackageAlreadyInstalled() =>
       "Package is already installed"


### PR DESCRIPTION
@jsancio quick fix to the error message we ran into today and spoke about.

###### Before
```json
{
   "message": "Package file [index.json] does not match schema",
    "type": "PackageFileSchemaMismatch"
}
```

###### After
```json
{
    "data": {
        "errorMessage": "String: El(DownField(0.3.0),true),El(DownField(versions),true),El(DownArray,true),El(DownField(packages),true)"
    },
    "message": "Package file [index.json] does not match schema",
    "type": "PackageFileSchemaMismatch"
}
```