### PR TITLE
Move request/response encoders/decoders to the versioned `rpc` packages

### DIFF
--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -3,9 +3,8 @@ package com.mesosphere.cosmos
 import cats.data.Xor
 import cats.data.Xor.Right
 import com.mesosphere.cosmos.circe.Decoders._
-import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.MediaTypes
-import com.mesosphere.cosmos.model._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model.{DescribeRequest, ListVersionsRequest}
 import com.mesosphere.cosmos.thirdparty.marathon.model.{AppId, MarathonApp, MarathonAppContainer, MarathonAppContainerDocker}
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -5,9 +5,10 @@ import java.util.{Base64, UUID}
 import cats.data.Xor
 import cats.data.Xor.Right
 import com.mesosphere.cosmos.circe.Decoders._
-import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.{MediaTypes, RequestSession}
 import com.mesosphere.cosmos.repository.DefaultRepositories
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model.{InstallRequest, InstallResponse}
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
 import com.mesosphere.cosmos.thirdparty.marathon.circe.Encoders._

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
@@ -3,10 +3,10 @@ package com.mesosphere.cosmos
 import java.util.UUID
 
 import cats.data.Xor
-import com.mesosphere.cosmos.circe.Decoders._
-import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.MediaTypes
 import com.mesosphere.cosmos.repository.DefaultRepositories
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
@@ -1,10 +1,10 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor
-import com.mesosphere.cosmos.circe.Decoders._
-import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.MediaTypes
 import com.mesosphere.cosmos.repository.{DefaultRepositories, PackageRepositorySpec}
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
 import com.netaporter.uri.dsl._

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -1,10 +1,9 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor.Right
-import com.mesosphere.cosmos.circe.Decoders._
-import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.MediaTypes
-import com.mesosphere.cosmos.model._
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model.{SearchRequest, SearchResponse, SearchResult}
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
 import com.mesosphere.universe.v2.model.{Images, PackageDetailsVersion, ReleaseVersion}

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
@@ -1,8 +1,8 @@
 package com.mesosphere.cosmos.handler
 
 import cats.data.Xor
-import com.mesosphere.cosmos.circe.Decoders._
 import com.mesosphere.cosmos.http.MediaTypes
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.model.{CapabilitiesResponse, Capability}
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
 import com.twitter.finagle.http.Status

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
@@ -6,6 +6,7 @@ import cats.data.Xor
 import com.mesosphere.cosmos.ErrorResponse
 import com.mesosphere.cosmos.circe.Decoders._
 import com.mesosphere.cosmos.http.MediaTypes
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.model.UninstallResponse
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
@@ -2,11 +2,12 @@ package com.mesosphere.cosmos.repository
 
 import cats.data.Xor
 import com.mesosphere.cosmos.circe.Decoders._
-import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.MediaTypes
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
-import com.mesosphere.cosmos.{UnitSpec, _}
+import com.mesosphere.cosmos._
 import com.mesosphere.universe.common.circe.Encoders._
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http._

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -2,14 +2,13 @@ package com.mesosphere.cosmos
 
 import java.nio.file.Path
 
-import com.mesosphere.cosmos.circe.Decoders._
 import com.mesosphere.cosmos.circe.Encoders._
-import com.mesosphere.cosmos.circe.{DispatchingMediaTypedEncoder, MediaTypedDecoder, MediaTypedEncoder}
 import com.mesosphere.cosmos.handler._
 import com.mesosphere.cosmos.http.MediaTypes
 import com.mesosphere.cosmos.repository.{PackageSourcesStorage, UniverseClient, ZooKeeperStorage}
+import com.mesosphere.cosmos.rpc.v1.circe.MediaTypedDecoders._
+import com.mesosphere.cosmos.rpc.v1.circe.MediaTypedEncoders._
 import com.mesosphere.cosmos.rpc.v1.model._
-import com.mesosphere.universe.v3.circe.{Encoders => V3Encoders}
 import com.netaporter.uri.Uri
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.{Request, Response, Status}
@@ -227,79 +226,4 @@ object Cosmos extends FinchServer {
     (base ? requestReader).apply((context: EndpointContext[Req, Res]) => handler(context))
   }
 
