### PR TITLE
Introduce coursier for dependency resolution

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -113,11 +113,31 @@ object CosmosBuild extends Build {
 
     exportJars := true,
 
-    resolvers ++= Seq(
-      "Clojars Repository" at "http://clojars.org/repo",
-      "Conjars Repository" at "http://conjars.org/repo",
-      "Twitter Maven" at "http://maven.twttr.com",
-      "finch-server" at "http://storage.googleapis.com/benwhitehead_me/maven/public"
+    externalResolvers := Seq(
+      Resolver.mavenLocal,
+      DefaultMavenRepository,
+      "finch-server" at "https://storage.googleapis.com/benwhitehead_me/maven/public",
+      "Twitter Maven" at "https://maven.twttr.com"
+      // Twitter maven has stability issues make sure it's LAST, it's needed for two transitive dependencies
+      // [warn]  ::::::::::::::::::::::::::::::::::::::::::::::
+      // [warn]  ::          UNRESOLVED DEPENDENCIES         ::
+      // [warn]  ::::::::::::::::::::::::::::::::::::::::::::::
+      // [warn]  :: com.twitter.common#metrics;0.0.37: not found
+      // [warn]  :: org.apache.thrift#libthrift;0.5.0: not found
+      // [warn]  ::::::::::::::::::::::::::::::::::::::::::::::
+      // [warn]
+      // [warn]  Note: Unresolved dependencies path:
+      // [warn]          com.twitter.common:metrics:0.0.37
+      // [warn]            +- com.twitter:finagle-stats_2.11:6.31.0
+      // [warn]            +- io.github.benwhitehead.finch:finch-server_2.11:0.9.0
+      // [warn]            +- com.mesosphere.cosmos:cosmos-server_2.11:0.2.0-SNAPSHOT
+      // [warn]          org.apache.thrift:libthrift:0.5.0
+      // [warn]            +- com.twitter:finagle-thrift_2.11:6.31.0
+      // [warn]            +- com.twitter:finagle-zipkin_2.11:6.31.0
+      // [warn]            +- com.twitter:twitter-server_2.11:1.16.0
+      // [warn]            +- io.github.benwhitehead.finch:finch-server_2.11:0.9.0
+      // [warn]            +- com.mesosphere.cosmos:cosmos-server_2.11:0.2.0-SNAPSHOT
+      //
     ),
 
     libraryDependencies ++= Deps.mockito ++ Deps.scalaTest,
@@ -190,7 +210,7 @@ object CosmosBuild extends Build {
 
   lazy val cosmos = Project("cosmos", file("."))
     .settings(sharedSettings)
-    .aggregate(model, server)
+    .aggregate(model, json, server)
 
   lazy val model = Project("cosmos-model", file("cosmos-model"))
     .settings(sharedSettings)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.1")
 addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar" % "0.8")
 
 addSbtPlugin("com.github.sdb" % "xsbt-filter" % "0.4")
+
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M12")


### PR DESCRIPTION
This PR introduces coursier[1] to the project for dependency resolution rather than the default ivy resolver included with sbt. It is significantly faster at resolving and downloading the dependencies of the project. Below are the runtimes for the project with and without coursier.

With the project already compiled, and an empty cache for ivy (`rm -rf ~/.ivy2/cache`):
```bash
time sbt compile it:compile
<snip>

real    5m13.391s
user    4m35.728s
sys     0m3.244s
```

With the project already compiled, and an empty coursier cache (`rm -rf ~/.coursier/cache`):
```bash
time sbt compile it:compile
<snip>

real    1m27.734s
user    4m51.496s
sys     0m2.680s
```


I've also updated the set of resolvers to ensure that Maven Central has the highest priority, this will hopefully help reduce the number of build failures due to 503's from maven.twttr.com.

[1] https://github.com/alexarchambault/coursier