### PR TITLE
Enforce an explicit schema for the "package metadata" Marathon label

### DIFF
--- a/cosmos-json/src/main/scala/com/mesosphere/cosmos/rpc/v2/circe/Encoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/cosmos/rpc/v2/circe/Encoders.scala
@@ -13,14 +13,6 @@ object Encoders {
     deriveFor[rpc.v2.model.InstallResponse].encoder
   }
 
-  implicit val encodeV2ListResponse: Encoder[rpc.v2.model.ListResponse] = {
-    deriveFor[rpc.v2.model.ListResponse].encoder
-  }
-
-  implicit val encodeV2Installation: Encoder[rpc.v2.model.Installation] = {
-    deriveFor[rpc.v2.model.Installation].encoder
-  }
-
   implicit val encodeV2DescribeResponse: Encoder[DescribeResponse] = {
     deriveFor[DescribeResponse].encoder
   }

--- a/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Decoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Decoders.scala
@@ -63,16 +63,16 @@ object Decoders {
 
   implicit val decodeRepository: Decoder[Repository] = deriveFor[Repository].decoder
 
-  implicit val decodeV2Package: Decoder[V2Package] = deriveFor[V2Package].decoder
-  implicit val decodeV2PackagingVersion: Decoder[V2PackagingVersion] = {
+  implicit val decodeV3V2Package: Decoder[V2Package] = deriveFor[V2Package].decoder
+  implicit val decodeV3V2PackagingVersion: Decoder[V2PackagingVersion] = {
     Decoder.decodeString.map(V2PackagingVersion(_))
   }
   implicit val decodeV3V2Resource: Decoder[V2Resource] = deriveFor[V2Resource].decoder
 
-  implicit val decodeV3Package: Decoder[V3Package] = deriveFor[V3Package].decoder
-  implicit val decodeV3PackagingVersion: Decoder[V3PackagingVersion] = {
+  implicit val decodeV3V3Package: Decoder[V3Package] = deriveFor[V3Package].decoder
+  implicit val decodeV3V3PackagingVersion: Decoder[V3PackagingVersion] = {
     Decoder.decodeString.map(V3PackagingVersion(_))
   }
-  implicit val decodeV3Resource: Decoder[V3Resource] = deriveFor[V3Resource].decoder
+  implicit val decodeV3V3Resource: Decoder[V3Resource] = deriveFor[V3Resource].decoder
 
 }

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/label/v1/model/PackageMetadata.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/label/v1/model/PackageMetadata.scala
@@ -1,0 +1,24 @@
+package com.mesosphere.cosmos.label.v1.model
+
+import com.mesosphere.universe
+
+/** Copy of [[com.mesosphere.universe.v2.model.PackageDetails]] with additional field `images` from
+  * [[com.mesosphere.universe.v2.model.Resource]].
+  */
+case class PackageMetadata(
+  packagingVersion: universe.v2.model.PackagingVersion,
+  name: String,
+  version: universe.v2.model.PackageDetailsVersion,
+  maintainer: String,
+  description: String,
+  tags: List[String] = Nil,
+  selected: Option[Boolean] = None,
+  scm: Option[String] = None,
+  website: Option[String] = None,
+  framework: Option[Boolean] = None,
+  preInstallNotes: Option[String] = None,
+  postInstallNotes: Option[String] = None,
+  postUninstallNotes: Option[String] = None,
+  licenses: Option[List[universe.v2.model.License]] = None,
+  images: Option[universe.v2.model.Images] = None
+)

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/Installation.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/Installation.scala
@@ -1,9 +1,0 @@
-package com.mesosphere.cosmos.rpc.v2.model
-
-import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
-import com.mesosphere.universe.v3.model.PackageDefinition
-
-case class Installation(
-  appId: AppId,
-  packageInformation: PackageDefinition
-)

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/ListResponse.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/ListResponse.scala
@@ -1,5 +1,0 @@
-package com.mesosphere.cosmos.rpc.v2.model
-
-case class ListResponse(
-  packages: Seq[Installation]
-)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -249,34 +249,13 @@ private object PackageInstallIntegrationSpec extends Matchers with TableDrivenPr
       "website" -> "https://github.com/mesosphere/dcos-helloworld".asJson,
       "name" -> "helloworld".asJson,
       "postInstallNotes" -> "A sample post-installation message".asJson,
-      "marathon" -> Map(
-        "v2AppMustacheTemplate" -> (
-          "ewogICJpZCI6ICJoZWxsb3dvcmxkIiwKICAiY3B1cyI6IDEuMCwKICAibWVtIjogNTEyLAogICJpbnN0YW5jZ" +
-            "XMiOiAxLAogICJjbWQiOiAicHl0aG9uMyAtbSBodHRwLnNlcnZlciB7e3BvcnR9fSIsCiAgImNvbnRhaW5l" +
-            "ciI6IHsKICAgICJ0eXBlIjogIkRPQ0tFUiIsCiAgICAiZG9ja2VyIjogewogICAgICAiaW1hZ2UiOiAicHl" +
-            "0aG9uOjMiLAogICAgICAibmV0d29yayI6ICJIT1NUIgogICAgfQogIH0KfQo="
-          ).asJson
-      ).asJson,
       "description" -> "Example DCOS application package".asJson,
       "packagingVersion" -> "2.0".asJson,
       "tags" -> List("mesosphere".asJson, "example".asJson, "subcommand".asJson).asJson,
       "selected" -> false.asJson,
       "maintainer" -> "support@mesosphere.io".asJson,
-      "config" -> Map(
-        "$schema" -> "http://json-schema.org/schema#".asJson,
-        "type" -> "object".asJson,
-        "properties" -> Map(
-          "port" -> Map(
-            "type" -> "integer".asJson,
-            "default" -> 8080.asJson
-          ).asJson
-        ).asJson,
-        "additionalProperties" -> false.asJson
-      ).asJson,
-      "command" -> HelloWorldCommand,
       "version" -> "0.1.0".asJson,
       "preInstallNotes" -> "A sample pre-installation message".asJson,
-      "releaseVersion" -> 0.asJson,
       "framework" -> false.asJson
     ).asJson,
     packageCommand = HelloWorldCommand,

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -27,7 +27,7 @@ private[cosmos] final class Cosmos(
   packageSearchHandler: EndpointHandler[rpc.v1.model.SearchRequest, rpc.v1.model.SearchResponse],
   packageDescribeHandler: EndpointHandler[rpc.v1.model.DescribeRequest, internal.model.PackageDefinition],
   packageListVersionsHandler: EndpointHandler[rpc.v1.model.ListVersionsRequest, rpc.v1.model.ListVersionsResponse],
-  listHandler: EndpointHandler[rpc.v1.model.ListRequest, rpc.v2.model.ListResponse],
+  listHandler: EndpointHandler[rpc.v1.model.ListRequest, rpc.v1.model.ListResponse],
   listRepositoryHandler: EndpointHandler[rpc.v1.model.PackageRepositoryListRequest, rpc.v1.model.PackageRepositoryListResponse],
   addRepositoryHandler: EndpointHandler[rpc.v1.model.PackageRepositoryAddRequest, rpc.v1.model.PackageRepositoryAddResponse],
   deleteRepositoryHandler: EndpointHandler[rpc.v1.model.PackageRepositoryDeleteRequest, rpc.v1.model.PackageRepositoryDeleteResponse],

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/converter/Label.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/converter/Label.scala
@@ -1,0 +1,85 @@
+package com.mesosphere.cosmos.converter
+
+import com.mesosphere.cosmos.converter.Universe._
+import com.mesosphere.cosmos.internal
+import com.mesosphere.cosmos.label
+import com.mesosphere.cosmos.rpc
+import com.mesosphere.universe
+import com.twitter.bijection.Conversion.asMethod
+import com.twitter.bijection.Conversion
+
+object Label {
+
+  implicit val internalPackageDefinitionToLabelV1PackageMetadata: Conversion[
+    internal.model.PackageDefinition, label.v1.model.PackageMetadata] =
+    Conversion.fromFunction { (x: internal.model.PackageDefinition) =>
+      label.v1.model.PackageMetadata(
+        packagingVersion = x.packagingVersion.as[universe.v2.model.PackagingVersion],
+        name = x.name,
+        version = x.version.as[universe.v2.model.PackageDetailsVersion],
+        maintainer = x.maintainer,
+        description = x.description,
+        tags = x.tags.as[List[String]],
+        selected = Some(x.selected),
+        scm = x.scm,
+        website = x.website,
+        framework = Some(x.framework),
+        preInstallNotes = x.preInstallNotes,
+        postInstallNotes = x.postInstallNotes,
+        postUninstallNotes = x.postUninstallNotes,
+        licenses = x.licenses.as[Option[List[universe.v2.model.License]]],
+        images = x.resource.flatMap(_.images).as[Option[universe.v2.model.Images]]
+      )
+    }
+
+    // TODO(version): This and the conversion below form a bijection
+  implicit val labelV1PackageMetadataToRpcV1InstalledPackageInformation: Conversion[
+    label.v1.model.PackageMetadata, rpc.v1.model.InstalledPackageInformation] =
+    Conversion.fromFunction { (x: label.v1.model.PackageMetadata) =>
+      rpc.v1.model.InstalledPackageInformation(
+        packageDefinition = universe.v2.model.PackageDetails(
+          packagingVersion = x.packagingVersion,
+          name = x.name,
+          version = x.version,
+          maintainer = x.maintainer,
+          description = x.description,
+          tags = x.tags,
+          selected = x.selected,
+          scm = x.scm,
+          website = x.website,
+          framework = x.framework,
+          preInstallNotes = x.preInstallNotes,
+          postInstallNotes = x.postInstallNotes,
+          postUninstallNotes = x.postUninstallNotes,
+          licenses = x.licenses
+        ),
+        resourceDefinition = x.images.map { images =>
+          universe.v2.model.Resource(images = Some(images))
+        }
+      )
+    }
+
+    // TODO(version): This and the conversion above form a bijection
+  implicit val rpcV1InstalledPackageInformationToLabelV1PackageMetadata: Conversion[
+    rpc.v1.model.InstalledPackageInformation, label.v1.model.PackageMetadata] =
+    Conversion.fromFunction { (x: rpc.v1.model.InstalledPackageInformation) =>
+      label.v1.model.PackageMetadata(
+        packagingVersion = x.packageDefinition.packagingVersion,
+        name = x.packageDefinition.name,
+        version = x.packageDefinition.version,
+        maintainer = x.packageDefinition.maintainer,
+        description = x.packageDefinition.description,
+        tags = x.packageDefinition.tags,
+        selected = x.packageDefinition.selected,
+        scm = x.packageDefinition.scm,
+        website = x.packageDefinition.website,
+        framework = x.packageDefinition.framework,
+        preInstallNotes = x.packageDefinition.preInstallNotes,
+        postInstallNotes = x.packageDefinition.postInstallNotes,
+        postUninstallNotes = x.packageDefinition.postUninstallNotes,
+        licenses = x.packageDefinition.licenses,
+        images = x.resourceDefinition.flatMap(_.images)
+      )
+    }
+
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/converter/Response.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/converter/Response.scala
@@ -59,29 +59,4 @@ object Response {
     }
   }
 
-   private[this] def getV2ResourceFromPackageDefinition(
-     packageDef: universe.v3.model.PackageDefinition
-   ): Option[universe.v2.model.Resource] = {
-      packageDef match {
-        case v2Package: universe.v3.model.V2Package =>
-          v2Package.resource.as[Option[universe.v2.model.Resource]]
-        case v3Package: universe.v3.model.V3Package =>
-          v3Package.resource.as[Option[universe.v2.model.Resource]]
-    }
-  }
-
-  def v2ListResponseToV1ListResponse(x: rpc.v2.model.ListResponse): rpc.v1.model.ListResponse = {
-    rpc.v1.model.ListResponse(
-      packages = x.packages.map { y =>
-        rpc.v1.model.Installation(
-          appId = y.appId,
-          packageInformation = rpc.v1.model.InstalledPackageInformation(
-              packageDefinition = y.packageInformation.as[universe.v2.model.PackageDetails],
-              resourceDefinition = getV2ResourceFromPackageDefinition(y.packageInformation)
-          )
-        )
-      }
-    )
-  }
-
 }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/converter/Universe.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/converter/Universe.scala
@@ -51,6 +51,7 @@ object Universe {
     Injection.build(fwd)(rev)
   }
 
+  // TODO(version): We should use Conversion if we are throwing unconditionally
   implicit val v3V2PackagingVersionToPackageDefinition: Injection[
       universe.v3.model.PackageDefinition, universe.v2.model.PackageDetails] = {
     Injection.build { (value: universe.v3.model.PackageDefinition) =>
@@ -65,6 +66,7 @@ object Universe {
     }
   }
 
+  // TODO(version): We should use Conversion if we are throwing unconditionally
   implicit val v3V3PackageToV2PackageDetails: Injection[
       universe.v3.model.V3Package, universe.v2.model.PackageDetails] = {
     Injection.build { (value: universe.v3.model.V3Package) =>
@@ -91,6 +93,7 @@ object Universe {
     }
   }
 
+  // TODO(version): We should use Conversion if we are throwing unconditionally
   implicit val v3V2PackageToV2PackageDetails: Injection[
       universe.v3.model.V2Package, universe.v2.model.PackageDetails] = {
     Injection.build { (value: universe.v3.model.V2Package) =>
@@ -325,6 +328,7 @@ object Universe {
     }
   }
 
+  // TODO(version): We should use Conversion if we are throwing unconditionally
   implicit val v3V3ResourceToV2Resource: Injection[
       universe.v3.model.V3Resource, universe.v2.model.Resource] = {
     Injection.build { (value: universe.v3.model.V3Resource) =>
@@ -426,5 +430,4 @@ object Universe {
 
     Injection.build(fwd)(rev)
   }
-
 }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/label/v1/circe/Decoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/label/v1/circe/Decoders.scala
@@ -1,0 +1,14 @@
+package com.mesosphere.cosmos.label.v1.circe
+
+import com.mesosphere.cosmos.label
+import com.mesosphere.universe.v2.circe.Decoders._
+import io.circe.Decoder
+import io.circe.generic.semiauto._
+
+object Decoders {
+
+  implicit val decodeLabelV1PackageMetadata: Decoder[label.v1.model.PackageMetadata] = {
+    deriveFor[label.v1.model.PackageMetadata].decoder
+  }
+
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/label/v1/circe/Encoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/label/v1/circe/Encoders.scala
@@ -1,0 +1,14 @@
+package com.mesosphere.cosmos.label.v1.circe
+
+import com.mesosphere.cosmos.label
+import com.mesosphere.universe.v2.circe.Encoders._
+import io.circe.Encoder
+import io.circe.generic.semiauto._
+
+object Encoders {
+
+  implicit val encodeLabelV1PackageMetadata: Encoder[label.v1.model.PackageMetadata] = {
+    deriveFor[label.v1.model.PackageMetadata].encoder
+  }
+
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v2/circe/MediaTypedEncoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v2/circe/MediaTypedEncoders.scala
@@ -40,18 +40,4 @@ object MediaTypedEncoders {
     ))
   }
 
-  implicit val packageListResponseEncoder: DispatchingMediaTypedEncoder[rpc.v2.model.ListResponse] = {
-    DispatchingMediaTypedEncoder(Seq(
-      MediaTypedEncoder(
-        encoder = rpc.v2.circe.Encoders.encodeV2ListResponse,
-        mediaType = MediaTypes.V2ListResponse
-      ),
-      MediaTypedEncoder(
-        encoder = rpc.v1.circe.Encoders.encodeListResponse.contramap(
-          converter.Response.v2ListResponseToV1ListResponse
-        ),
-        mediaType = MediaTypes.V1ListResponse
-      )
-    ))
-  }
 }

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/MarathonLabelsSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/MarathonLabelsSpec.scala
@@ -1,0 +1,182 @@
+package com.mesosphere.cosmos
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+import cats.data.Xor
+import com.mesosphere.cosmos.converter.Universe._
+import com.mesosphere.cosmos.label.v1.circe.Decoders._
+import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonApp
+import com.mesosphere.universe
+import com.netaporter.uri.Uri
+import com.twitter.bijection.Conversion.asMethod
+import io.circe.parse._
+import io.circe.syntax._
+import io.circe.{Decoder, JsonObject}
+import org.scalatest.FreeSpec
+
+final class MarathonLabelsSpec extends FreeSpec {
+
+  import MarathonLabelsSpec._
+
+  "requiredLabels" - {
+
+    "MarathonApp.metadataLabel" - {
+      "minimal" in {
+        val marathonLabels = MarathonLabels(MinimalPackageDefinition, RepoUri)
+        val packageMetadata =
+          decodeRequiredLabel[label.v1.model.PackageMetadata](marathonLabels, MarathonApp.metadataLabel)
+
+        assertCompatible(MinimalPackageDefinition, packageMetadata)
+      }
+
+      "maximal" in {
+        val marathonLabels = MarathonLabels(MaximalPackageDefinition, RepoUri)
+        val packageMetadata =
+          decodeRequiredLabel[label.v1.model.PackageMetadata](marathonLabels, MarathonApp.metadataLabel)
+
+        assertCompatible(MaximalPackageDefinition, packageMetadata)
+      }
+    }
+
+  }
+
+  private[this] def decodeRequiredLabel[A: Decoder](labels: MarathonLabels, label: String): A = {
+    val base64Json = labels.requiredLabels(MarathonApp.metadataLabel)
+    val jsonBytes = Base64.getDecoder.decode(base64Json)
+    val jsonText = new String(jsonBytes, StandardCharsets.UTF_8)
+    val Xor.Right(data) = decode[A](jsonText)
+    data
+  }
+
+  private[this] def assertCompatible(
+    original: internal.model.PackageDefinition,
+    result: label.v1.model.PackageMetadata
+  ): Unit = {
+    // To test that `original` was accurately turned into `result`, reverse the transformation
+    val resultPackagingVersion = result.packagingVersion.toString match {
+      case "2.0" => universe.v3.model.V2PackagingVersion.instance
+      case "3.0" => universe.v3.model.V3PackagingVersion.instance
+    }
+    val resultTags = result.tags.map(tag => universe.v3.model.PackageDefinition.Tag(tag))
+    val resultLicenses = result.licenses.map { licenses =>
+      licenses.map { case universe.v2.model.License(name, url) =>
+        universe.v3.model.License(name, Uri.parse(url))
+      }
+    }
+
+    assertResult(original.packagingVersion)(resultPackagingVersion)
+    assertResult(original.name)(result.name)
+    assertResult(original.version)(result.version.as[universe.v3.model.PackageDefinition.Version])
+    assertResult(original.maintainer)(result.maintainer)
+    assertResult(original.description)(result.description)
+    assertResult(original.tags)(resultTags)
+    assertResult(Some(original.selected))(result.selected)
+    assertResult(original.scm)(result.scm)
+    assertResult(original.website)(result.website)
+    assertResult(Some(original.framework))(result.framework)
+    assertResult(original.preInstallNotes)(result.preInstallNotes)
+    assertResult(original.postInstallNotes)(result.postInstallNotes)
+    assertResult(original.postUninstallNotes)(result.postUninstallNotes)
+    assertResult(original.licenses)(resultLicenses)
+    assertResult(original.resource.flatMap(_.images))(result.images.as[Option[universe.v3.model.Images]])
+  }
+
+}
+
+object MarathonLabelsSpec {
+
+  val RepoUri = Uri.parse("some/repo/uri")
+
+  val MinimalPackageDefinition = internal.model.PackageDefinition(
+    packagingVersion = universe.v3.model.V2PackagingVersion.instance,
+    name = "minimal",
+    version = universe.v3.model.PackageDefinition.Version("1.2.3"),
+    releaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(0),
+    maintainer = "minimal@mesosphere.io",
+    description = "A minimal package definition"
+  )
+
+  val MaximalPackageDefinition = internal.model.PackageDefinition(
+    packagingVersion = universe.v3.model.V3PackagingVersion.instance,
+    name = "MAXIMAL",
+    version = universe.v3.model.PackageDefinition.Version("9.87.654.3210"),
+    releaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(Int.MaxValue),
+    maintainer = "max@mesosphere.io",
+    description = "A complete package definition",
+    tags = List("all", "the", "things").map(s => universe.v3.model.PackageDefinition.Tag(s)),
+    selected = true,
+    scm = Some("git"),
+    website = Some("mesosphere.com"),
+    framework = true,
+    preInstallNotes = Some("pre-install message"),
+    postInstallNotes = Some("post-install message"),
+    postUninstallNotes = Some("post-uninstall message"),
+    licenses = Some(List(
+      universe.v3.model.License(name = "ABC", url = Uri.parse("a/b/c")),
+      universe.v3.model.License(name = "XYZ", url = Uri.parse("x/y/z"))
+    )),
+    minDcosReleaseVersion = Some(universe.v3.model.DcosReleaseVersionParser.parseUnsafe("1.9.99")),
+    marathon = Some(universe.v3.model.Marathon(
+      v2AppMustacheTemplate = ByteBuffer.wrap("marathon template".getBytes(StandardCharsets.UTF_8))
+    )),
+    resource = Some(universe.v3.model.V3Resource(
+      assets = Some(universe.v3.model.Assets(
+        uris = Some(Map(
+          "foo.tar.gz" -> "http://mesosphere.com/foo.tar.gz",
+          "bar.jar"    -> "https://mesosphere.com/bar.jar"
+        )),
+        container = Some(universe.v3.model.Container(Map(
+          "image1" -> "docker/image:1",
+          "image2" -> "docker/image:2"
+        )))
+      )),
+      images = Some(universe.v3.model.Images(
+        iconSmall = "small.png",
+        iconMedium = "medium.png",
+        iconLarge = "large.png",
+        screenshots = Some(List("ooh.png", "aah.png"))
+      )),
+      cli = Some(universe.v3.model.Cli(
+        binaries = Some(universe.v3.model.Platforms(
+          windows = Some(universe.v3.model.Architectures(
+            `x86-64` = universe.v3.model.Binary(
+              kind = "windows",
+              url = "mesosphere.com/windows.exe",
+              contentHash = List(
+                universe.v3.model.HashInfo("letters", "abcba"),
+                universe.v3.model.HashInfo("numbers", "12321")
+              )
+            )
+          )),
+          linux = Some(universe.v3.model.Architectures(
+            `x86-64` = universe.v3.model.Binary(
+              kind = "linux",
+              url = "mesosphere.com/linux",
+              contentHash = List(
+                universe.v3.model.HashInfo("letters", "ijkji"),
+                universe.v3.model.HashInfo("numbers", "13579")
+              )
+            )
+          )),
+          darwin = Some(universe.v3.model.Architectures(
+            `x86-64` = universe.v3.model.Binary(
+              kind = "darwin",
+              url = "mesosphere.com/darwin",
+              contentHash = List(
+                universe.v3.model.HashInfo("letters", "xyzyx"),
+                universe.v3.model.HashInfo("numbers", "02468")
+              )
+            )
+          ))
+        ))
+      ))
+    )),
+    config = Some(JsonObject.fromMap(Map("foo" -> 42.asJson, "bar" -> "baz".asJson))),
+    command = Some(universe.v3.model.Command(
+      pip = List("flask", "jinja", "jsonschema")
+    ))
+  )
+
+}

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/UserOptionsSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/UserOptionsSpec.scala
@@ -59,7 +59,7 @@ final class UserOptionsSpec extends UnitSpec {
           constHandler(rpc.v1.model.SearchResponse(List.empty)),
           constHandler(packageDefinition),
           constHandler(rpc.v1.model.ListVersionsResponse(Map.empty)),
-          constHandler(rpc.v2.model.ListResponse(Nil)),
+          constHandler(rpc.v1.model.ListResponse(Nil)),
           constHandler(rpc.v1.model.PackageRepositoryListResponse(Nil)),
           constHandler(rpc.v1.model.PackageRepositoryAddResponse(Nil)),
           constHandler(rpc.v1.model.PackageRepositoryDeleteResponse(Nil)),

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/converter/LabelSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/converter/LabelSpec.scala
@@ -1,0 +1,46 @@
+package com.mesosphere.cosmos.converter
+
+import com.mesosphere.cosmos.MarathonLabelsSpec
+import com.mesosphere.cosmos.converter.Label._
+import com.mesosphere.cosmos.label
+import com.mesosphere.cosmos.rpc
+import com.twitter.bijection.Conversion
+import com.twitter.bijection.Conversion.asMethod
+import org.scalatest.FreeSpec
+
+final class LabelSpec extends FreeSpec {
+
+  "label.v1.model.PackageMetadata <=> rpc.v1.model.InstalledPackageInformation" - {
+
+    "minimal" in {
+      val packageDefinition = MarathonLabelsSpec.MinimalPackageDefinition
+      val packageMetadata = packageDefinition.as[label.v1.model.PackageMetadata]
+
+      val result = roundTrip[label.v1.model.PackageMetadata, rpc.v1.model.InstalledPackageInformation](
+        packageMetadata
+      )
+
+      assertResult(packageMetadata)(result)
+    }
+
+    "maximal" in {
+      val packageDefinition = MarathonLabelsSpec.MaximalPackageDefinition
+      val packageMetadata = packageDefinition.as[label.v1.model.PackageMetadata]
+
+      val result = roundTrip[label.v1.model.PackageMetadata, rpc.v1.model.InstalledPackageInformation](
+        packageMetadata
+      )
+
+      assertResult(packageMetadata)(result)
+    }
+
+  }
+
+  private[this] def roundTrip[A, B](a: A)(implicit
+    aToB: Conversion[A, B],
+    bToA: Conversion[B, A]
+  ): A = {
+    a.as[B].as[A]
+  }
+
+}


### PR DESCRIPTION
As a result, the ListHandler response will not contain the new
package fields from the Universe 3.0 schema.

This gets us closer to the CLI integration tests passing (#409). Some things to follow up on:
- @tamarrow this change doesn't fix the CLI test failures because we are now including the `selected` field explicitly in the label even if it wasn't specified in the package. So the CLI tests will need to be updated to expect that field.
- At one point we were running the CLI integration tests against Cosmos regularly. Should we start doing that again? It would have caught the `selected` discrepancy I mentioned above much earlier.