-  implicit val packageListDecoder: MediaTypedDecoder[ListRequest] =
-    MediaTypedDecoder(MediaTypes.ListRequest)
-
-  implicit val packageListVersionsDecoder: MediaTypedDecoder[ListVersionsRequest] =
-    MediaTypedDecoder(MediaTypes.ListVersionsRequest)
-
-  implicit val packageDescribeDecoder: MediaTypedDecoder[DescribeRequest] =
-    MediaTypedDecoder(MediaTypes.DescribeRequest)
-
-  implicit val packageInstallDecoder: MediaTypedDecoder[InstallRequest] =
-    MediaTypedDecoder(MediaTypes.InstallRequest)
-
-  implicit val packageRenderDecoder: MediaTypedDecoder[RenderRequest] =
-    MediaTypedDecoder(MediaTypes.RenderRequest)
-
-  implicit val packageRepositoryAddDecoder: MediaTypedDecoder[PackageRepositoryAddRequest] =
-    MediaTypedDecoder(MediaTypes.PackageRepositoryAddRequest)
-
-  implicit val packageRepositoryDeleteDecoder: MediaTypedDecoder[PackageRepositoryDeleteRequest] =
-    MediaTypedDecoder(MediaTypes.PackageRepositoryDeleteRequest)
-
-  implicit val packageRepositoryListDecoder: MediaTypedDecoder[PackageRepositoryListRequest] =
-    MediaTypedDecoder(MediaTypes.PackageRepositoryListRequest)
-
-  implicit val packageSearchDecoder: MediaTypedDecoder[SearchRequest] =
-    MediaTypedDecoder(MediaTypes.SearchRequest)
-
-  implicit val packageUninstallDecoder: MediaTypedDecoder[UninstallRequest] =
-    MediaTypedDecoder(MediaTypes.UninstallRequest)
-
-  implicit val capabilitiesEncoder: DispatchingMediaTypedEncoder[CapabilitiesResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.CapabilitiesResponse)
-
-  implicit val packageListEncoder: DispatchingMediaTypedEncoder[ListResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.ListResponse)
-
-  implicit val packageListVersionsEncoder: DispatchingMediaTypedEncoder[ListVersionsResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.ListVersionsResponse)
-
-  implicit val packageDescribeV1Encoder: DispatchingMediaTypedEncoder[DescribeResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.V1DescribeResponse)
-
-  implicit val packageDescribeEncoder: DispatchingMediaTypedEncoder[rpc.v2.model.DescribeResponse] = {
-    DispatchingMediaTypedEncoder(Seq(
-      MediaTypedEncoder(
-        encoder = V3Encoders.encodeV3Package,
-        mediaType = MediaTypes.V2DescribeResponse
-      ),
-      MediaTypedEncoder(
-        encoder = encodeDescribeResponse.contramap(converter.Response.v3PackageToDescribeResponse),
-        mediaType = MediaTypes.V1DescribeResponse
-      )
-    ))
-  }
-
-  implicit val packageInstallEncoder: DispatchingMediaTypedEncoder[InstallResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.InstallResponse)
-
-  implicit val packageRenderEncoder: DispatchingMediaTypedEncoder[RenderResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.RenderResponse)
-
-  implicit val packageRepositoryAddEncoder: DispatchingMediaTypedEncoder[PackageRepositoryAddResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.PackageRepositoryAddResponse)
-
-  implicit val packageRepositoryDeleteEncoder: DispatchingMediaTypedEncoder[PackageRepositoryDeleteResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.PackageRepositoryDeleteResponse)
-
-  implicit val packageRepositoryListEncoder: DispatchingMediaTypedEncoder[PackageRepositoryListResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.PackageRepositoryListResponse)
-
-  implicit val packageSearchEncoder: DispatchingMediaTypedEncoder[SearchResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.SearchResponse)
-
-  implicit val packageUninstallEncoder: DispatchingMediaTypedEncoder[UninstallResponse] =
-    DispatchingMediaTypedEncoder(MediaTypes.UninstallResponse)
 }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Decoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Decoders.scala
@@ -1,95 +1,16 @@
 package com.mesosphere.cosmos.circe
 
-import com.mesosphere.cosmos.ErrorResponse
-import com.mesosphere.cosmos.model._
-import com.mesosphere.cosmos.rpc.v1.model._
-import com.mesosphere.cosmos.thirdparty.marathon.circe.Decoders._
-import com.mesosphere.universe._
 import com.mesosphere.universe.common.circe.Decoders._
-import com.mesosphere.universe.v2.circe.Decoders._
-import com.mesosphere.universe.v2.model.{Images, PackageDetailsVersion, ReleaseVersion}
+import com.mesosphere.cosmos.ErrorResponse
+import com.mesosphere.cosmos.model.ZooKeeperStorageEnvelope
+import io.circe.Decoder
 import io.circe.generic.semiauto._
