### PR TITLE
Update default value for zookeeperUri to be 127.0.0.1

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Flags.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Flags.scala
@@ -28,7 +28,7 @@ object mesosMasterUri extends GlobalFlag[Uri](
 )
 
 object zookeeperUri extends GlobalFlag[ZooKeeperUri](
-  ZooKeeperUri.parse("zk://localhost:2181/cosmos").get(),
+  ZooKeeperUri.parse("zk://127.0.0.1:2181/cosmos").get(),
   "The ZooKeeper connection string"
 )
 


### PR DESCRIPTION
Due to localhost not being available for all cloud providers we've been asked to remove DNS names that aren't provided by dc/os itself.