### PR TITLE
Update start_ccm_cluster.sh to allow aws region to be passed as a parameter

### DIFF
--- a/build/start_ccm_cluster.sh
+++ b/build/start_ccm_cluster.sh
@@ -16,7 +16,7 @@ CLUSTER_ID=$(
         "Authorization:Token ${CCM_AUTH_TOKEN}" \
         "name=${CLUSTER_NAME}" \
         cloud_provider=0 \
-        region=us-west-2 \
+        region="${CCM_AWS_CLUSTER_REGION:-"us-west-2"}" \
         time=60 \
         channel=testing/master \
         "cluster_desc=Cosmos testing cluster" \


### PR DESCRIPTION
New environment variable `CCM_AWS_CLUSTER_REGION` can now override the region the cluster is started in.