### PR TITLE
Update Install and Render handlers to tolerate v3 packages with optional marathon templates

### DIFF
--- a/cosmos-json/src/main/scala/com/mesosphere/cosmos/rpc/v2/circe/Decoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/cosmos/rpc/v2/circe/Decoders.scala
@@ -1,0 +1,13 @@
+package com.mesosphere.cosmos.rpc.v2.circe
+
+import com.mesosphere.cosmos.rpc.v2.model.InstallResponse
+import com.mesosphere.cosmos.thirdparty.marathon.circe.Decoders._
+import com.mesosphere.universe.v3.circe.Decoders._
+import io.circe.Decoder
+import io.circe.generic.semiauto._
+
+object Decoders {
+
+  implicit val decodeV2InstallResponse: Decoder[InstallResponse] = deriveFor[InstallResponse].decoder
+
+}

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/InstallResponse.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/InstallResponse.scala
@@ -6,7 +6,7 @@ import com.mesosphere.universe
 case class InstallResponse(
   packageName: String,
   packageVersion: universe.v3.model.PackageDefinition.Version,
-  appId: AppId,
+  appId: Option[AppId] = None,
   postInstallNotes: Option[String] = None,
   cli: Option[universe.v3.model.Cli] = None
 )

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
@@ -1,0 +1,91 @@
+package com.mesosphere.cosmos.handler
+
+import cats.data.Xor
+import com.mesosphere.cosmos.ErrorResponse
+import com.mesosphere.cosmos.circe.Decoders._
+import com.mesosphere.cosmos.http.MediaTypes
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
+import com.mesosphere.cosmos.rpc.v1.model.{RenderRequest, RenderResponse}
+import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
+import com.mesosphere.universe.v2.model.PackageDetailsVersion
+import com.twitter.finagle.http.Status
+import com.twitter.io.Buf
+import io.circe.{Json, JsonObject}
+import io.circe.parse._
+import io.circe.syntax._
+import org.scalatest.FreeSpec
+
+class PackageRenderHandlerSpec extends FreeSpec {
+  import CosmosIntegrationTestClient._
+
+  "PackageRenderHandler should" - {
+
+    "succeed when attempting to render a service with a marathon template" in {
+      val expectedBody = RenderResponse(Json.fromFields(Seq(
+        "id" -> "helloworld".asJson,
+        "cpus" -> 1.0.asJson,
+        "mem" -> 512.asJson,
+        "instances" -> 1.asJson,
+        "cmd" -> "python3 -m http.server 8080".asJson,
+        "container" -> Json.fromFields(Seq(
+          "type" -> "DOCKER".asJson,
+          "docker" -> Json.fromFields(Seq(
+            "image" -> "python:3".asJson,
+            "network" -> "HOST".asJson
+          ))
+        )),
+        "labels" -> Json.fromFields(Seq(
+          "DCOS_PACKAGE_RELEASE" -> "0".asJson,
+          "DCOS_PACKAGE_SOURCE" -> "https://downloads.mesosphere.com/universe/helloworld.zip".asJson,
+          "DCOS_PACKAGE_COMMAND" -> "eyJwaXAiOlsiZGNvczwxLjAiLCJnaXQraHR0cHM6Ly9naXRodWIuY29tL21lc29zcGhlcmUvZGNvcy1oZWxsb3dvcmxkLmdpdCNkY29zLWhlbGxvd29ybGQ9MC4xLjAiXX0=".asJson,
+          "DCOS_PACKAGE_METADATA" -> "eyJ3ZWJzaXRlIjoiaHR0cHM6Ly9naXRodWIuY29tL21lc29zcGhlcmUvZGNvcy1oZWxsb3dvcmxkIiwibmFtZSI6ImhlbGxvd29ybGQiLCJwb3N0SW5zdGFsbE5vdGVzIjoiQSBzYW1wbGUgcG9zdC1pbnN0YWxsYXRpb24gbWVzc2FnZSIsImRlc2NyaXB0aW9uIjoiRXhhbXBsZSBEQ09TIGFwcGxpY2F0aW9uIHBhY2thZ2UiLCJwYWNrYWdpbmdWZXJzaW9uIjoiMi4wIiwidGFncyI6WyJtZXNvc3BoZXJlIiwiZXhhbXBsZSIsInN1YmNvbW1hbmQiXSwibWFpbnRhaW5lciI6InN1cHBvcnRAbWVzb3NwaGVyZS5pbyIsInNlbGVjdGVkIjpmYWxzZSwiZnJhbWV3b3JrIjpmYWxzZSwidmVyc2lvbiI6IjAuMS4wIiwicHJlSW5zdGFsbE5vdGVzIjoiQSBzYW1wbGUgcHJlLWluc3RhbGxhdGlvbiBtZXNzYWdlIn0=".asJson,
+          "DCOS_PACKAGE_REGISTRY_VERSION" -> "2.0".asJson,
+          "DCOS_PACKAGE_VERSION" -> "0.1.0".asJson,
+          "DCOS_PACKAGE_NAME" -> "helloworld".asJson,
+          "DCOS_PACKAGE_IS_FRAMEWORK" -> "false".asJson
+        ))
+      )))
+      val installRequest = RenderRequest("helloworld", Some(PackageDetailsVersion("0.1.0")))
+
+      val request = CosmosClient.requestBuilder("package/render")
+        .addHeader("Content-Type", MediaTypes.RenderRequest.show)
+        .addHeader("Accept", MediaTypes.RenderResponse.show)
+        .buildPost(Buf.Utf8(installRequest.asJson.noSpaces))
+
+      val response = CosmosClient(request)
+
+      assertResult(Status.Ok)(response.status)
+      assertResult(MediaTypes.RenderResponse.show)(response.contentType.get)
+      val Xor.Right(actualBody) = decode[RenderResponse](response.contentString)
+      assertResult(expectedBody)(actualBody)
+    }
+
+    "error if attempting to render a service with no marathon template" in {
+      val expectedBody = ErrorResponse(
+        "ServiceMarathonTemplateNotFound",
+        s"Package: [enterprise-security-cli] version: [0.8.0] does not have a " +
+          "Marathon template defined and can not be rendered",
+        Some(JsonObject.fromMap(Map(
+          "packageName" -> "enterprise-security-cli".asJson,
+          "packageVersion" -> "0.8.0".asJson
+        )))
+      )
+
+      val installRequest = RenderRequest("enterprise-security-cli")
+
+      val request = CosmosClient.requestBuilder("package/render")
+        .addHeader("Content-Type", MediaTypes.RenderRequest.show)
+        .addHeader("Accept", MediaTypes.RenderResponse.show)
+        .buildPost(Buf.Utf8(installRequest.asJson.noSpaces))
+
+      val response = CosmosClient(request)
+
+      assertResult(Status.BadRequest)(response.status)
+      assertResult(MediaTypes.ErrorResponse.show)(response.contentType.get)
+      val Xor.Right(actualBody) = decode[ErrorResponse](response.contentString)
+      assertResult(expectedBody)(actualBody)
+    }
+
+  }
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -7,6 +7,7 @@ import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
 import com.mesosphere.cosmos.thirdparty.marathon.model.{AppId, MarathonError}
 import com.mesosphere.universe
 import com.mesosphere.universe.common.circe.Encoders._
+import com.mesosphere.universe.v3.model.PackageDefinition
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http.Status
 import io.circe.syntax._
@@ -214,3 +215,4 @@ case class RepositoryNotPresent(nameOrUri: Ior[String, Uri]) extends CosmosError
 
 // TODO(version): Can this be given more structure (e.g. name and type of field that failed, package, etc.)?
 case class ConversionFailure(message: String) extends CosmosError
+case class ServiceMarathonTemplateNotFound(packageName: String, packageVersion: PackageDefinition.Version) extends CosmosError

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -9,6 +9,7 @@ import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.universe.common.circe.Encoders._
 import com.mesosphere.universe.v2.circe.Encoders._
 import com.mesosphere.universe.v3.circe.Encoders._
+import com.mesosphere.universe.v3.model._
 import com.twitter.finagle.http.Status
 import io.circe.generic.encoding.DerivedObjectEncoder
 import io.circe.generic.semiauto._
@@ -222,6 +223,8 @@ object Encoders {
           s"Unsupported redirect scheme - supported: $supportedMsg"
       }
     case ConversionFailure(message) => message
+    case ServiceMarathonTemplateNotFound(name, PackageDefinition.Version(version)) =>
+      s"Package: [$name] version: [$version] does not have a Marathon template defined and can not be rendered"
   }
 
 }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/converter/Response.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/converter/Response.scala