-import io.circe.{Decoder, HCursor}
 
 object Decoders {
 
-  implicit val decodeSearchResult: Decoder[SearchResult] = Decoder.instance { cursor =>
-    for {
-      indexEntry <- v2.circe.Decoders.decodePackageIndex(cursor)
-      images <- cursor.downField("images").as[Option[Images]]
-    } yield {
-      SearchResult(
-        name = indexEntry.name,
-        currentVersion = indexEntry.currentVersion,
-        versions = indexEntry.versions,
-        description = indexEntry.description,
-        framework = indexEntry.framework,
-        tags = indexEntry.tags,
-        selected = indexEntry.selected,
-        images = images
-      )
-    }
-  }
-
-  implicit val decodeDescribeRequest: Decoder[DescribeRequest] = deriveFor[DescribeRequest].decoder
-  implicit val decodeSearchRequest: Decoder[SearchRequest] = deriveFor[SearchRequest].decoder
-  implicit val decodeSearchResponse: Decoder[SearchResponse] = deriveFor[SearchResponse].decoder
-  implicit val decodeInstallRequest: Decoder[InstallRequest] = deriveFor[InstallRequest].decoder
-  implicit val decodeInstallResponse: Decoder[InstallResponse] = deriveFor[InstallResponse].decoder
-  implicit val decodeUninstallRequest: Decoder[UninstallRequest] = deriveFor[UninstallRequest].decoder
-  implicit val decodeUninstallResponse: Decoder[UninstallResponse] = deriveFor[UninstallResponse].decoder
-  implicit val decodeUninstallResult: Decoder[UninstallResult] = deriveFor[UninstallResult].decoder
-
-  implicit val decodeRenderRequest: Decoder[RenderRequest] = deriveFor[RenderRequest].decoder
-  implicit val decodeRenderResponse: Decoder[RenderResponse] = deriveFor[RenderResponse].decoder
-
-  implicit val decodeDescribeResponse: Decoder[DescribeResponse] = deriveFor[DescribeResponse].decoder
-  implicit val decodeListVersionsRequest: Decoder[ListVersionsRequest] = deriveFor[ListVersionsRequest].decoder
-  implicit val decodeListVersionsResponse: Decoder[ListVersionsResponse] = Decoder.instance { (cursor: HCursor) =>
-    for {
-      r <- cursor.downField("results").as[Map[String, String]]
-    } yield {
-      val results = r.map { case (s1, s2) =>
-        PackageDetailsVersion(s1) -> ReleaseVersion(s2)
-      }
-      ListVersionsResponse(results)
-    }
-  }
-
   implicit val decodeErrorResponse: Decoder[ErrorResponse] = deriveFor[ErrorResponse].decoder
-
-  implicit val decodeListRequest: Decoder[ListRequest] = deriveFor[ListRequest].decoder
-  implicit val decodeListResponse: Decoder[ListResponse] = deriveFor[ListResponse].decoder
-  implicit val decodeInstallation: Decoder[Installation] = deriveFor[Installation].decoder
-  implicit val decodePackageInformation: Decoder[InstalledPackageInformation] = deriveFor[InstalledPackageInformation].decoder
-
-  implicit val decodeCapabilitiesResponse: Decoder[CapabilitiesResponse] = deriveFor[CapabilitiesResponse].decoder
-  implicit val decodeCapability: Decoder[Capability] = deriveFor[Capability].decoder
-
-  implicit val decodePackageRepositoryListRequest: Decoder[PackageRepositoryListRequest] = {
-    deriveFor[PackageRepositoryListRequest].decoder
-  }
-  implicit val decodePackageRepositoryListResponse: Decoder[PackageRepositoryListResponse] = {
-    deriveFor[PackageRepositoryListResponse].decoder
-  }
-  implicit val decodePackageRepository: Decoder[PackageRepository] = {
-    deriveFor[PackageRepository].decoder
-  }
-  implicit val decodePackageRepositoryAddRequest: Decoder[PackageRepositoryAddRequest] = {
-    deriveFor[PackageRepositoryAddRequest].decoder
-  }
-  implicit val decodePackageRepositoryAddResponse: Decoder[PackageRepositoryAddResponse] = {
-    deriveFor[PackageRepositoryAddResponse].decoder
-  }
-  implicit val decodePackageRepositoryDeleteRequest: Decoder[PackageRepositoryDeleteRequest] = {
-    deriveFor[PackageRepositoryDeleteRequest].decoder
-  }
-  implicit val decodePackageRepositoryDeleteResponse: Decoder[PackageRepositoryDeleteResponse] = {
-    deriveFor[PackageRepositoryDeleteResponse].decoder
-  }
 
   implicit val decodeZooKeeperStorageEnvelope: Decoder[ZooKeeperStorageEnvelope] =
     deriveFor[ZooKeeperStorageEnvelope].decoder
-
 
 }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -4,15 +4,15 @@ import cats.data.Ior
 import com.mesosphere.cosmos._
 import com.mesosphere.cosmos.http.MediaType
 import com.mesosphere.cosmos.model._
