### PR TITLE
add dcos-log capability

### DIFF
--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
@@ -23,7 +23,8 @@ final class CapabilitiesHandlerSpec extends FreeSpec {
     val expected = CapabilitiesResponse(List(
       Capability("PACKAGE_MANAGEMENT"),
       Capability("SUPPORT_CLUSTER_REPORT"),
-      Capability("METRONOME")
+      Capability("METRONOME"),
+      Capability("LOGGING")
     ))
     assertResult(expected)(body)
   }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/CapabilitiesHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/CapabilitiesHandler.scala
@@ -9,7 +9,10 @@ private[cosmos] final class CapabilitiesHandler
   extends EndpointHandler[Unit, CapabilitiesResponse] {
 
   private[this] val response = CapabilitiesResponse(
-    List(Capability("PACKAGE_MANAGEMENT"), Capability("SUPPORT_CLUSTER_REPORT"), Capability("METRONOME")))
+    List(Capability("PACKAGE_MANAGEMENT"),
+         Capability("SUPPORT_CLUSTER_REPORT"),
+         Capability("METRONOME"),
+         Capability("LOGGING")))
 
   override def apply(v1: Unit)(implicit
     session: RequestSession


### PR DESCRIPTION
with 1.10 release we are going to use new `dcos-log` backend for cluster logs.
That said UI and CLI need a new capability to recognize supported clusters.

Related PRs
DC/OS:
https://github.com/dcos/dcos/pull/832

DC/OS CLI:
https://github.com/dcos/dcos-cli/pull/817

dcos-log project:
https://github.com/dcos/dcos-log