@@ -1,23 +1,23 @@
 package com.mesosphere.cosmos.converter
 
 import java.nio.charset.StandardCharsets
-
 import com.mesosphere.cosmos.converter.Universe._
-import com.mesosphere.cosmos.ConversionFailure
-import com.mesosphere.cosmos.internal
-import com.mesosphere.cosmos.rpc
+import com.mesosphere.cosmos.{ConversionFailure, ServiceMarathonTemplateNotFound, internal, rpc}
 import com.mesosphere.universe
 import com.mesosphere.universe.common.ByteBuffers
 import com.twitter.bijection.Conversion.asMethod
+import com.twitter.util.Try
 
 object Response {
 
-  def v2InstallResponseToV1InstallResponse(x: rpc.v2.model.InstallResponse): rpc.v1.model.InstallResponse = {
-    rpc.v1.model.InstallResponse(
-      packageName = x.packageName,
-      packageVersion = x.packageVersion.as[universe.v2.model.PackageDetailsVersion],
-      appId = x.appId
-    )
+  def v2InstallResponseToV1InstallResponse(x: rpc.v2.model.InstallResponse): Try[rpc.v1.model.InstallResponse] = {
+    Try(x.appId.getOrElse(throw ServiceMarathonTemplateNotFound(x.packageName, x.packageVersion))).map { appId =>
+      rpc.v1.model.InstallResponse(
+        packageName = x.packageName,
+        packageVersion = x.packageVersion.as[universe.v2.model.PackageDetailsVersion],
+        appId = appId
+      )
+    }
   }
 
   def packageDefinitionToDescribeResponse(

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageRenderHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageRenderHandler.scala
@@ -1,5 +1,6 @@
 package com.mesosphere.cosmos.handler
 
+import com.mesosphere.cosmos.ServiceMarathonTemplateNotFound
 import com.mesosphere.cosmos.converter.Universe._
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.repository.PackageCollection
@@ -23,9 +24,10 @@ private[cosmos] final class PackageRenderHandler(
         request.packageVersion.as[Option[universe.v3.model.PackageDefinition.Version]]
       )
       .map { case (v3Package, uri) =>
-        RenderResponse(
-          preparePackageConfig(request.appId, request.options, v3Package, uri)
-        )
+        preparePackageConfig(request.appId, request.options, v3Package, uri) match {
+          case Some(json) => RenderResponse(json)
+          case None => throw ServiceMarathonTemplateNotFound(v3Package.name, v3Package.version)
+        }
       }
   }
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v2/circe/MediaTypedEncoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/rpc/v2/circe/MediaTypedEncoders.scala
@@ -32,9 +32,9 @@ object MediaTypedEncoders {
         mediaType = MediaTypes.V2InstallResponse
       ),
       MediaTypedEncoder(
-        encoder = rpc.v1.circe.Encoders.encodeInstallResponse.contramap(
-          converter.Response.v2InstallResponseToV1InstallResponse
-        ),
+        encoder = rpc.v1.circe.Encoders.encodeInstallResponse.contramap { (x: rpc.v2.model.InstallResponse) =>
+          converter.Response.v2InstallResponseToV1InstallResponse(x).get()
+        },
         mediaType = MediaTypes.V1InstallResponse
       )
     ))

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/PackageInstallSpec.scala
@@ -107,7 +107,7 @@ class PackageInstallSpec extends FreeSpec with Matchers with TableDrivenProperty
     val pd = packageDefinition(mustache)
 
     try {
-      val json = PackageInstallHandler.preparePackageConfig(None, None, pd, "http://someplace")
+      val Some(json) = PackageInstallHandler.preparePackageConfig(None, None, pd, "http://someplace")
 
       val _ = for {
         i <- json.hcursor.downField("labels").downField("idx").as[Int]
@@ -134,7 +134,7 @@ class PackageInstallSpec extends FreeSpec with Matchers with TableDrivenProperty
 
     val pd = packageDefinition(mustache)
 
-    val json = PackageInstallHandler.preparePackageConfig(None, None, pd, "http://someplace")
+    val Some(json) = PackageInstallHandler.preparePackageConfig(None, None, pd, "http://someplace")
 
     val Xor.Right(some) = for {
       i <- json.hcursor.downField("env").downField("some").as[String]


### PR DESCRIPTION
Depends on #421 
Fixes #419 
Fixes #410 
Fixes #417 

When reviewing, please only look at the contents of the second commit.