-import com.mesosphere.cosmos.rpc.v1.model._
 import com.mesosphere.cosmos.thirdparty.marathon.circe.Encoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.universe.common.circe.Encoders._
 import com.mesosphere.universe.v2.circe.Encoders._
 import com.twitter.finagle.http.Status
 import io.circe.generic.encoding.DerivedObjectEncoder
 import io.circe.generic.semiauto._
 import io.circe.syntax._
-import io.circe.{Encoder, JsonObject, ObjectEncoder}
+import io.circe.{Encoder, JsonObject}
 import io.finch.Error
 import org.jboss.netty.handler.codec.http.HttpMethod
 import shapeless._
@@ -20,68 +20,7 @@ import shapeless.labelled.FieldType
 
 object Encoders {
 
-  implicit val encodeSearchResult: Encoder[SearchResult] = ObjectEncoder.instance { searchResult =>
-    val encodedFields = encodeIndexEntryFields(
-      searchResult.name,
-      searchResult.currentVersion,
-      searchResult.versions,
-      searchResult.description,
-      searchResult.framework,
-      searchResult.tags,
-      searchResult.selected
-    )
-    JsonObject.fromIndexedSeq(encodedFields :+ ("images" -> searchResult.images.asJson))
-  }
-
-  implicit val encodeDescribeRequest: Encoder[DescribeRequest] = deriveFor[DescribeRequest].encoder
-  implicit val encodeSearchRequest: Encoder[SearchRequest] = deriveFor[SearchRequest].encoder
-  implicit val encodeSearchResponse: Encoder[SearchResponse] = deriveFor[SearchResponse].encoder
-  implicit val encodeInstallRequest: Encoder[InstallRequest] = deriveFor[InstallRequest].encoder
-  implicit val encodeInstallResponse: Encoder[InstallResponse] = deriveFor[InstallResponse].encoder
-  implicit val encodeUninstallRequest: Encoder[UninstallRequest] = deriveFor[UninstallRequest].encoder
-  implicit val encodeUninstallResponse: Encoder[UninstallResponse] = deriveFor[UninstallResponse].encoder
-  implicit val encodeUninstallResult: Encoder[UninstallResult] = deriveFor[UninstallResult].encoder
-
-  implicit val encodeRenderRequest: Encoder[RenderRequest] = deriveFor[RenderRequest].encoder
-  implicit val encodeRenderResponse: Encoder[RenderResponse] = deriveFor[RenderResponse].encoder
-
-  implicit val encodeDescribeResponse: Encoder[DescribeResponse] = deriveFor[DescribeResponse].encoder
-  implicit val encodeListVersionsRequest: Encoder[ListVersionsRequest] = deriveFor[ListVersionsRequest].encoder
-  implicit val encodeListVersionsResponse: Encoder[ListVersionsResponse] = ObjectEncoder.instance( response => {
-    JsonObject.singleton("results", encodePackageDetailsVersionToReleaseVersionMap(response.results))
-  })
-
   implicit val encodeErrorResponse: Encoder[ErrorResponse] = deriveFor[ErrorResponse].encoder
-
-  implicit val encodeListRequest: Encoder[ListRequest] = deriveFor[ListRequest].encoder
-  implicit val encodeListResponse: Encoder[ListResponse] = deriveFor[ListResponse].encoder
-  implicit val encodeInstallation: Encoder[Installation] = deriveFor[Installation].encoder
-  implicit val encodePackageInformation: Encoder[InstalledPackageInformation] = deriveFor[InstalledPackageInformation].encoder
-
-  implicit val encodeCapabilitiesResponse: Encoder[CapabilitiesResponse] = deriveFor[CapabilitiesResponse].encoder
-  implicit val encodeCapability: Encoder[Capability] = deriveFor[Capability].encoder
-
-  implicit val encodePackageRepositoryListRequest: Encoder[PackageRepositoryListRequest] = {
-    deriveFor[PackageRepositoryListRequest].encoder
-  }
-  implicit val encodePackageRepositoryListResponse: Encoder[PackageRepositoryListResponse] = {
-    deriveFor[PackageRepositoryListResponse].encoder
-  }
-  implicit val encodePackageRepository: Encoder[PackageRepository] = {
-    deriveFor[PackageRepository].encoder
-  }
-  implicit val encodePackageRepositoryAddRequest: Encoder[PackageRepositoryAddRequest] = {
-    deriveFor[PackageRepositoryAddRequest].encoder
-  }
-  implicit val encodePackageRepositoryAddResponse: Encoder[PackageRepositoryAddResponse] = {
-    deriveFor[PackageRepositoryAddResponse].encoder
-  }
-  implicit val encodePackageRepositoryDeleteRequest: Encoder[PackageRepositoryDeleteRequest] = {
-    deriveFor[PackageRepositoryDeleteRequest].encoder
-  }
-  implicit val encodePackageRepositoryDeleteResponse: Encoder[PackageRepositoryDeleteResponse] = {
-    deriveFor[PackageRepositoryDeleteResponse].encoder
-  }
 
   implicit val encodeZooKeeperStorageEnvelope: Encoder[ZooKeeperStorageEnvelope] =
     deriveFor[ZooKeeperStorageEnvelope].encoder

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/DefaultRepositories.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/DefaultRepositories.scala
@@ -4,7 +4,7 @@ import java.io.InputStreamReader
 
 import cats.data.Xor
 import com.google.common.io.CharStreams
-import com.mesosphere.cosmos.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
 import com.twitter.util.Try
 import io.circe.parse._

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/ZooKeeperStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/ZooKeeperStorage.scala
@@ -4,13 +4,15 @@ import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 import cats.data.Ior
+import com.mesosphere.cosmos._
 import com.mesosphere.cosmos.circe.Decoders._
 import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.http.{MediaType, MediaTypeOps, MediaTypeSubType}
 import com.mesosphere.cosmos.model.ZooKeeperStorageEnvelope
 import com.mesosphere.cosmos.repository.DefaultRepositories._
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
-import com.mesosphere.cosmos._
 import com.mesosphere.universe.common.ByteBuffers
 import com.netaporter.uri.Uri
 import com.twitter.finagle.stats.{NullStatsReceiver, Stat, StatsReceiver}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/Decoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/Decoders.scala
@@ -1,0 +1,87 @@
+package com.mesosphere.cosmos.rpc.v1.circe
+
+import com.mesosphere.cosmos.rpc.v1.model._
+import com.mesosphere.cosmos.thirdparty.marathon.circe.Decoders._
+import com.mesosphere.universe
+import com.mesosphere.universe.common.circe.Decoders._
+import com.mesosphere.universe.v2.circe.Decoders._
+import com.mesosphere.universe.v2.model.{Images, PackageDetailsVersion, ReleaseVersion}
+import io.circe.generic.semiauto._
+import io.circe.{Decoder, HCursor}
+
+object Decoders {
+
+  implicit val decodeSearchResult: Decoder[SearchResult] = Decoder.instance { cursor =>
+    for {
+      indexEntry <- universe.v2.circe.Decoders.decodePackageIndex(cursor)
+      images <- cursor.downField("images").as[Option[Images]]
+    } yield {
+      SearchResult(
+        name = indexEntry.name,
+        currentVersion = indexEntry.currentVersion,
+        versions = indexEntry.versions,
+        description = indexEntry.description,
+        framework = indexEntry.framework,
+        tags = indexEntry.tags,
+        selected = indexEntry.selected,
+        images = images
+      )
+    }
+  }
+
+  implicit val decodeDescribeRequest: Decoder[DescribeRequest] = deriveFor[DescribeRequest].decoder
+  implicit val decodeSearchRequest: Decoder[SearchRequest] = deriveFor[SearchRequest].decoder
+  implicit val decodeSearchResponse: Decoder[SearchResponse] = deriveFor[SearchResponse].decoder
+  implicit val decodeInstallRequest: Decoder[InstallRequest] = deriveFor[InstallRequest].decoder
+  implicit val decodeInstallResponse: Decoder[InstallResponse] = deriveFor[InstallResponse].decoder
+  implicit val decodeUninstallRequest: Decoder[UninstallRequest] = deriveFor[UninstallRequest].decoder
+  implicit val decodeUninstallResponse: Decoder[UninstallResponse] = deriveFor[UninstallResponse].decoder
+  implicit val decodeUninstallResult: Decoder[UninstallResult] = deriveFor[UninstallResult].decoder
+
+  implicit val decodeRenderRequest: Decoder[RenderRequest] = deriveFor[RenderRequest].decoder
+  implicit val decodeRenderResponse: Decoder[RenderResponse] = deriveFor[RenderResponse].decoder
+
+  implicit val decodeDescribeResponse: Decoder[DescribeResponse] = deriveFor[DescribeResponse].decoder
+  implicit val decodeListVersionsRequest: Decoder[ListVersionsRequest] = deriveFor[ListVersionsRequest].decoder
+  implicit val decodeListVersionsResponse: Decoder[ListVersionsResponse] = Decoder.instance { (cursor: HCursor) =>
+    for {
+      r <- cursor.downField("results").as[Map[String, String]]
+    } yield {
+      val results = r.map { case (s1, s2) =>
+        PackageDetailsVersion(s1) -> ReleaseVersion(s2)
+      }
+      ListVersionsResponse(results)
+    }
+  }
+
+  implicit val decodeListRequest: Decoder[ListRequest] = deriveFor[ListRequest].decoder
+  implicit val decodeListResponse: Decoder[ListResponse] = deriveFor[ListResponse].decoder
+  implicit val decodeInstallation: Decoder[Installation] = deriveFor[Installation].decoder
+  implicit val decodePackageInformation: Decoder[InstalledPackageInformation] = deriveFor[InstalledPackageInformation].decoder
+
+  implicit val decodeCapabilitiesResponse: Decoder[CapabilitiesResponse] = deriveFor[CapabilitiesResponse].decoder
+  implicit val decodeCapability: Decoder[Capability] = deriveFor[Capability].decoder
+
+  implicit val decodePackageRepositoryListRequest: Decoder[PackageRepositoryListRequest] = {
+    deriveFor[PackageRepositoryListRequest].decoder
+  }
+  implicit val decodePackageRepositoryListResponse: Decoder[PackageRepositoryListResponse] = {
+    deriveFor[PackageRepositoryListResponse].decoder
+  }
+  implicit val decodePackageRepository: Decoder[PackageRepository] = {
+    deriveFor[PackageRepository].decoder
+  }
+  implicit val decodePackageRepositoryAddRequest: Decoder[PackageRepositoryAddRequest] = {
+    deriveFor[PackageRepositoryAddRequest].decoder
+  }
+  implicit val decodePackageRepositoryAddResponse: Decoder[PackageRepositoryAddResponse] = {
+    deriveFor[PackageRepositoryAddResponse].decoder
+  }
+  implicit val decodePackageRepositoryDeleteRequest: Decoder[PackageRepositoryDeleteRequest] = {
+    deriveFor[PackageRepositoryDeleteRequest].decoder
+  }
+  implicit val decodePackageRepositoryDeleteResponse: Decoder[PackageRepositoryDeleteResponse] = {
+    deriveFor[PackageRepositoryDeleteResponse].decoder
+  }
+
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/Encoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/Encoders.scala
@@ -1,0 +1,74 @@
+package com.mesosphere.cosmos.rpc.v1.circe
+
+import com.mesosphere.cosmos.rpc.v1.model._
+import com.mesosphere.cosmos.thirdparty.marathon.circe.Encoders._
+import com.mesosphere.universe.common.circe.Encoders._
+import com.mesosphere.universe.v2.circe.Encoders._
+import io.circe.generic.semiauto._
+import io.circe.syntax._
+import io.circe.{Encoder, JsonObject, ObjectEncoder}
+
+object Encoders {
+
+  implicit val encodeSearchResult: Encoder[SearchResult] = ObjectEncoder.instance { searchResult =>
+    val encodedFields = encodeIndexEntryFields(
+      searchResult.name,
+      searchResult.currentVersion,
+      searchResult.versions,
+      searchResult.description,
+      searchResult.framework,
+      searchResult.tags,
+      searchResult.selected
+    )
+    JsonObject.fromIndexedSeq(encodedFields :+ ("images" -> searchResult.images.asJson))
+  }
+
+  implicit val encodeDescribeRequest: Encoder[DescribeRequest] = deriveFor[DescribeRequest].encoder
+  implicit val encodeSearchRequest: Encoder[SearchRequest] = deriveFor[SearchRequest].encoder
+  implicit val encodeSearchResponse: Encoder[SearchResponse] = deriveFor[SearchResponse].encoder
+  implicit val encodeInstallRequest: Encoder[InstallRequest] = deriveFor[InstallRequest].encoder
+  implicit val encodeInstallResponse: Encoder[InstallResponse] = deriveFor[InstallResponse].encoder
+  implicit val encodeUninstallRequest: Encoder[UninstallRequest] = deriveFor[UninstallRequest].encoder
+  implicit val encodeUninstallResponse: Encoder[UninstallResponse] = deriveFor[UninstallResponse].encoder
+  implicit val encodeUninstallResult: Encoder[UninstallResult] = deriveFor[UninstallResult].encoder
+
+  implicit val encodeRenderRequest: Encoder[RenderRequest] = deriveFor[RenderRequest].encoder
+  implicit val encodeRenderResponse: Encoder[RenderResponse] = deriveFor[RenderResponse].encoder
+
+  implicit val encodeDescribeResponse: Encoder[DescribeResponse] = deriveFor[DescribeResponse].encoder
+  implicit val encodeListVersionsRequest: Encoder[ListVersionsRequest] = deriveFor[ListVersionsRequest].encoder
+  implicit val encodeListVersionsResponse: Encoder[ListVersionsResponse] = ObjectEncoder.instance( response => {
+    JsonObject.singleton("results", encodePackageDetailsVersionToReleaseVersionMap(response.results))
+  })
+
+  implicit val encodeListRequest: Encoder[ListRequest] = deriveFor[ListRequest].encoder
+  implicit val encodeListResponse: Encoder[ListResponse] = deriveFor[ListResponse].encoder
+  implicit val encodeInstallation: Encoder[Installation] = deriveFor[Installation].encoder
+  implicit val encodePackageInformation: Encoder[InstalledPackageInformation] = deriveFor[InstalledPackageInformation].encoder
+
+  implicit val encodeCapabilitiesResponse: Encoder[CapabilitiesResponse] = deriveFor[CapabilitiesResponse].encoder
+  implicit val encodeCapability: Encoder[Capability] = deriveFor[Capability].encoder
+
+  implicit val encodePackageRepositoryListRequest: Encoder[PackageRepositoryListRequest] = {
+    deriveFor[PackageRepositoryListRequest].encoder
+  }
+  implicit val encodePackageRepositoryListResponse: Encoder[PackageRepositoryListResponse] = {
+    deriveFor[PackageRepositoryListResponse].encoder
+  }
+  implicit val encodePackageRepository: Encoder[PackageRepository] = {
+    deriveFor[PackageRepository].encoder
+  }
+  implicit val encodePackageRepositoryAddRequest: Encoder[PackageRepositoryAddRequest] = {
+    deriveFor[PackageRepositoryAddRequest].encoder
+  }
+  implicit val encodePackageRepositoryAddResponse: Encoder[PackageRepositoryAddResponse] = {
+    deriveFor[PackageRepositoryAddResponse].encoder
+  }
+  implicit val encodePackageRepositoryDeleteRequest: Encoder[PackageRepositoryDeleteRequest] = {
+    deriveFor[PackageRepositoryDeleteRequest].encoder
+  }
+  implicit val encodePackageRepositoryDeleteResponse: Encoder[PackageRepositoryDeleteResponse] = {
+    deriveFor[PackageRepositoryDeleteResponse].encoder
+  }
+
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/MediaTypedDecoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/MediaTypedDecoders.scala
@@ -1,0 +1,41 @@
+package com.mesosphere.cosmos.rpc.v1.circe
+
+import com.mesosphere.cosmos.circe.MediaTypedDecoder
+import com.mesosphere.cosmos.http.MediaTypes
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.model._
+import io.finch.circe._
+
+object MediaTypedDecoders {
+
+  implicit val packageListDecoder: MediaTypedDecoder[ListRequest] =
+    MediaTypedDecoder(MediaTypes.ListRequest)
+
+  implicit val packageListVersionsDecoder: MediaTypedDecoder[ListVersionsRequest] =
+    MediaTypedDecoder(MediaTypes.ListVersionsRequest)
+
+  implicit val packageDescribeDecoder: MediaTypedDecoder[DescribeRequest] =
+    MediaTypedDecoder(MediaTypes.DescribeRequest)
+
+  implicit val packageInstallDecoder: MediaTypedDecoder[InstallRequest] =
+    MediaTypedDecoder(MediaTypes.InstallRequest)
+
+  implicit val packageRenderDecoder: MediaTypedDecoder[RenderRequest] =
+    MediaTypedDecoder(MediaTypes.RenderRequest)
+
+  implicit val packageRepositoryAddDecoder: MediaTypedDecoder[PackageRepositoryAddRequest] =
+    MediaTypedDecoder(MediaTypes.PackageRepositoryAddRequest)
+
+  implicit val packageRepositoryDeleteDecoder: MediaTypedDecoder[PackageRepositoryDeleteRequest] =
+    MediaTypedDecoder(MediaTypes.PackageRepositoryDeleteRequest)
+
+  implicit val packageRepositoryListDecoder: MediaTypedDecoder[PackageRepositoryListRequest] =
+    MediaTypedDecoder(MediaTypes.PackageRepositoryListRequest)
+
+  implicit val packageSearchDecoder: MediaTypedDecoder[SearchRequest] =
+    MediaTypedDecoder(MediaTypes.SearchRequest)
+
+  implicit val packageUninstallDecoder: MediaTypedDecoder[UninstallRequest] =
+    MediaTypedDecoder(MediaTypes.UninstallRequest)
+
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/MediaTypedEncoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/MediaTypedEncoders.scala
@@ -1,0 +1,43 @@
+package com.mesosphere.cosmos.rpc.v1.circe
+
+import com.mesosphere.cosmos.circe.DispatchingMediaTypedEncoder
+import com.mesosphere.cosmos.http.MediaTypes
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
+import com.mesosphere.cosmos.rpc.v1.model._
+
+object MediaTypedEncoders {
+
+  implicit val capabilitiesEncoder: DispatchingMediaTypedEncoder[CapabilitiesResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.CapabilitiesResponse)
+
+  implicit val packageListEncoder: DispatchingMediaTypedEncoder[ListResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.ListResponse)
+
+  implicit val packageListVersionsEncoder: DispatchingMediaTypedEncoder[ListVersionsResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.ListVersionsResponse)
+
+  implicit val packageDescribeV1Encoder: DispatchingMediaTypedEncoder[DescribeResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.V1DescribeResponse)
+
+  implicit val packageInstallEncoder: DispatchingMediaTypedEncoder[InstallResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.InstallResponse)
+
+  implicit val packageRenderEncoder: DispatchingMediaTypedEncoder[RenderResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.RenderResponse)
+
+  implicit val packageRepositoryAddEncoder: DispatchingMediaTypedEncoder[PackageRepositoryAddResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.PackageRepositoryAddResponse)
+
+  implicit val packageRepositoryDeleteEncoder: DispatchingMediaTypedEncoder[PackageRepositoryDeleteResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.PackageRepositoryDeleteResponse)
+
+  implicit val packageRepositoryListEncoder: DispatchingMediaTypedEncoder[PackageRepositoryListResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.PackageRepositoryListResponse)
+
+  implicit val packageSearchEncoder: DispatchingMediaTypedEncoder[SearchResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.SearchResponse)
+
+  implicit val packageUninstallEncoder: DispatchingMediaTypedEncoder[UninstallResponse] =
+    DispatchingMediaTypedEncoder(MediaTypes.UninstallResponse)
+
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v2/circe/MediaTypedEncoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v2/circe/MediaTypedEncoders.scala
@@ -1,0 +1,24 @@
+package com.mesosphere.cosmos.rpc.v2.circe
+
+import com.mesosphere.cosmos.circe.{DispatchingMediaTypedEncoder, MediaTypedEncoder}
+import com.mesosphere.cosmos.converter
+import com.mesosphere.cosmos.http.MediaTypes
+import com.mesosphere.cosmos.rpc
+import com.mesosphere.universe
+
+object MediaTypedEncoders {
+
+  implicit val packageDescribeEncoder: DispatchingMediaTypedEncoder[rpc.v2.model.DescribeResponse] = {
+    DispatchingMediaTypedEncoder(Seq(
+      MediaTypedEncoder(
+        encoder = universe.v3.circe.Encoders.encodeV3Package,
+        mediaType = MediaTypes.V2DescribeResponse
+      ),
+      MediaTypedEncoder(
+        encoder = rpc.v1.circe.Encoders.encodeDescribeResponse.contramap(converter.Response.v3PackageToDescribeResponse),
+        mediaType = MediaTypes.V1DescribeResponse
+      )
+    ))
+  }
+
+}

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/SelectedPackageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/SelectedPackageSpec.scala
@@ -1,10 +1,10 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor
-import com.mesosphere.cosmos.circe.Decoders._
-import com.mesosphere.cosmos.circe.Encoders._
 import com.mesosphere.cosmos.handler.PackageSearchHandler
 import com.mesosphere.cosmos.repository.PackageCollection
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model.{SearchRequest, SearchResponse, SearchResult}
 import com.mesosphere.universe.v2.circe.Decoders._
 import com.mesosphere.universe.v2.circe.Encoders._

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/UserOptionsSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/UserOptionsSpec.scala
@@ -3,7 +3,8 @@ package com.mesosphere.cosmos
 import cats.data.Xor
 import com.mesosphere.cosmos.handler._
 import com.mesosphere.cosmos.http.{MediaTypes, RequestSession}
-import com.mesosphere.cosmos.model._
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model._
 import com.mesosphere.cosmos.thirdparty.marathon.model._
 import com.mesosphere.cosmos.thirdparty.marathon.circe.Decoders._
@@ -53,9 +54,6 @@ final class UserOptionsSpec extends UnitSpec {
         val packageCache = MemoryPackageCache(packages)
         val packageRunner = new RecordingPackageRunner
 
-        // these two imports provide the implicit DecodeRequest instances needed to instantiate Cosmos
-        import com.mesosphere.cosmos.circe.Decoders._
-        import com.mesosphere.cosmos.circe.Encoders._
         import io.finch.circe._
         val cosmos = new Cosmos(
           constHandler(UninstallResponse(Nil)),


### PR DESCRIPTION
This is the last big "repackaging" change.