### PR TITLE
Refactor ZkRepositoryList: Pull out Distributed Global

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/ZkRepositoryList.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/ZkRepositoryList.scala
@@ -4,55 +4,34 @@ import cats.data.Ior
 import com.mesosphere.cosmos._
 import com.mesosphere.cosmos.repository.DefaultRepositories._
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
-import com.mesosphere.cosmos.storage.Envelope
+import com.mesosphere.cosmos.storage.DistributedGlobal
 import com.mesosphere.cosmos.storage.v1.circe.MediaTypedDecoders._
 import com.mesosphere.cosmos.storage.v1.circe.MediaTypedEncoders._
 import com.netaporter.uri.Uri
 import com.twitter.finagle.stats.{NullStatsReceiver, Stat, StatsReceiver}
 import com.twitter.util._
 import org.apache.curator.framework.CuratorFramework
-import org.apache.curator.framework.api.{BackgroundCallback, CuratorEvent, CuratorEventType}
-import org.apache.curator.framework.recipes.cache.NodeCache
-import org.apache.zookeeper.KeeperException
-import org.apache.zookeeper.data.{Stat => ZooKeeperStat}
 
 private[cosmos] final class ZkRepositoryList(
   zkClient: CuratorFramework
 )(implicit
   statsReceiver: StatsReceiver = NullStatsReceiver
 ) extends PackageSourcesStorage {
-
   import ZkRepositoryList._
 
-  private[this] val caching = new NodeCache(zkClient, ZkRepositoryList.PackageRepositoriesPath)
-  caching.start()
-
   private[this] val stats = statsReceiver.scope("zkStorage")
-
   private[this] val DefaultRepos: List[PackageRepository] = DefaultRepositories().getOrElse(Nil)
+  private[this] val global = DistributedGlobal(zkClient, ZkRepositoryList.PackageRepositoriesPath, DefaultRepos)
 
   override def read(): Future[List[PackageRepository]] = {
     Stat.timeFuture(stats.stat("read")) {
-      readFromZooKeeper.flatMap {
-        case Some((_, bytes)) =>
-          Future(Envelope.decodeData[List[PackageRepository]](bytes))
-        case None =>
-          create(DefaultRepos)
-      }
+      global.get.map(_._1)
     }
   }
 
   override def readCache(): Future[List[PackageRepository]] = {
-    val readCacheStats = stats.scope("readCache")
-    Stat.timeFuture(readCacheStats.stat("call")) {
-      readFromCache.flatMap {
-        case Some((_, bytes)) =>
-          readCacheStats.counter("hit").incr
-          Future(Envelope.decodeData[List[PackageRepository]](bytes))
-        case None =>
-          readCacheStats.counter("miss").incr
-          read()
-      }
+    Stat.timeFuture(stats.stat("readCache")) {
+      global.getCached.map(_._1)
     }
   }
 
@@ -61,12 +40,8 @@ private[cosmos] final class ZkRepositoryList(
     packageRepository: PackageRepository
   ): Future[List[PackageRepository]] = {
     Stat.timeFuture(stats.stat("add")) {
-      readFromZooKeeper.flatMap {
-        case Some((stat, bytes)) =>
-          write(stat, addToList(index, packageRepository, Envelope.decodeData[List[PackageRepository]](bytes)))
-
-        case None =>
-          create(addToList(index, packageRepository, DefaultRepos))
+      global.get.flatMap { case (data, version) =>
+          global.set(addToList(index, packageRepository, data), version).map(_._1)
       }
     }
   }
@@ -74,71 +49,16 @@ private[cosmos] final class ZkRepositoryList(
   override def delete(nameOrUri: Ior[String, Uri]): Future[List[PackageRepository]] = {
     Future.value(getPredicate(nameOrUri)).flatMap { predicate =>
       Stat.timeFuture(stats.stat("delete")) {
-        readFromZooKeeper.flatMap {
-          case Some((stat, bytes)) =>
-            val originalData = Envelope.decodeData[List[PackageRepository]](bytes)
+        global.get.flatMap {
+          case (originalData, version) =>
             val updatedData = originalData.filterNot(predicate)
             if (originalData.size == updatedData.size) {
               throw new RepositoryNotPresent(nameOrUri)
             }
-
-            write(stat, updatedData)
-          case None =>
-            create(DefaultRepos.filterNot(predicate))
+            global.set(updatedData, version).map(_._1)
         }
       }
     }
-  }
-
-  private[this] def create(
-    repositories: List[PackageRepository]
-  ): Future[List[PackageRepository]] = {
-    val promise = Promise[List[PackageRepository]]()
-
-    zkClient.create.creatingParentsIfNeeded.inBackground(
-      new CreateHandler(promise, repositories)
-    ).forPath(
-      ZkRepositoryList.PackageRepositoriesPath,
-      Envelope.encodeData(repositories)
-    )
-
-    promise
-  }
-
-  private[this] def write(
-    stat: ZooKeeperStat,
-    repositories: List[PackageRepository]
-  ): Future[List[PackageRepository]] = {
-    val promise = Promise[List[PackageRepository]]()
-
-    zkClient.setData().withVersion(stat.getVersion).inBackground(
-      new WriteHandler(promise, repositories)
-    ).forPath(
-      ZkRepositoryList.PackageRepositoriesPath,
-      Envelope.encodeData(repositories)
-    )
-
-    promise
-  }
-
-  private[this] def readFromCache: Future[Option[(ZooKeeperStat, Array[Byte])]] = {
-    Future {
-      Option(caching.getCurrentData()).map { data =>
-        (data.getStat, data.getData)
-      }
-    }
-  }
-
-  private[this] def readFromZooKeeper: Future[Option[(ZooKeeperStat, Array[Byte])]] = {
-    val promise = Promise[Option[(ZooKeeperStat, Array[Byte])]]()
-
-    zkClient.getData().inBackground(
-      new ReadHandler(promise)
-    ).forPath(
-      ZkRepositoryList.PackageRepositoriesPath
-    )
-
-    promise
   }
 
   private[this] def addToList(
@@ -181,82 +101,6 @@ private object ZkRepositoryList {
       case Ior.Both(n, u) => (repo: PackageRepository) => namePredicate(n)(repo) && uriPredicate(u)(repo)
       case Ior.Left(n) => namePredicate(n)
       case Ior.Right(u) => uriPredicate(u)
-    }
-  }
-
-}
-
-private final class WriteHandler(
-  promise: Promise[List[PackageRepository]],
-  repositories: List[PackageRepository]
-) extends  BackgroundCallback {
-  private[this] val logger = org.slf4j.LoggerFactory.getLogger(getClass)
-
-  override def processResult(client: CuratorFramework, event: CuratorEvent): Unit ={
-    if (event.getType == CuratorEventType.SET_DATA) {
-      val code = KeeperException.Code.get(event.getResultCode)
-      if (code == KeeperException.Code.OK) {
-        promise.setValue(repositories)
-      } else {
-        val exception = if (code == KeeperException.Code.BADVERSION) {
-          // BADVERSION is expected so let's display a friendlier error
-          ConcurrentAccess(KeeperException.create(code, event.getPath))
-        } else {
-          KeeperException.create(code, event.getPath)
-        }
-
-        promise.setException(exception)
-      }
-    } else {
-      logger.error("Repository storage write callback called for incorrect event: {}", event)
-    }
-  }
-}
-
-private final class CreateHandler(
-  promise: Promise[List[PackageRepository]],
-  repositories: List[PackageRepository]
-) extends  BackgroundCallback {
-  private[this] val logger = org.slf4j.LoggerFactory.getLogger(getClass)
-
-  override def processResult(client: CuratorFramework, event: CuratorEvent): Unit ={
-    if (event.getType == CuratorEventType.CREATE) {
-      val code = KeeperException.Code.get(event.getResultCode)
-      if (code == KeeperException.Code.OK) {
-        promise.setValue(repositories)
-      } else {
-        val exception = if (code == KeeperException.Code.NODEEXISTS) {
-          // NODEEXISTS is expected so let's display a friendlier error
-          ConcurrentAccess(KeeperException.create(code, event.getPath))
-        } else {
-          KeeperException.create(code, event.getPath)
-        }
-
-        promise.setException(exception)
-      }
-    } else {
-      logger.error("Repository storage create callback called for incorrect event: {}", event)
-    }
-  }
-}
-
-private final class ReadHandler(
-  promise: Promise[Option[(ZooKeeperStat, Array[Byte])]]
-) extends  BackgroundCallback {
-  private[this] val logger = org.slf4j.LoggerFactory.getLogger(getClass)
-
-  override def processResult(client: CuratorFramework, event: CuratorEvent): Unit ={
-    if (event.getType == CuratorEventType.GET_DATA) {
-      val code = KeeperException.Code.get(event.getResultCode)
-      if (code == KeeperException.Code.OK) {
-        promise.setValue(Some((event.getStat, event.getData)))
-      } else if (code == KeeperException.Code.NONODE) {
-        promise.setValue(None)
-      } else {
-        promise.setException(KeeperException.create(code, event.getPath))
-      }
-    } else {
-      logger.error("Repository storage read callback called for incorrect event: {}", event)
     }
   }
 }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/DistributedGlobal.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/DistributedGlobal.scala
@@ -1,0 +1,137 @@
+package com.mesosphere.cosmos.storage
+
+import com.mesosphere.cosmos.ConcurrentAccess
+import com.mesosphere.cosmos.circe.{MediaTypedDecoder, MediaTypedEncoder}
+import com.twitter.util.{Future, Promise}
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.api.{BackgroundCallback, CuratorEvent, CuratorEventType}
+import org.apache.curator.framework.recipes.cache.NodeCache
+import org.apache.zookeeper.KeeperException
+
+final class DistributedGlobal[T] private(
+  client: CuratorFramework, path: String, default: T
+)(implicit mediaTypedEncoder: MediaTypedEncoder[T], mediaTypedDecoder: MediaTypedDecoder[T]) {
+  import DistributedGlobal._
+
+  private[this] val cache = new NodeCache(client, path)
+  cache.start()
+
+  private def getCachedOption: Future[Option[(T, Int)]] = {
+    Future {
+      Option(cache.getCurrentData).map { response =>
+        (Envelope.decodeData(response.getData), response.getStat.getVersion)
+      }
+    }
+  }
+
+  private def getOption: Future[Option[(T, Int)]] = {
+    val promise = Promise[Option[(T, Int)]]()
+    client.getData.inBackground(handler { case event: CuratorEvent if event.getType == CuratorEventType.GET_DATA =>
+      KeeperException.Code.get(event.getResultCode) match {
+        case KeeperException.Code.OK =>
+          promise.setValue(Some((Envelope.decodeData(event.getData), event.getStat.getVersion)))
+        case KeeperException.Code.NONODE =>
+          promise.setValue(None)
+        case code =>
+          promise.setException(KeeperException.create(code, event.getPath))
+      }
+    }).forPath(path)
+    promise
+  }
+
+  private def setOption(value: T): Future[Option[(T, Int)]] = {
+    val promise = Promise[Option[(T, Int)]]()
+    client.setData().inBackground(handler { case event: CuratorEvent if event.getType == CuratorEventType.SET_DATA =>
+      KeeperException.Code.get(event.getResultCode) match {
+        case KeeperException.Code.OK =>
+          promise.setValue(Some((value, event.getStat.getVersion)))
+        case KeeperException.Code.NONODE =>
+          promise.setValue(None)
+        case code =>
+          promise.setException(KeeperException.create(code, event.getPath))
+      }
+    }).forPath(path, Envelope.encodeData(value))
+    promise
+  }
+
+  private def setOption(value: T, version: Int): Future[Option[(T, Int)]] = {
+    val promise = Promise[Option[(T, Int)]]()
+    client.setData().withVersion(version)
+      .inBackground(handler { case event: CuratorEvent if event.getType == CuratorEventType.SET_DATA =>
+        KeeperException.Code.get(event.getResultCode) match {
+          case KeeperException.Code.OK =>
+            promise.setValue(Some((value, event.getStat.getVersion)))
+          case KeeperException.Code.NONODE =>
+            promise.setValue(None)
+          case code if code == KeeperException.Code.BADVERSION =>
+            promise.setException(ConcurrentAccess(KeeperException.create(code, event.getPath)))
+          case code =>
+            promise.setException(KeeperException.create(code, event.getPath))
+        }
+      }).forPath(path, Envelope.encodeData(value))
+    promise
+  }
+
+  private def create(value: T)(ifNodeExists: => Future[(T, Int)]): Future[(T, Int)] = {
+    val promise = Promise[(T, Int)]()
+    client.create().inBackground(handler { case event: CuratorEvent if event.getType == CuratorEventType.CREATE =>
+      KeeperException.Code.get(event.getResultCode) match {
+        case KeeperException.Code.OK =>
+          promise.setValue((value, 0)) // assumes newly created nodes have version 0
+        case KeeperException.Code.NODEEXISTS =>
+          promise.become(ifNodeExists)
+        case code =>
+          promise.setException(KeeperException.create(code, event.getPath))
+      }
+    }).forPath(path, Envelope.encodeData(value))
+    promise
+  }
+
+  def get: Future[(T, Int)] = {
+    getOption.flatMap{ valueOption =>
+      valueOption.map(Future.value)
+        .getOrElse(create(default)(ifNodeExists = get))
+    }
+  }
+
+  def set(value: T): Future[(T, Int)] = {
+    setOption(value).flatMap { valueOption =>
+      valueOption.map(Future.value)
+        .getOrElse(create(value)(ifNodeExists = set(value)))
+    }
+  }
+
+  def set(value: T, version: Int): Future[(T, Int)] = {
+    setOption(value, version).flatMap { valueOption =>
+      valueOption.map(Future.value)
+        .getOrElse(create(value)(ifNodeExists = set(value, version)))
+    }
+  }
+
+  def getCached: Future[(T, Int)] = {
+    getCachedOption.flatMap {
+      case Some((stat, data)) => Future((stat, data))
+      case None => get
+    }
+  }
+}
+
+object DistributedGlobal {
+
+  def apply[T](
+    client: CuratorFramework, path: String, default: T
+  )( implicit
+     mediaTypedEncoder: MediaTypedEncoder[T],
+     mediaTypedDecoder: MediaTypedDecoder[T]): DistributedGlobal[T] = {
+    new DistributedGlobal(client, path, default)
+  }
+
+  private def handler(handle: PartialFunction[CuratorEvent, Unit]) = {
+    new BackgroundCallback {
+      override def processResult(client: CuratorFramework, event: CuratorEvent): Unit = {
+        handle(event)
+      }
+    }
+  }
+
+}

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/DistributedGlobalSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/DistributedGlobalSpec.scala
@@ -1,0 +1,124 @@
+package com.mesosphere.cosmos.storage
+
+import com.mesosphere.cosmos.ConcurrentAccess
+import com.mesosphere.cosmos.test.TestUtil._
+import com.twitter.util.Await
+import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
+import org.apache.curator.retry.ExponentialBackoffRetry
+import org.scalatest.FreeSpec
+
+/**
+  * Requires zookeeper to be running on localhost:2181
+  * ignoring tests for now
+  */
+class DistributedGlobalSpec extends FreeSpec {
+
+  import DistributedGlobalSpec._
+
+  private[this] def startZk(): CuratorFramework = {
+    val zk = CuratorFrameworkFactory.newClient(
+      zkPath,
+      new ExponentialBackoffRetry(1000, 300)
+    )
+    zk.start()
+    zk.getZookeeperClient.blockUntilConnectedOrTimedOut()
+    zk
+  }
+
+  "When path does not exist default value should be written and returned" ignore {
+    val zk = startZk()
+    val path = "/unset"
+    val global = DistributedGlobal(zk, path, default)
+    val exp = default
+    val act = Await.result(global.get)._1
+    assertResult(exp)(act)
+    zk.delete().forPath(path)
+    ()
+  }
+
+  "When path does exist the value should be decoded and returned" ignore {
+    val zk = startZk()
+    val path = "/exists"
+    val exp = TestClass("foo")
+    zk.create().forPath(path, Envelope.encodeData(exp))
+    val global = DistributedGlobal(zk, path, default)
+    val act = Await.result(global.get)._1
+    assertResult(exp)(act)
+    zk.delete().forPath(path)
+    ()
+  }
+
+  "A write of a value X followed by a read should return X given that no other" +
+    " writes have occurred" ignore {
+    val zk = startZk()
+    val path = "/readOwnWrites"
+    val global = DistributedGlobal(zk, path, default)
+    val exp = TestClass("foo")
+    val act = Await.result(global.set(exp).flatMap(_ => global.get))._1
+    assertResult(exp)(act)
+    zk.delete().forPath(path)
+    ()
+  }
+
+  "A write of a value X followed by a cached read should return X or any other" +
+    " value written before X including the default" ignore {
+    val zk = startZk()
+    val path = "/cacheDoesNotReadOwnWrites"
+    val global = DistributedGlobal(zk, path, default)
+    val x = TestClass("x")
+    val y = TestClass("y")
+    val act = Await.result(
+      global.set(x)
+        .flatMap(_ => global.set(y))
+        .flatMap(_ => global.getCached)
+    )._1
+    assert(Set(default, x, y).contains(act))
+    zk.delete().forPath(path)
+    ()
+  }
+
+  "A series of set with version operations should succeed if there are no" +
+    " other concurrent sets" ignore {
+    val zk = startZk()
+    val path = "/setWithVersion"
+    val global = DistributedGlobal(zk, path, default)
+    val max = 10
+    val values = (0 to max).map(v => TestClass(v.toString))
+    val exp = TestClass(max.toString)
+    val act = Await.result(
+      values.foldLeft(global.get){
+        case (acc, value) => acc.flatMap(p => global.set(value, p._2))
+      }
+    )._1
+    assertResult(exp)(act)
+    zk.delete().forPath(path)
+    ()
+  }
+
+  "A series of set with version operations should fail if there are" +
+    " other concurrent sets" ignore {
+    val zk = startZk()
+    val path = "/setWithVersion"
+    val global = DistributedGlobal(zk, path, default)
+    val max = 10
+    val values = (0 to max).map(v => TestClass(v.toString))
+    val exp = TestClass(max.toString)
+    val act = Await.result(
+      values.foldLeft(global.get){
+        case (acc, value) => acc.flatMap(p => global.set(value, p._2))
+      }
+    )._1
+    intercept[ConcurrentAccess]{
+      Await.result(global.set(TestClass("fail!!"), max))
+    }
+    assertResult(exp)(act)
+    zk.delete().forPath(path)
+    ()
+  }
+
+}
+
+object DistributedGlobalSpec {
+  private val zkPath = "localhost:2181"
+  private val default = TestClass("")
+}

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/EnvelopeSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/EnvelopeSpec.scala
@@ -1,16 +1,11 @@
 package com.mesosphere.cosmos.storage
 
 import com.mesosphere.cosmos.EnvelopeError
-import com.mesosphere.cosmos.circe.{MediaTypedDecoder, MediaTypedEncoder}
-import com.mesosphere.cosmos.http.{MediaType, MediaTypeSubType}
 import com.mesosphere.cosmos.storage.Envelope._
-import io.circe.generic.semiauto._
-import io.circe.{Decoder, Encoder}
+import com.mesosphere.cosmos.test.TestUtil._
 import org.scalatest.FreeSpec
 
 class EnvelopeSpec extends FreeSpec {
-  import EnvelopeSpec._
-
   "Decoding the result of an encoding should yield back the original data" in {
     val exp = TestClass("fooooo")
     val act = decodeData[TestClass](encodeData(exp))
@@ -24,36 +19,4 @@ class EnvelopeSpec extends FreeSpec {
     }
     ()
   }
-}
-
-object  EnvelopeSpec {
-  private case class TestClass(name: String)
-  private val TestClassMt = MediaType(
-    "application",
-    MediaTypeSubType("vnd.dcos.package.repository.test-class", Some("json")),
-    Map(
-      "charset" -> "utf-8",
-      "version" -> "v1"
-    )
-  )
-  private implicit val decodeTestClass: Decoder[TestClass] = deriveDecoder
-  private implicit val encodeTestClass: Encoder[TestClass] = deriveEncoder
-  private implicit val mtdTestClass: MediaTypedDecoder[TestClass] =
-    MediaTypedDecoder(TestClassMt)
-  private implicit val mteTestClass: MediaTypedEncoder[TestClass] =
-    MediaTypedEncoder(TestClassMt)
-
-  private case class TestClass2(name: String)
-  private val TestClass2Mt = MediaType(
-    "application",
-    MediaTypeSubType("vnd.dcos.package.repository.test-class2", Some("json")),
-    Map(
-      "charset" -> "utf-8",
-      "version" -> "v1"
-    )
-  )
-  private implicit val encodeTestClass2: Encoder[TestClass2] = deriveEncoder
-  private implicit val mteTestClass2: MediaTypedEncoder[TestClass2] =
-    MediaTypedEncoder(TestClass2Mt)
-
 }

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/test/TestUtil.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/test/TestUtil.scala
@@ -1,20 +1,24 @@
 package com.mesosphere.cosmos.test
 
-import com.mesosphere.cosmos.http.RequestSession
+import com.mesosphere.cosmos.http.{MediaType, MediaTypeSubType, RequestSession}
 import java.io.IOException
 import java.nio.file._
 import java.nio.file.attribute.BasicFileAttributes
+
 import com.mesosphere.cosmos._
 import com.mesosphere.cosmos.converter.Common._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+
+import com.mesosphere.cosmos.circe.{MediaTypedDecoder, MediaTypedEncoder}
 import com.mesosphere.universe
 import com.mesosphere.universe.v3.model.PackageDefinition.ReleaseVersion
 import com.mesosphere.universe.v3.model._
 import com.netaporter.uri.Uri
 import com.twitter.bijection.Conversion.asMethod
+import io.circe.generic.semiauto._
 import io.circe.syntax._
-import io.circe.JsonObject
+import io.circe.{Decoder, Encoder, JsonObject}
 
 object TestUtil {
 
@@ -322,4 +326,33 @@ object TestUtil {
     case v2: V2Package => (v2.name, v2.releaseVersion)
     case v3: V3Package => (v3.name, v3.releaseVersion)
   }
+
+  case class TestClass(name: String)
+  private val TestClassMt = MediaType(
+    "application",
+    MediaTypeSubType("vnd.dcos.package.repository.test-class", Some("json")),
+    Map(
+      "charset" -> "utf-8",
+      "version" -> "v1"
+    )
+  )
+  implicit val decodeTestClass: Decoder[TestClass] = deriveDecoder
+  implicit val encodeTestClass: Encoder[TestClass] = deriveEncoder
+  implicit val testClassDecoder: MediaTypedDecoder[TestClass] =
+    MediaTypedDecoder(TestClassMt)
+  implicit val testClassEncoder: MediaTypedEncoder[TestClass] =
+    MediaTypedEncoder(TestClassMt)
+
+  case class TestClass2(name: String)
+  val TestClass2Mt = MediaType(
+    "application",
+    MediaTypeSubType("vnd.dcos.package.repository.test-class2", Some("json")),
+    Map(
+      "charset" -> "utf-8",
+      "version" -> "v1"
+    )
+  )
+  implicit val encodeTestClass2: Encoder[TestClass2] = deriveEncoder
+  implicit val testClass2Encoder: MediaTypedEncoder[TestClass2] =
+    MediaTypedEncoder(TestClass2Mt)
 }


### PR DESCRIPTION
* Pull out zk functionality into distributed global
	* distributed global is a class that model data that
	  is shared across multiple cosmos. Whose lifetime persists
	  indefinitely i.e. once a distributed global is created
	  it will never be deleted.