### PR TITLE
Update JsonSchema to take JsonSchemaFactory

### DIFF
--- a/cosmos-jsonschema/src/main/scala/com/mesosphere/cosmos/jsonschema/JsonSchema.scala
+++ b/cosmos-jsonschema/src/main/scala/com/mesosphere/cosmos/jsonschema/JsonSchema.scala
@@ -17,15 +17,10 @@ object JsonSchema {
   type ValidationErrors = Iterable[Json]
 
   /**
-    * Pre-configured validator instance for draft v4 JsonSchema documents
-    */
-  val draftV4Validator: JsonValidator = JsonSchemaFactory.byDefault().getValidator
-
-  /**
     * Validates `document` against `schema` returning all validation failures.
     * @param document   The document to validation
     * @param schema     The schema to validate against
-    * @param validator  The configured validator to use for the validation. The default validator is pre-configured
+    * @param jsf        The configured validator to use for the validation. The default validator is pre-configured
     *                   for draft v4 of json schema.
     * @return           Returns an [[cats.data.Xor Xor]] representing the result of validating `document` against `schema`.
     *                   [[cats.data.Xor.Left Xor.Left[ValidationErrors] ]] Will be returned containing all validation
@@ -35,7 +30,7 @@ object JsonSchema {
     document: JsonObject,
     schema: JsonObject
   )(
-    implicit validator: JsonValidator = draftV4Validator
+    implicit jsf: JsonSchemaFactory
   ): Xor[ValidationErrors, Unit] = {
     jsonMatchesSchema(Json.fromJsonObject(document), Json.fromJsonObject(schema))
   }
@@ -44,7 +39,7 @@ object JsonSchema {
     * Validates `document` against `schema` returning all validation failures.
     * @param document   The document to validation
     * @param schema     The schema to validate against
-    * @param validator  The configured validator to use for the validation. The default validator is pre-configured
+    * @param jsf        The configured validator to use for the validation. The default validator is pre-configured
     *                   for draft v4 of json schema.
     * @return           Returns an [[cats.data.Xor Xor]] representing the result of validating `document` against `schema`.
     *                   [[cats.data.Xor.Left Xor.Left[ValidationErrors] ]] Will be returned containing all validation
@@ -54,12 +49,12 @@ object JsonSchema {
     document: Json,
     schema: Json
   )(
-    implicit validator: JsonValidator = draftV4Validator
+    implicit jsf: JsonSchemaFactory
   ): Xor[Iterable[Json], Unit] = {
     val Xor.Right(documentNode) = document.as[JsonNode]
     val Xor.Right(schemaNode) = schema.as[JsonNode]
 
-    val validationErrors = validator.validate(schemaNode, documentNode)
+    val validationErrors = jsf.getValidator.validate(schemaNode, documentNode)
     if (validationErrors.isSuccess) {
       Xor.right[ValidationErrors, Unit](())
     } else {

--- a/cosmos-jsonschema/src/main/scala/com/mesosphere/cosmos/jsonschema/JsonSchema.scala
+++ b/cosmos-jsonschema/src/main/scala/com/mesosphere/cosmos/jsonschema/JsonSchema.scala
@@ -20,8 +20,7 @@ object JsonSchema {
     * Validates `document` against `schema` returning all validation failures.
     * @param document   The document to validation
     * @param schema     The schema to validate against
-    * @param jsf        The configured validator to use for the validation. The default validator is pre-configured
-    *                   for draft v4 of json schema.
+    * @param jsf        The configured factory used to acquire the validator used for the validation.
     * @return           Returns an [[cats.data.Xor Xor]] representing the result of validating `document` against `schema`.
     *                   [[cats.data.Xor.Left Xor.Left[ValidationErrors] ]] Will be returned containing all validation
     *                   failures if they occur. [[cats.data.Xor.Right Xor.Right[Unit] ]] Will be returned if no validation failures occur.
@@ -39,8 +38,7 @@ object JsonSchema {
     * Validates `document` against `schema` returning all validation failures.
     * @param document   The document to validation
     * @param schema     The schema to validate against
-    * @param jsf        The configured validator to use for the validation. The default validator is pre-configured
-    *                   for draft v4 of json schema.
+    * @param jsf        The configured factory used to acquire the validator used for the validation.
     * @return           Returns an [[cats.data.Xor Xor]] representing the result of validating `document` against `schema`.
     *                   [[cats.data.Xor.Left Xor.Left[ValidationErrors] ]] Will be returned containing all validation
     *                   failures if they occur. [[cats.data.Xor.Right Xor.Right[Unit] ]] Will be returned if no validation failures occur.

--- a/cosmos-jsonschema/src/test/scala/com/mesosphere/cosmos/jsonschema/JsonSchemaSpec.scala
+++ b/cosmos-jsonschema/src/test/scala/com/mesosphere/cosmos/jsonschema/JsonSchemaSpec.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.cosmos.jsonschema
 
 import cats.data.Xor
+import com.github.fge.jsonschema.main.JsonSchemaFactory
 import io.circe.jawn.parse
 import io.circe.syntax._
 import io.circe.{Json, JsonObject}
@@ -10,6 +11,7 @@ import scala.io.Source
 
 class JsonSchemaSpec extends FreeSpec {
 
+  private[this] implicit val jsf = JsonSchemaFactory.byDefault()
 
   "JsonSchema should" - {
     "be able to validate a document against a schema" - {

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/schema/repo
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/schema/repo
@@ -1,0 +1,507 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "definitions": {
+
+
+    "dcosReleaseVersion": {
+      "type": "string",
+      "pattern": "^(?:0|[1-9][0-9]*)(?:\\.(?:0|[1-9][0-9]*))*$",
+      "description": "A string representation of a DC/OS Release Version"
+    },
+
+    "url": {
+      "type": "string",
+      "allOf": [
+        { "format": "uri" },
+        { "pattern": "^https?://" }
+      ]
+    },
+
+    "base64String": {
+      "type": "string",
+      "pattern": "^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$"
+    },
+
+    "cliInfo": {
+      "additionalProperties": false,
+      "properties": {
+        "contentHash": {
+          "items": {
+            "$ref": "#/definitions/hash"
+          },
+          "minItems": 1,
+          "type": "array"
+        },
+        "kind": {
+          "enum": [
+            "executable",
+            "zip"
+          ],
+          "type": "string"
+        },
+        "url": {
+          "$ref": "#/definitions/url"
+        }
+      },
+      "required": [
+        "url",
+        "kind",
+        "contentHash"
+      ],
+      "type": "object"
+    },
+
+    "hash": {
+      "additionalProperties": false,
+      "properties": {
+        "algo": {
+          "enum": [
+            "sha256"
+          ],
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "algo",
+        "value"
+      ],
+      "type": "object"
+    },
+
+
+    "marathon": {
+      "type": "object",
+      "properties": {
+        "v2AppMustacheTemplate": {
+          "$ref": "#/definitions/base64String"
+        }
+      },
+      "required": [ "v2AppMustacheTemplate" ],
+      "additionalProperties": false
+    },
+
+
+
+    "v20resource": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "object",
+          "properties": {
+            "uris": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "container": {
+              "type": "object",
+              "properties": {
+                "docker": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "images": {
+          "type": "object",
+          "properties": {
+            "icon-small": {
+              "type": "string",
+              "description": "PNG icon URL, preferably 48 by 48 pixels."
+            },
+            "icon-medium": {
+              "type": "string",
+              "description": "PNG icon URL, preferably 128 by 128 pixels."
+            },
+            "icon-large": {
+              "type": "string",
+              "description": "PNG icon URL, preferably 256 by 256 pixels."
+            },
+            "screenshots": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "PNG screen URL, preferably 1024 by 1024 pixels."
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+
+
+    "v30resource": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "assets": {
+          "type": "object",
+          "properties": {
+            "uris": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "container": {
+              "type": "object",
+              "properties": {
+                "docker": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "cli": {
+          "additionalProperties": false,
+          "properties": {
+            "binaries": {
+              "additionalProperties": false,
+              "minProperties": 1,
+              "properties": {
+                "darwin": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "x86-64": {
+                      "$ref": "#/definitions/cliInfo"
+                    }
+                  },
+                  "required": [
+                    "x86-64"
+                  ],
+                  "type": "object"
+                },
+                "linux": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "x86-64": {
+                      "$ref": "#/definitions/cliInfo"
+                    }
+                  },
+                  "required": [
+                    "x86-64"
+                  ],
+                  "type": "object"
+                },
+                "windows": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "x86-64": {
+                      "$ref": "#/definitions/cliInfo"
+                    }
+                  },
+                  "required": [
+                    "x86-64"
+                  ],
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+              "binaries"
+          ],
+          "type": "object"
+        },
+        "images": {
+          "type": "object",
+          "properties": {
+            "icon-small": {
+              "type": "string",
+              "description": "PNG icon URL, preferably 48 by 48 pixels."
+            },
+            "icon-medium": {
+              "type": "string",
+              "description": "PNG icon URL, preferably 128 by 128 pixels."
+            },
+            "icon-large": {
+              "type": "string",
+              "description": "PNG icon URL, preferably 256 by 256 pixels."
+            },
+            "screenshots": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "description": "PNG screen URL, preferably 1024 by 1024 pixels."
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+
+
+    "config": {
+      "$ref": "http://json-schema.org/draft-04/schema#"
+    },
+
+
+    "command": {
+      "additionalProperties": false,
+      "required": ["pip"],
+      "properties": {
+        "pip": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "title": "Embedded Requirements File",
+          "description": "[Deprecated v3.x] An array of strings representing of the requirements file to use for installing the subcommand for Pip. Each item is interpreted as a line in the requirements file."
+        }
+      }
+    },
+
+
+
+    "v20Package": {
+      "properties": {
+        "packagingVersion": {
+          "type": "string",
+          "enum": ["2.0"]
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "releaseVersion": {
+          "type": "integer",
+          "description": "Corresponds to the revision index from the universe directory structure",
+          "minimum": 0
+        },
+        "scm": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "framework": {
+          "type": "boolean",
+          "default": false,
+          "description": "True if this package installs a new Mesos framework."
+        },
+        "preInstallNotes": {
+          "type": "string",
+          "description": "Pre installation notes that would be useful to the user of this package."
+        },
+        "postInstallNotes": {
+          "type": "string",
+          "description": "Post installation notes that would be useful to the user of this package."
+        },
+        "postUninstallNotes": {
+          "type": "string",
+          "description": "Post uninstallation notes that would be useful to the user of this package."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[^\\s]+$"
+          }
+        },
+        "selected": {
+          "type": "boolean",
+          "description": "Flag indicating if the package is selected in search results",
+          "default": false
+        },
+        "licenses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the license. For example one of [Apache License Version 2.0 | MIT License | BSD License | Proprietary]"
+              },
+              "url": {
+                "$ref": "#/definitions/url"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "url"
+            ]
+          }
+        },
+        "marathon": {
+          "$ref": "#/definitions/marathon"
+        },
+        "resource": {
+          "$ref": "#/definitions/v20resource"
+        },
+        "config": {
+          "$ref": "#/definitions/config"
+        },
+        "command": {
+          "$ref": "#/definitions/command"
+        }
+      },
+      "required": [
+        "packagingVersion",
+        "name",
+        "version",
+        "maintainer",
+        "description",
+        "tags"
+      ],
+      "additionalProperties": false
+    },
+
+    "v30Package": {
+      "properties": {
+        "packagingVersion": {
+          "type": "string",
+          "enum": ["3.0"]
+        },
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "releaseVersion": {
+          "type": "integer",
+          "description": "Corresponds to the revision index from the universe directory structure",
+          "minimum": 0
+        },
+        "scm": {
+          "type": "string"
+        },
+        "maintainer": {
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "framework": {
+          "type": "boolean",
+          "default": false,
+          "description": "True if this package installs a new Mesos framework."
+        },
+        "preInstallNotes": {
+          "type": "string",
+          "description": "Pre installation notes that would be useful to the user of this package."
+        },
+        "postInstallNotes": {
+          "type": "string",
+          "description": "Post installation notes that would be useful to the user of this package."
+        },
+        "postUninstallNotes": {
+          "type": "string",
+          "description": "Post uninstallation notes that would be useful to the user of this package."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[^\\s]+$"
+          }
+        },
+        "selected": {
+          "type": "boolean",
+          "description": "Flag indicating if the package is selected in search results",
+          "default": false
+        },
+        "licenses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The name of the license. For example one of [Apache License Version 2.0 | MIT License | BSD License | Proprietary]"
+              },
+              "url": {
+                "$ref": "#/definitions/url",
+                "description": "The URL where the license can be accessed"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "url"
+            ]
+          }
+        },
+        "minDcosReleaseVersion": {
+          "$ref": "#/definitions/dcosReleaseVersion",
+          "description": "The minimum DC/OS Release Version the package can run on."
+        },
+        "marathon": {
+          "$ref": "#/definitions/marathon"
+        },
+        "resource": {
+          "$ref": "#/definitions/v30resource"
+        },
+        "config": {
+          "$ref": "#/definitions/config"
+        },
+        "command": {
+          "$ref": "#/definitions/command"
+        }
+      },
+      "required": [
+        "packagingVersion",
+        "name",
+        "version",
+        "releaseVersion",
+        "maintainer",
+        "description",
+        "tags"
+      ],
+      "additionalProperties": false
+    }
+
+
+  },
+
+  "type": "object",
+  "properties": {
+    "packages": {
+      "type": "array",
+      "description": "The list of packages in the repo",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/definitions/v20Package" },
+          { "$ref": "#/definitions/v30Package" }
+        ]
+      }
+    }
+  },
+  "required": [
+    "packages"
+  ],
+  "additionalProperties": false
+}

--- a/cosmos-render/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
+++ b/cosmos-render/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.cosmos.render
 
 import cats.data.Xor
+import com.github.fge.jsonschema.main.JsonSchemaFactory
 import com.github.mustachejava.DefaultMustacheFactory
 import com.mesosphere.cosmos.jsonschema.JsonSchema
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
@@ -21,6 +22,7 @@ import java.nio.charset.StandardCharsets
 
 object PackageDefinitionRenderer {
   private[this] final val MustacheFactory = new DefaultMustacheFactory()
+  private[this] implicit val jsf: JsonSchemaFactory = JsonSchemaFactory.byDefault()
 
   def renderMarathonV2App(
     sourceUri: Uri,


### PR DESCRIPTION
* Update JsonSchema to take an implicit JsonSchemaFactory rather than JsonValidator
  * This allows for more configuration handling on the library side since factories can be cloned and have config added, for example to remap http uris to classpath uris.
* Define JsonSchemaFactory for PackageDefinitionRenderer
* Add v3/schema/repo to resources.
  * This resource allows for a resource mapping that is very similar the the 
     universe hosted schema `/com/mesosphere/universe/v3/schema/repo` -> `https://universe.mesosphere.com/v3/schema/repo`