### PR TITLE
Prevent test authors from creating incorrect Finagle Request objects

### DIFF
--- a/cosmos-finch/src/main/scala/com/mesosphere/cosmos/finch/FinchExtensions.scala
+++ b/cosmos-finch/src/main/scala/com/mesosphere/cosmos/finch/FinchExtensions.scala
@@ -24,9 +24,9 @@ object FinchExtensions {
     base: Endpoint[HNil],
     handler: EndpointHandler[Req, Res]
   )(
-    requestReader: Endpoint[EndpointContext[Req, Res]]
+    requestValidator: Endpoint[EndpointContext[Req, Res]]
   ): Endpoint[Json] = {
-    (base ? requestReader).apply((context: EndpointContext[Req, Res]) => handler(context))
+    (base ? requestValidator).apply((context: EndpointContext[Req, Res]) => handler(context))
   }
 
 }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -9,6 +9,7 @@ import com.mesosphere.cosmos.rpc.v1.model.DescribeRequest
 import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.rpc.v1.model.ListVersionsRequest
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
+import com.mesosphere.cosmos.test.CosmosRequest
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonApp
 import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonAppContainer
@@ -105,23 +106,25 @@ final class PackageDescribeSpec extends FreeSpec with TableDrivenPropertyChecks 
   private[this] def describeRequest(
     describeRequest: DescribeRequest
   ): Response = {
-    CosmosClient.doPost(
+    val request = CosmosRequest.post(
       path = DescribeEndpoint,
-      requestBody = describeRequest,
+      body = describeRequest,
       contentType = MediaTypes.DescribeRequest,
       accept = MediaTypes.V1DescribeResponse
     )
+    CosmosClient.submit(request)
   }
 
   private[this] def listVersionsRequest(
     listVersionsRequest: ListVersionsRequest
   ): Response = {
-    CosmosClient.doPost(
+    val request = CosmosRequest.post(
       path = ListVersionsEndpoint,
-      requestBody = listVersionsRequest,
+      body = listVersionsRequest,
       contentType = MediaTypes.ListVersionsRequest,
       accept = MediaTypes.ListVersionsResponse
     )
+    CosmosClient.submit(request)
   }
 }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -3,15 +3,19 @@ package com.mesosphere.cosmos
 import cats.data.Xor
 import cats.data.Xor.Right
 import com.mesosphere.cosmos.rpc.MediaTypes
-import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
-import com.mesosphere.cosmos.rpc.v1.model.{DescribeRequest, ErrorResponse, ListVersionsRequest}
-import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
-import com.mesosphere.cosmos.thirdparty.marathon.model.{AppId, MarathonApp, MarathonAppContainer, MarathonAppContainerDocker}
-import com.mesosphere.universe.v2.model._
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
+import com.mesosphere.cosmos.rpc.v1.model.DescribeRequest
+import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
+import com.mesosphere.cosmos.rpc.v1.model.ListVersionsRequest
+import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
+import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
+import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonApp
+import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonAppContainer
+import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonAppContainerDocker
 import com.mesosphere.universe.v2.circe.Decoders._
+import com.mesosphere.universe.v2.model._
 import com.twitter.finagle.http._
-import com.twitter.io.Buf
 import io.circe.Json
 import io.circe.jawn._
 import io.circe.syntax._
@@ -21,8 +25,6 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 final class PackageDescribeSpec extends FreeSpec with TableDrivenPropertyChecks {
 
   import PackageDescribeSpec._
-
-  val apiClient = CosmosIntegrationTestClient.CosmosClient
 
   "The package describe endpoint" - {
     "returns an error when package w/ version not found" in {
@@ -103,21 +105,23 @@ final class PackageDescribeSpec extends FreeSpec with TableDrivenPropertyChecks 
   private[this] def describeRequest(
     describeRequest: DescribeRequest
   ): Response = {
-    val request = apiClient.requestBuilder(DescribeEndpoint)
-      .addHeader("Content-Type", MediaTypes.DescribeRequest.show)
-      .addHeader("Accept", MediaTypes.V1DescribeResponse.show)
-      .buildPost(Buf.Utf8(describeRequest.asJson.noSpaces))
-    apiClient(request)
+    CosmosClient.doPost(
+      path = DescribeEndpoint,
+      requestBody = describeRequest,
+      contentType = MediaTypes.DescribeRequest,
+      accept = MediaTypes.V1DescribeResponse
+    )
   }
 
   private[this] def listVersionsRequest(
     listVersionsRequest: ListVersionsRequest
   ): Response = {
-    val request = apiClient.requestBuilder(ListVersionsEndpoint)
-      .addHeader("Content-Type", MediaTypes.ListVersionsRequest.show)
-      .addHeader("Accept", MediaTypes.ListVersionsResponse.show)
-      .buildPost(Buf.Utf8(listVersionsRequest.asJson.noSpaces))
-    apiClient(request)
+    CosmosClient.doPost(
+      path = ListVersionsEndpoint,
+      requestBody = listVersionsRequest,
+      contentType = MediaTypes.ListVersionsRequest,
+      accept = MediaTypes.ListVersionsResponse
+    )
   }
 }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -107,10 +107,10 @@ final class PackageDescribeSpec extends FreeSpec with TableDrivenPropertyChecks 
     describeRequest: DescribeRequest
   ): Response = {
     val request = CosmosRequest.post(
-      path = DescribeEndpoint,
-      body = describeRequest,
-      contentType = MediaTypes.DescribeRequest,
-      accept = MediaTypes.V1DescribeResponse
+      DescribeEndpoint,
+      describeRequest,
+      MediaTypes.DescribeRequest,
+      MediaTypes.V1DescribeResponse
     )
     CosmosClient.submit(request)
   }
@@ -119,10 +119,10 @@ final class PackageDescribeSpec extends FreeSpec with TableDrivenPropertyChecks 
     listVersionsRequest: ListVersionsRequest
   ): Response = {
     val request = CosmosRequest.post(
-      path = ListVersionsEndpoint,
-      body = listVersionsRequest,
-      contentType = MediaTypes.ListVersionsRequest,
-      accept = MediaTypes.ListVersionsResponse
+      ListVersionsEndpoint,
+      listVersionsRequest,
+      MediaTypes.ListVersionsRequest,
+      MediaTypes.ListVersionsResponse
     )
     CosmosClient.submit(request)
   }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -206,10 +206,10 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
       val installRequest = InstallRequest("enterprise-security-cli")
 
       val request = CosmosRequest.post(
-        path = "package/install",
-        body = installRequest,
-        contentType = MediaTypes.InstallRequest,
-        accept = MediaTypes.V2InstallResponse
+        "package/install",
+        installRequest,
+        MediaTypes.InstallRequest,
+        MediaTypes.V2InstallResponse
       )
       val response = CosmosClient.submit(request)
 
@@ -282,10 +282,10 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
     installRequest: InstallRequest
   ): Response = {
     val request = CosmosRequest.post(
-      path = "package/install",
-      body = installRequest,
-      contentType = MediaTypes.InstallRequest,
-      accept = MediaTypes.V1InstallResponse
+      "package/install",
+      installRequest,
+      MediaTypes.InstallRequest,
+      MediaTypes.V1InstallResponse
     )
     CosmosClient.submit(request)
   }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -195,12 +195,12 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
 
       val installRequest = InstallRequest("enterprise-security-cli")
 
-      val request = CosmosClient.requestBuilder("package/install")
-        .addHeader("Content-Type", MediaTypes.InstallRequest.show)
-        .addHeader("Accept", MediaTypes.V2InstallResponse.show)
-        .buildPost(Buf.Utf8(installRequest.asJson.noSpaces))
-
-      val response = CosmosClient(request)
+      val response = CosmosClient.doPost(
+        path = "package/install",
+        requestBody = installRequest,
+        contentType = MediaTypes.InstallRequest,
+        accept = MediaTypes.V2InstallResponse
+      )
 
       assertResult(Status.Ok)(response.status)
       assertResult(MediaTypes.V2InstallResponse.show)(response.contentType.get)
@@ -270,11 +270,12 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
   private[this] def installPackage(
     installRequest: InstallRequest
   ): Response = {
-    val request = CosmosClient.requestBuilder("package/install")
-      .addHeader("Content-Type", MediaTypes.InstallRequest.show)
-      .addHeader("Accept", MediaTypes.V1InstallResponse.show)
-      .buildPost(Buf.Utf8(installRequest.asJson.noSpaces))
-    CosmosClient(request)
+    CosmosClient.doPost(
+      path = "package/install",
+      requestBody = installRequest,
+      contentType = MediaTypes.InstallRequest,
+      accept = MediaTypes.V1InstallResponse
+    )
   }
 
 }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -7,24 +7,34 @@ import com.mesosphere.cosmos.repository.DefaultRepositories
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
-import com.mesosphere.cosmos.rpc.v1.model.{ErrorResponse, InstallRequest, InstallResponse}
+import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
+import com.mesosphere.cosmos.rpc.v1.model.InstallRequest
+import com.mesosphere.cosmos.rpc.v1.model.InstallResponse
 import com.mesosphere.cosmos.rpc.v2.circe.Decoders._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
+import com.mesosphere.cosmos.test.CosmosRequest
 import com.mesosphere.cosmos.thirdparty.marathon.circe.Encoders._
 import com.mesosphere.cosmos.thirdparty.marathon.model._
 import com.mesosphere.universe
-import com.mesosphere.universe.v2.model.{PackageDetails, PackageDetailsVersion, PackageFiles, PackagingVersion}
+import com.mesosphere.universe.v2.model.PackageDetails
+import com.mesosphere.universe.v2.model.PackageDetailsVersion
+import com.mesosphere.universe.v2.model.PackageFiles
+import com.mesosphere.universe.v2.model.PackagingVersion
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http._
-import com.twitter.io.{Buf, Charsets}
-import com.twitter.util.{Await, Future}
+import com.twitter.io.Charsets
+import com.twitter.util.Await
+import com.twitter.util.Future
 import io.circe.jawn._
 import io.circe.syntax._
-import io.circe.{Json, JsonObject}
+import io.circe.Json
+import io.circe.JsonObject
+import java.util.Base64
+import java.util.UUID
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
-
-import java.util.{Base64, UUID}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FreeSpec
+import org.scalatest.Matchers
 
 final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAll {
 
@@ -195,12 +205,13 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
 
       val installRequest = InstallRequest("enterprise-security-cli")
 
-      val response = CosmosClient.doPost(
+      val request = CosmosRequest.post(
         path = "package/install",
-        requestBody = installRequest,
+        body = installRequest,
         contentType = MediaTypes.InstallRequest,
         accept = MediaTypes.V2InstallResponse
       )
+      val response = CosmosClient.submit(request)
 
       assertResult(Status.Ok)(response.status)
       assertResult(MediaTypes.V2InstallResponse.show)(response.contentType.get)
@@ -270,12 +281,13 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
   private[this] def installPackage(
     installRequest: InstallRequest
   ): Response = {
-    CosmosClient.doPost(
+    val request = CosmosRequest.post(
       path = "package/install",
-      requestBody = installRequest,
+      body = installRequest,
       contentType = MediaTypes.InstallRequest,
       accept = MediaTypes.V1InstallResponse
     )
+    CosmosClient.submit(request)
   }
 
 }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
@@ -8,6 +8,7 @@ import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
+import com.mesosphere.cosmos.test.CosmosRequest
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.http._
 import org.scalatest.BeforeAndAfter
@@ -148,12 +149,13 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
   private def sendAddRequest(
     addRequest: PackageRepositoryAddRequest
   ): Response = {
-    CosmosClient.doPost(
+    val request = CosmosRequest.post(
       path = "package/repository/add",
-      requestBody = addRequest,
+      body = addRequest,
       contentType = MediaTypes.PackageRepositoryAddRequest,
       accept = MediaTypes.PackageRepositoryAddResponse
     )
+    CosmosClient.submit(request)
   }
 
 }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
@@ -1,7 +1,8 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor
-import com.mesosphere.cosmos.repository.{DefaultRepositories, PackageRepositorySpec}
+import com.mesosphere.cosmos.repository.DefaultRepositories
+import com.mesosphere.cosmos.repository.PackageRepositorySpec
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
@@ -9,10 +10,9 @@ import com.mesosphere.cosmos.rpc.v1.model._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.http._
-import com.twitter.io.Buf
-import io.circe.syntax._
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FreeSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{BeforeAndAfter, FreeSpec}
 
 final class PackageRepositoryIntegrationSpec extends FreeSpec with BeforeAndAfter {
 
@@ -148,13 +148,12 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
   private def sendAddRequest(
     addRequest: PackageRepositoryAddRequest
   ): Response = {
-    val path = "package/repository/add"
-    val request = CosmosClient.requestBuilder(path)
-      .addHeader("Content-type", MediaTypes.PackageRepositoryAddRequest.show)
-      .addHeader("Accept", MediaTypes.PackageRepositoryAddResponse.show)
-      .buildPost(Buf.Utf8(addRequest.asJson.noSpaces))
-
-    CosmosClient(request)
+    CosmosClient.doPost(
+      path = "package/repository/add",
+      requestBody = addRequest,
+      contentType = MediaTypes.PackageRepositoryAddRequest,
+      accept = MediaTypes.PackageRepositoryAddResponse
+    )
   }
 
 }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
@@ -113,36 +113,39 @@ final class PackageRepositoryIntegrationSpec extends FreeSpec with BeforeAndAfte
 private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyChecks {
 
   private def listRepositories(): Seq[PackageRepository] = {
-    val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryListRequest, PackageRepositoryListResponse](
+    val request = CosmosRequest.post(
       "package/repository/list",
       PackageRepositoryListRequest(),
       MediaTypes.PackageRepositoryListRequest,
       MediaTypes.PackageRepositoryListResponse
     )
+    val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryListResponse](request)
     response.repositories
   }
 
   private def addRepository(
     source: PackageRepository
   ): PackageRepositoryAddResponse = {
-    val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryAddRequest, PackageRepositoryAddResponse](
+    val request = CosmosRequest.post(
       "package/repository/add",
       PackageRepositoryAddRequest(source.name, source.uri),
       MediaTypes.PackageRepositoryAddRequest,
       MediaTypes.PackageRepositoryAddResponse
     )
+    val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryAddResponse](request)
     response
   }
 
   private def deleteRepository(
     source: PackageRepository
   ): PackageRepositoryDeleteResponse = {
-    val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryDeleteRequest, PackageRepositoryDeleteResponse](
+    val request = CosmosRequest.post(
       "package/repository/delete",
       PackageRepositoryDeleteRequest(name = Some(source.name)),
       MediaTypes.PackageRepositoryDeleteRequest,
       MediaTypes.PackageRepositoryDeleteResponse
     )
+    val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryDeleteResponse](request)
     response
   }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
@@ -153,10 +153,10 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
     addRequest: PackageRepositoryAddRequest
   ): Response = {
     val request = CosmosRequest.post(
-      path = "package/repository/add",
-      body = addRequest,
-      contentType = MediaTypes.PackageRepositoryAddRequest,
-      accept = MediaTypes.PackageRepositoryAddResponse
+      "package/repository/add",
+      addRequest,
+      MediaTypes.PackageRepositoryAddRequest,
+      MediaTypes.PackageRepositoryAddResponse
     )
     CosmosClient.submit(request)
   }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -47,10 +47,10 @@ final class PackageSearchSpec extends FreeSpec {
     expectedResponse: SearchResponse
   ): Unit = {
     val request = CosmosRequest.post(
-      path = "package/search",
-      body = SearchRequest(Some(query)),
-      contentType = MediaTypes.SearchRequest,
-      accept = MediaTypes.SearchResponse
+      "package/search",
+      SearchRequest(Some(query)),
+      MediaTypes.SearchRequest,
+      MediaTypes.SearchResponse
     )
     val response = CosmosClient.submit(request)
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -8,6 +8,7 @@ import com.mesosphere.cosmos.rpc.v1.model.SearchRequest
 import com.mesosphere.cosmos.rpc.v1.model.SearchResponse
 import com.mesosphere.cosmos.rpc.v1.model.SearchResult
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
+import com.mesosphere.cosmos.test.CosmosRequest
 import com.mesosphere.universe
 import com.twitter.finagle.http._
 import io.circe.jawn._
@@ -45,12 +46,13 @@ final class PackageSearchSpec extends FreeSpec {
     status: Status,
     expectedResponse: SearchResponse
   ): Unit = {
-    val response = CosmosClient.doPost(
+    val request = CosmosRequest.post(
       path = "package/search",
-      requestBody = SearchRequest(Some(query)),
+      body = SearchRequest(Some(query)),
       contentType = MediaTypes.SearchRequest,
       accept = MediaTypes.SearchResponse
     )
+    val response = CosmosClient.submit(request)
 
     assertResult(status)(response.status)
     val Right(actualResponse) = decode[SearchResponse](response.contentString)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -4,13 +4,13 @@ import cats.data.Xor.Right
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
-import com.mesosphere.cosmos.rpc.v1.model.{SearchRequest, SearchResponse, SearchResult}
+import com.mesosphere.cosmos.rpc.v1.model.SearchRequest
+import com.mesosphere.cosmos.rpc.v1.model.SearchResponse
+import com.mesosphere.cosmos.rpc.v1.model.SearchResult
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
 import com.mesosphere.universe
 import com.twitter.finagle.http._
-import com.twitter.io.Buf
 import io.circe.jawn._
-import io.circe.syntax._
 import org.scalatest.FreeSpec
 import org.scalatest.prop.TableDrivenPropertyChecks
 
@@ -45,11 +45,13 @@ final class PackageSearchSpec extends FreeSpec {
     status: Status,
     expectedResponse: SearchResponse
   ): Unit = {
-    val request = CosmosClient.requestBuilder("package/search")
-      .addHeader("Content-Type", MediaTypes.SearchRequest.show)
-      .addHeader("Accept", MediaTypes.SearchResponse.show)
-      .buildPost(Buf.Utf8(SearchRequest(Some(query)).asJson.noSpaces))
-    val response = CosmosClient(request)
+    val response = CosmosClient.doPost(
+      path = "package/search",
+      requestBody = SearchRequest(Some(query)),
+      contentType = MediaTypes.SearchRequest,
+      accept = MediaTypes.SearchResponse
+    )
+
     assertResult(status)(response.status)
     val Right(actualResponse) = decode[SearchResponse](response.contentString)
     assertResult(expectedResponse)(actualResponse)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.FreeSpec
 final class CapabilitiesHandlerSpec extends FreeSpec {
 
   "The capabilities handler should return a document" in {
-    val request = CosmosRequest.get(path = "capabilities", accept = MediaTypes.CapabilitiesResponse)
+    val request = CosmosRequest.get("capabilities", MediaTypes.CapabilitiesResponse)
     val response = CosmosClient.submit(request)
 
     assertResult(Status.Ok)(response.status)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
@@ -3,8 +3,10 @@ package com.mesosphere.cosmos.handler
 import cats.data.Xor
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
-import com.mesosphere.cosmos.rpc.v1.model.{CapabilitiesResponse, Capability}
+import com.mesosphere.cosmos.rpc.v1.model.CapabilitiesResponse
+import com.mesosphere.cosmos.rpc.v1.model.Capability
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
+import com.mesosphere.cosmos.test.CosmosRequest
 import com.twitter.finagle.http.Status
 import io.circe.jawn._
 import org.scalatest.FreeSpec
@@ -12,10 +14,8 @@ import org.scalatest.FreeSpec
 final class CapabilitiesHandlerSpec extends FreeSpec {
 
   "The capabilities handler should return a document" in {
-    val response = CosmosClient.doGet(
-      path = "capabilities",
-      accept = MediaTypes.CapabilitiesResponse
-    )
+    val request = CosmosRequest.get(path = "capabilities", accept = MediaTypes.CapabilitiesResponse)
+    val response = CosmosClient.submit(request)
 
     assertResult(Status.Ok)(response.status)
     assertResult(MediaTypes.CapabilitiesResponse.show)(response.headerMap("Content-Type"))

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
@@ -12,14 +12,14 @@ import org.scalatest.FreeSpec
 final class CapabilitiesHandlerSpec extends FreeSpec {
 
   "The capabilities handler should return a document" in {
-    val request = CosmosClient.requestBuilder("capabilities")
-      .setHeader("Accept", MediaTypes.CapabilitiesResponse.show)
-      .buildGet()
-    val response = CosmosClient(request)
-    val responseBody = response.contentString
+    val response = CosmosClient.doGet(
+      path = "capabilities",
+      accept = MediaTypes.CapabilitiesResponse
+    )
+
     assertResult(Status.Ok)(response.status)
     assertResult(MediaTypes.CapabilitiesResponse.show)(response.headerMap("Content-Type"))
-    val Xor.Right(body) = decode[CapabilitiesResponse](responseBody)
+    val Xor.Right(body) = decode[CapabilitiesResponse](response.contentString)
     val expected = CapabilitiesResponse(List(
       Capability("PACKAGE_MANAGEMENT"),
       Capability("SUPPORT_CLUSTER_REPORT"),

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
@@ -96,10 +96,10 @@ object PackageRenderHandlerSpec {
 
   def packageRender(renderRequest: RenderRequest): Response = {
     val request = CosmosRequest.post(
-      path = "package/render",
-      body = renderRequest,
-      contentType = MediaTypes.RenderRequest,
-      accept = MediaTypes.RenderResponse
+      "package/render",
+      renderRequest,
+      MediaTypes.RenderRequest,
+      MediaTypes.RenderResponse
     )
     CosmosClient.submit(request)
   }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
@@ -8,6 +8,7 @@ import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.rpc.v1.model.RenderRequest
 import com.mesosphere.cosmos.rpc.v1.model.RenderResponse
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
+import com.mesosphere.cosmos.test.CosmosRequest
 import com.mesosphere.universe.v2.model.PackageDetailsVersion
 import com.twitter.finagle.http.Response
 import com.twitter.finagle.http.Status
@@ -94,12 +95,13 @@ class PackageRenderHandlerSpec extends FreeSpec {
 object PackageRenderHandlerSpec {
 
   def packageRender(renderRequest: RenderRequest): Response = {
-    CosmosClient.doPost(
+    val request = CosmosRequest.post(
       path = "package/render",
-      requestBody = renderRequest,
+      body = renderRequest,
       contentType = MediaTypes.RenderRequest,
       accept = MediaTypes.RenderResponse
     )
+    CosmosClient.submit(request)
   }
 
 }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/RequestErrorsSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/RequestErrorsSpec.scala
@@ -33,10 +33,10 @@ class RequestErrorsSpec extends FreeSpec {
         ).asJson
 
         val request = CosmosRequest.post(
-          path = "package/install",
-          body = body.noSpaces,
-          contentType = Some(MediaTypes.DescribeRequest.show),
-          accept = Some(accept.show)
+          "package/install",
+          body.noSpaces,
+          Some(MediaTypes.DescribeRequest.show),
+          Some(accept.show)
         )
         val response = CosmosClient.submit(request)
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/RequestErrorsSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/RequestErrorsSpec.scala
@@ -30,14 +30,15 @@ class RequestErrorsSpec extends FreeSpec {
           "bad",
           "http://bad/repo",
           Some(0)
-        ).asJson
+        )
 
-        val req = CosmosClient.requestBuilder("package/install")
-          .addHeader("Accept", accept.show)
-          .addHeader("Content-Type", MediaTypes.DescribeRequest.show)
-          .buildPost(Buf.Utf8(body.noSpaces))
+        val response = CosmosClient.doPost(
+          path = "package/install",
+          requestBody = body,
+          contentType = MediaTypes.DescribeRequest.show,
+          accept = accept.show
+        )
 
-        val response = CosmosClient(req)
         assertResult(Status.BadRequest)(response.status)
         assertResult(MediaTypes.ErrorResponse.show)(response.headerMap("Content-Type"))
         val Xor.Right(obj: JsonObject) = parse(response.contentString).map(jsonToJsonObject)
@@ -87,10 +88,13 @@ class RequestErrorsSpec extends FreeSpec {
       }
 
       "Missing Accept, Missing Content-Type, Missing body" in {
-        val req = CosmosClient.requestBuilder("package/install")
-          .buildPost(Buf.Utf8(""))
+        val response = CosmosClient.doPost(
+          path = "package/install",
+          requestBody = "",
+          contentType = None,
+          accept = None
+        )
 
-        val response = CosmosClient(req)
         assertResult(Status.BadRequest)(response.status)
         assertResult(MediaTypes.ErrorResponse.show)(response.headerMap("Content-Type"))
         val Xor.Right(obj: JsonObject) = parse(response.contentString).map(jsonToJsonObject)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/RequestErrorsSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/RequestErrorsSpec.scala
@@ -30,13 +30,13 @@ class RequestErrorsSpec extends FreeSpec {
           "bad",
           "http://bad/repo",
           Some(0)
-        )
+        ).asJson
 
         val response = CosmosClient.doPost(
           path = "package/install",
-          requestBody = body,
-          contentType = MediaTypes.DescribeRequest.show,
-          accept = accept.show
+          requestBody = body.noSpaces,
+          contentType = Some(MediaTypes.DescribeRequest.show),
+          accept = Some(accept.show)
         )
 
         assertResult(Status.BadRequest)(response.status)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/RequestErrorsSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/RequestErrorsSpec.scala
@@ -1,19 +1,19 @@
 package com.mesosphere.cosmos.handler
 
 import cats.data.Xor
-import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.http.CompoundMediaTypeParser
-import com.mesosphere.cosmos.rpc.v1.model.PackageRepositoryAddRequest
+import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
+import com.mesosphere.cosmos.rpc.v1.model.PackageRepositoryAddRequest
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
+import com.mesosphere.cosmos.test.CosmosRequest
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.http.Status
-import com.twitter.io.Buf
-import io.circe.{Json, JsonObject}
 import io.circe.jawn._
 import io.circe.syntax._
+import io.circe.Json
+import io.circe.JsonObject
 import org.scalatest.FreeSpec
-
 import scala.language.implicitConversions
 
 class RequestErrorsSpec extends FreeSpec {
@@ -32,12 +32,13 @@ class RequestErrorsSpec extends FreeSpec {
           Some(0)
         ).asJson
 
-        val response = CosmosClient.doPost(
+        val request = CosmosRequest.post(
           path = "package/install",
-          requestBody = body.noSpaces,
+          body = body.noSpaces,
           contentType = Some(MediaTypes.DescribeRequest.show),
           accept = Some(accept.show)
         )
+        val response = CosmosClient.submit(request)
 
         assertResult(Status.BadRequest)(response.status)
         assertResult(MediaTypes.ErrorResponse.show)(response.headerMap("Content-Type"))
@@ -88,12 +89,13 @@ class RequestErrorsSpec extends FreeSpec {
       }
 
       "Missing Accept, Missing Content-Type, Missing body" in {
-        val response = CosmosClient.doPost(
+        val request = CosmosRequest.post(
           path = "package/install",
-          requestBody = "",
+          body = "",
           contentType = None,
           accept = None
         )
+        val response = CosmosClient.submit(request)
 
         assertResult(Status.BadRequest)(response.status)
         assertResult(MediaTypes.ErrorResponse.show)(response.headerMap("Content-Type"))

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
@@ -23,10 +23,10 @@ final class UninstallHandlerSpec extends FreeSpec {
     "be able to uninstall a service" in {
       val appId = AppId("cassandra" / "uninstall-test")
       val installRequest = CosmosRequest.post(
-        path = "package/install",
-        body = s"""{"packageName":"cassandra", "appId":"${appId.toString}"}""",
-        contentType = Some(MediaTypes.InstallRequest.show),
-        accept = Some(MediaTypes.V1InstallResponse.show)
+        "package/install",
+        s"""{"packageName":"cassandra", "appId":"${appId.toString}"}""",
+        Some(MediaTypes.InstallRequest.show),
+        Some(MediaTypes.V1InstallResponse.show)
       )
       val installResponse = CosmosClient.submit(installRequest)
       assertResult(Status.Ok)(installResponse.status)
@@ -37,10 +37,10 @@ final class UninstallHandlerSpec extends FreeSpec {
       //TODO: Assert framework starts up
 
       val uninstallRequest = CosmosRequest.post(
-        path = "package/uninstall",
-        body = """{"packageName":"cassandra"}""",
-        contentType = Some(MediaTypes.UninstallRequest.show),
-        accept = Some(MediaTypes.UninstallResponse.show)
+        "package/uninstall",
+        """{"packageName":"cassandra"}""",
+        Some(MediaTypes.UninstallRequest.show),
+        Some(MediaTypes.UninstallResponse.show)
       )
       val uninstallResponse = CosmosClient.submit(uninstallRequest)
       val uninstallResponseBody = uninstallResponse.contentString
@@ -54,29 +54,29 @@ final class UninstallHandlerSpec extends FreeSpec {
       // install 'helloworld' twice
       val installBody1 = s"""{"packageName":"helloworld", "appId":"${UUID.randomUUID()}"}"""
       val installRequest1 = CosmosRequest.post(
-        path = "package/install",
-        body = installBody1,
-        contentType = Some(MediaTypes.InstallRequest.show),
-        accept = Some(MediaTypes.V1InstallResponse.show)
+        "package/install",
+        installBody1,
+        Some(MediaTypes.InstallRequest.show),
+        Some(MediaTypes.V1InstallResponse.show)
       )
       val installResponse1 = CosmosClient.submit(installRequest1)
       assertResult(Status.Ok, s"install failed: $installBody1")(installResponse1.status)
 
       val installBody2 = s"""{"packageName":"helloworld", "appId":"${UUID.randomUUID()}"}"""
       val installRequest2 = CosmosRequest.post(
-        path = "package/install",
-        body = installBody2,
-        contentType = Some(MediaTypes.InstallRequest.show),
-        accept = Some(MediaTypes.V1InstallResponse.show)
+        "package/install",
+        installBody2,
+        Some(MediaTypes.InstallRequest.show),
+        Some(MediaTypes.V1InstallResponse.show)
       )
       val installResponse2 = CosmosClient.submit(installRequest2)
       assertResult(Status.Ok, s"install failed: $installBody2")(installResponse2.status)
 
       val uninstallRequest = CosmosRequest.post(
-        path = "package/uninstall",
-        body = """{"packageName":"helloworld", "all":true}""",
-        contentType = Some(MediaTypes.UninstallRequest.show),
-        accept = Some(MediaTypes.UninstallResponse.show)
+        "package/uninstall",
+        """{"packageName":"helloworld", "all":true}""",
+        Some(MediaTypes.UninstallRequest.show),
+        Some(MediaTypes.UninstallResponse.show)
       )
       val uninstallResponse = CosmosClient.submit(uninstallRequest)
       assertResult(Status.Ok)(uninstallResponse.status)
@@ -88,10 +88,10 @@ final class UninstallHandlerSpec extends FreeSpec {
       val appId1 = UUID.randomUUID()
       val installBody1 = s"""{"packageName":"helloworld", "appId":"$appId1"}"""
       val installRequest1 = CosmosRequest.post(
-        path = "package/install",
-        body = installBody1,
-        contentType = Some(MediaTypes.InstallRequest.show),
-        accept = Some(MediaTypes.V1InstallResponse.show)
+        "package/install",
+        installBody1,
+        Some(MediaTypes.InstallRequest.show),
+        Some(MediaTypes.V1InstallResponse.show)
       )
       val installResponse1 = CosmosClient.submit(installRequest1)
       assertResult(Status.Ok, s"install failed: $installBody1")(installResponse1.status)
@@ -99,19 +99,19 @@ final class UninstallHandlerSpec extends FreeSpec {
       val appId2 = UUID.randomUUID()
       val installBody2 = s"""{"packageName":"helloworld", "appId":"$appId2"}"""
       val installRequest2 = CosmosRequest.post(
-        path = "package/install",
-        body = installBody2,
-        contentType = Some(MediaTypes.InstallRequest.show),
-        accept = Some(MediaTypes.V1InstallResponse.show)
+        "package/install",
+        installBody2,
+        Some(MediaTypes.InstallRequest.show),
+        Some(MediaTypes.V1InstallResponse.show)
       )
       val installResponse2 = CosmosClient.submit(installRequest2)
       assertResult(Status.Ok, s"install failed: $installBody2")(installResponse2.status)
 
       val uninstallRequest = CosmosRequest.post(
-        path = "package/uninstall",
-        body = """{"packageName":"helloworld"}""",
-        contentType = Some(MediaTypes.UninstallRequest.show),
-        accept = Some(MediaTypes.UninstallResponse.show)
+        "package/uninstall",
+        """{"packageName":"helloworld"}""",
+        Some(MediaTypes.UninstallRequest.show),
+        Some(MediaTypes.UninstallResponse.show)
       )
       val uninstallResponse = CosmosClient.submit(uninstallRequest)
       val uninstallResponseBody = uninstallResponse.contentString
@@ -121,10 +121,10 @@ final class UninstallHandlerSpec extends FreeSpec {
       assertResult(s"Multiple apps named [helloworld] are installed: [/$appId1, /$appId2]")(err.message)
 
       val cleanupRequest = CosmosRequest.post(
-        path = "package/uninstall",
-        body = """{"packageName":"helloworld", "all":true}""",
-        contentType = Some(MediaTypes.UninstallRequest.show),
-        accept = Some(MediaTypes.UninstallResponse.show)
+        "package/uninstall",
+        """{"packageName":"helloworld", "all":true}""",
+        Some(MediaTypes.UninstallRequest.show),
+        Some(MediaTypes.UninstallResponse.show)
       )
       val cleanupResponse = CosmosClient.submit(cleanupRequest)
       assertResult(Status.Ok)(cleanupResponse.status)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
@@ -1,17 +1,17 @@
 package com.mesosphere.cosmos.handler
 
-import java.util.UUID
 import cats.data.Xor
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
-import com.mesosphere.cosmos.rpc.v1.model.{ErrorResponse, UninstallResponse}
+import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
+import com.mesosphere.cosmos.rpc.v1.model.UninstallResponse
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.http.Status
-import com.twitter.io.Buf
 import com.twitter.util.Await
 import io.circe.jawn._
+import java.util.UUID
 import org.scalatest.FreeSpec
 
 final class UninstallHandlerSpec extends FreeSpec {
@@ -21,11 +21,12 @@ final class UninstallHandlerSpec extends FreeSpec {
   "The uninstall handler should" - {
     "be able to uninstall a service" in {
       val appId = AppId("cassandra" / "uninstall-test")
-      val installRequest = CosmosClient.requestBuilder("package/install")
-        .addHeader("Content-Type", MediaTypes.InstallRequest.show)
-        .addHeader("Accept", MediaTypes.V1InstallResponse.show)
-        .buildPost(Buf.Utf8(s"""{"packageName":"cassandra", "appId":"${appId.toString}"}"""))
-      val installResponse = CosmosClient(installRequest)
+      val installResponse = CosmosClient.doPost(
+        path = "package/install",
+        requestBody = s"""{"packageName":"cassandra", "appId":"${appId.toString}"}""",
+        contentType = Some(MediaTypes.InstallRequest.show),
+        accept = Some(MediaTypes.V1InstallResponse.show)
+      )
       assertResult(Status.Ok)(installResponse.status)
 
       val marathonApp = Await.result(adminRouter.getApp(appId))
@@ -33,11 +34,12 @@ final class UninstallHandlerSpec extends FreeSpec {
 
       //TODO: Assert framework starts up
 
-      val uninstallRequest = CosmosClient.requestBuilder("package/uninstall")
-        .setHeader("Accept", MediaTypes.UninstallResponse.show)
-        .setHeader("Content-Type", MediaTypes.UninstallRequest.show)
-        .buildPost(Buf.Utf8("""{"packageName":"cassandra"}"""))
-      val uninstallResponse = CosmosClient(uninstallRequest)
+      val uninstallResponse = CosmosClient.doPost(
+        path = "package/uninstall",
+        requestBody = """{"packageName":"cassandra"}""",
+        contentType = Some(MediaTypes.UninstallRequest.show),
+        accept = Some(MediaTypes.UninstallResponse.show)
+      )
       val uninstallResponseBody = uninstallResponse.contentString
       assertResult(Status.Ok)(uninstallResponse.status)
       assertResult(MediaTypes.UninstallResponse.show)(uninstallResponse.headerMap("Content-Type"))
@@ -48,26 +50,29 @@ final class UninstallHandlerSpec extends FreeSpec {
     "be able to uninstall multiple packages when 'all' is specified" in {
       // install 'helloworld' twice
       val installBody1 = s"""{"packageName":"helloworld", "appId":"${UUID.randomUUID()}"}"""
-      val installRequest1 = CosmosClient.requestBuilder("package/install")
-        .addHeader("Content-Type", MediaTypes.InstallRequest.show)
-        .addHeader("Accept", MediaTypes.V1InstallResponse.show)
-        .buildPost(Buf.Utf8(installBody1))
-      val installResponse1 = CosmosClient(installRequest1)
+      val installResponse1 = CosmosClient.doPost(
+        path = "package/install",
+        requestBody = installBody1,
+        contentType = Some(MediaTypes.InstallRequest.show),
+        accept = Some(MediaTypes.V1InstallResponse.show)
+      )
       assertResult(Status.Ok, s"install failed: $installBody1")(installResponse1.status)
 
       val installBody2 = s"""{"packageName":"helloworld", "appId":"${UUID.randomUUID()}"}"""
-      val installRequest2 = CosmosClient.requestBuilder("package/install")
-        .addHeader("Content-Type", MediaTypes.InstallRequest.show)
-        .addHeader("Accept", MediaTypes.V1InstallResponse.show)
-        .buildPost(Buf.Utf8(installBody2))
-      val installResponse2 = CosmosClient(installRequest2)
+      val installResponse2 = CosmosClient.doPost(
+        path = "package/install",
+        requestBody = installBody2,
+        contentType = Some(MediaTypes.InstallRequest.show),
+        accept = Some(MediaTypes.V1InstallResponse.show)
+      )
       assertResult(Status.Ok, s"install failed: $installBody2")(installResponse2.status)
 
-      val uninstallRequest = CosmosClient.requestBuilder("package/uninstall")
-        .setHeader("Accept", MediaTypes.UninstallResponse.show)
-        .setHeader("Content-Type", MediaTypes.UninstallRequest.show)
-        .buildPost(Buf.Utf8("""{"packageName":"helloworld", "all":true}"""))
-      val uninstallResponse = CosmosClient(uninstallRequest)
+      val uninstallResponse = CosmosClient.doPost(
+        path = "package/uninstall",
+        requestBody = """{"packageName":"helloworld", "all":true}""",
+        contentType = Some(MediaTypes.UninstallRequest.show),
+        accept = Some(MediaTypes.UninstallResponse.show)
+      )
       assertResult(Status.Ok)(uninstallResponse.status)
       assertResult(MediaTypes.UninstallResponse.show)(uninstallResponse.headerMap("Content-Type"))
     }
@@ -76,38 +81,42 @@ final class UninstallHandlerSpec extends FreeSpec {
       // install 'helloworld' twice
       val appId1 = UUID.randomUUID()
       val installBody1 = s"""{"packageName":"helloworld", "appId":"$appId1"}"""
-      val installRequest1 = CosmosClient.requestBuilder("package/install")
-        .addHeader("Content-Type", MediaTypes.InstallRequest.show)
-        .addHeader("Accept", MediaTypes.V1InstallResponse.show)
-        .buildPost(Buf.Utf8(installBody1))
-      val installResponse1 = CosmosClient(installRequest1)
+      val installResponse1 = CosmosClient.doPost(
+        path = "package/install",
+        requestBody = installBody1,
+        contentType = Some(MediaTypes.InstallRequest.show),
+        accept = Some(MediaTypes.V1InstallResponse.show)
+      )
       assertResult(Status.Ok, s"install failed: $installBody1")(installResponse1.status)
 
       val appId2 = UUID.randomUUID()
       val installBody2 = s"""{"packageName":"helloworld", "appId":"$appId2"}"""
-      val installRequest2 = CosmosClient.requestBuilder("package/install")
-        .addHeader("Content-Type", MediaTypes.InstallRequest.show)
-        .addHeader("Accept", MediaTypes.V1InstallResponse.show)
-        .buildPost(Buf.Utf8(installBody2))
-      val installResponse2 = CosmosClient(installRequest2)
+      val installResponse2 = CosmosClient.doPost(
+        path = "package/install",
+        requestBody = installBody2,
+        contentType = Some(MediaTypes.InstallRequest.show),
+        accept = Some(MediaTypes.V1InstallResponse.show)
+      )
       assertResult(Status.Ok, s"install failed: $installBody2")(installResponse2.status)
 
-      val uninstallRequest = CosmosClient.requestBuilder("package/uninstall")
-        .setHeader("Accept", MediaTypes.UninstallResponse.show)
-        .setHeader("Content-Type", MediaTypes.UninstallRequest.show)
-        .buildPost(Buf.Utf8("""{"packageName":"helloworld"}"""))
-      val uninstallResponse = CosmosClient(uninstallRequest)
+      val uninstallResponse = CosmosClient.doPost(
+        path = "package/uninstall",
+        requestBody = """{"packageName":"helloworld"}""",
+        contentType = Some(MediaTypes.UninstallRequest.show),
+        accept = Some(MediaTypes.UninstallResponse.show)
+      )
       val uninstallResponseBody = uninstallResponse.contentString
       assertResult(Status.BadRequest)(uninstallResponse.status)
       assertResult(MediaTypes.ErrorResponse.show)(uninstallResponse.headerMap("Content-Type"))
       val Xor.Right(err) = decode[ErrorResponse](uninstallResponseBody)
       assertResult(s"Multiple apps named [helloworld] are installed: [/$appId1, /$appId2]")(err.message)
 
-      val cleanupRequest = CosmosClient.requestBuilder("package/uninstall")
-        .setHeader("Accept", MediaTypes.UninstallResponse.show)
-        .setHeader("Content-Type", MediaTypes.UninstallRequest.show)
-        .buildPost(Buf.Utf8("""{"packageName":"helloworld", "all":true}"""))
-      val cleanupResponse = CosmosClient(cleanupRequest)
+      val cleanupResponse = CosmosClient.doPost(
+        path = "package/uninstall",
+        requestBody = """{"packageName":"helloworld", "all":true}""",
+        contentType = Some(MediaTypes.UninstallRequest.show),
+        accept = Some(MediaTypes.UninstallResponse.show)
+      )
       assertResult(Status.Ok)(cleanupResponse.status)
     }
   }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
@@ -319,10 +319,10 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
 
     assertResult(expectedErrorMessage) {
       val request = CosmosRequest.post(
-        path = "package/repository/add",
-        body = PackageRepositoryAddRequest(repository.name, repository.uri),
-        contentType = MediaTypes.PackageRepositoryAddRequest,
-        accept = MediaTypes.PackageRepositoryAddResponse
+        "package/repository/add",
+        PackageRepositoryAddRequest(repository.name, repository.uri),
+        MediaTypes.PackageRepositoryAddRequest,
+        MediaTypes.PackageRepositoryAddResponse
       )
       val response = CosmosClient.submit(request)
       assertResult(Status.BadRequest)(response.status)
@@ -372,10 +372,10 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
 
   private def searchPackages(req: SearchRequest): Response = {
     val request = CosmosRequest.post(
-      path = "package/search",
-      body = req,
-      contentType = MediaTypes.SearchRequest,
-      accept = MediaTypes.SearchResponse
+      "package/search",
+      req,
+      MediaTypes.SearchRequest,
+      MediaTypes.SearchResponse
     )
     CosmosClient.submit(request)
   }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
@@ -7,15 +7,20 @@ import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
+import com.mesosphere.cosmos.test.CosmosRequest
 import com.mesosphere.universe.common.circe.Encoders._
 import com.netaporter.uri.Uri
 import com.twitter.finagle.http._
 import io.circe.jawn._
 import io.circe.syntax._
-import io.circe.{Encoder, Json, JsonObject}
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.JsonObject
 import org.scalatest.concurrent.Eventually
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{AppendedClues, BeforeAndAfter, FreeSpec}
+import org.scalatest.AppendedClues
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FreeSpec
 
 final class PackageRepositorySpec
   extends FreeSpec with BeforeAndAfter with Eventually with AppendedClues {
@@ -313,13 +318,13 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
     val repositoriesBeforeAdd = listRepos()
 
     assertResult(expectedErrorMessage) {
-      val addRequest = PackageRepositoryAddRequest(repository.name, repository.uri)
-      val response = CosmosClient.doPost(
-        "package/repository/add",
-        addRequest,
-        MediaTypes.PackageRepositoryAddRequest,
-        MediaTypes.PackageRepositoryAddResponse
+      val request = CosmosRequest.post(
+        path = "package/repository/add",
+        body = PackageRepositoryAddRequest(repository.name, repository.uri),
+        contentType = MediaTypes.PackageRepositoryAddRequest,
+        accept = MediaTypes.PackageRepositoryAddResponse
       )
+      val response = CosmosClient.submit(request)
       assertResult(Status.BadRequest)(response.status)
       val Xor.Right(err) = decode[ErrorResponse](response.contentString)
       err.message
@@ -364,12 +369,13 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
   }
 
   private def searchPackages(req: SearchRequest): Response = {
-    CosmosClient.doPost(
-      "package/search",
-      req,
-      MediaTypes.SearchRequest,
-      MediaTypes.SearchResponse
+    val request = CosmosRequest.post(
+      path = "package/search",
+      body = req,
+      contentType = MediaTypes.SearchRequest,
+      accept = MediaTypes.SearchResponse
     )
+    CosmosClient.submit(request)
   }
 
   private[this] def deleteRequestByName(

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
@@ -314,13 +314,12 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
 
     assertResult(expectedErrorMessage) {
       val addRequest = PackageRepositoryAddRequest(repository.name, repository.uri)
-      val post = CosmosClient.buildPost(
+      val response = CosmosClient.doPost(
         "package/repository/add",
         addRequest,
         MediaTypes.PackageRepositoryAddRequest,
         MediaTypes.PackageRepositoryAddResponse
       )
-      val response = CosmosClient(post)
       assertResult(Status.BadRequest)(response.status)
       val Xor.Right(err) = decode[ErrorResponse](response.contentString)
       err.message
@@ -365,13 +364,12 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
   }
 
   private def searchPackages(req: SearchRequest): Response = {
-    val request = CosmosClient.buildPost(
+    CosmosClient.doPost(
       "package/search",
       req,
       MediaTypes.SearchRequest,
       MediaTypes.SearchResponse
     )
-    CosmosClient(request)
   }
 
   private[this] def deleteRequestByName(

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
@@ -336,12 +336,13 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
   }
 
   private def addRepo(addRequest: PackageRepositoryAddRequest): PackageRepositoryAddResponse  = {
-    val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryAddRequest, PackageRepositoryAddResponse](
+    val request = CosmosRequest.post(
       "package/repository/add",
       addRequest,
       MediaTypes.PackageRepositoryAddRequest,
       MediaTypes.PackageRepositoryAddResponse
     )
+    val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryAddResponse](request)
     response
   }
 
@@ -349,22 +350,23 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
     deleteRequest: PackageRepositoryDeleteRequest,
     status: Status = Status.Ok
   ): Xor[ErrorResponse, PackageRepositoryDeleteResponse]  = {
-    CosmosClient.callEndpoint[PackageRepositoryDeleteRequest, PackageRepositoryDeleteResponse](
+    val request = CosmosRequest.post(
       "package/repository/delete",
       deleteRequest,
       MediaTypes.PackageRepositoryDeleteRequest,
-      MediaTypes.PackageRepositoryDeleteResponse,
-      status
+      MediaTypes.PackageRepositoryDeleteResponse
     )
+    CosmosClient.callEndpoint[PackageRepositoryDeleteResponse](request, status)
   }
 
   private def listRepos(): PackageRepositoryListResponse = {
-    val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryListRequest, PackageRepositoryListResponse](
+    val request = CosmosRequest.post(
       "package/repository/list",
       PackageRepositoryListRequest(),
       MediaTypes.PackageRepositoryListRequest,
       MediaTypes.PackageRepositoryListResponse
     )
+    val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryListResponse](request)
     response
   }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/rpc/v1/model/ErrorResponseSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/rpc/v1/model/ErrorResponseSpec.scala
@@ -13,10 +13,10 @@ class ErrorResponseSpec extends FreeSpec {
 
   "An ErrorResponse should be returned as the body when a request can't be parsed" in {
     val request = CosmosRequest.post(
-      path = "package/install",
-      body = Map("invalid" -> true),
-      contentType = MediaTypes.InstallRequest,
-      accept = MediaTypes.V1InstallResponse
+      "package/install",
+      Map("invalid" -> true),
+      MediaTypes.InstallRequest,
+      MediaTypes.V1InstallResponse
     )
     val response = CosmosClient.submit(request)
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/rpc/v1/model/ErrorResponseSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/rpc/v1/model/ErrorResponseSpec.scala
@@ -4,6 +4,7 @@ import cats.data.Xor
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
+import com.mesosphere.cosmos.test.CosmosRequest
 import com.twitter.finagle.http.Status
 import io.circe.jawn._
 import org.scalatest.FreeSpec
@@ -11,12 +12,13 @@ import org.scalatest.FreeSpec
 class ErrorResponseSpec extends FreeSpec {
 
   "An ErrorResponse should be returned as the body when a request can't be parsed" in {
-    val response = CosmosClient.doPost(
+    val request = CosmosRequest.post(
       path = "package/install",
-      requestBody = Map("invalid" -> true),
+      body = Map("invalid" -> true),
       contentType = MediaTypes.InstallRequest,
       accept = MediaTypes.V1InstallResponse
     )
+    val response = CosmosClient.submit(request)
 
     assertResult(Status.BadRequest)(response.status)
     assertResult(MediaTypes.ErrorResponse.show)(response.headerMap("Content-Type"))

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/rpc/v1/model/ErrorResponseSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/rpc/v1/model/ErrorResponseSpec.scala
@@ -5,20 +5,18 @@ import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
 import com.twitter.finagle.http.Status
-import com.twitter.io.Buf
 import io.circe.jawn._
-import io.circe.syntax._
 import org.scalatest.FreeSpec
 
 class ErrorResponseSpec extends FreeSpec {
 
   "An ErrorResponse should be returned as the body when a request can't be parsed" in {
-    val requestString = Map("invalid" -> true).asJson.noSpaces
-    val post = CosmosClient.requestBuilder("package/install")
-      .addHeader("Content-Type", MediaTypes.InstallRequest.show)
-      .addHeader("Accept", MediaTypes.V1InstallResponse.show)
-      .buildPost(Buf.Utf8(requestString))
-    val response = CosmosClient(post)
+    val response = CosmosClient.doPost(
+      path = "package/install",
+      requestBody = Map("invalid" -> true),
+      contentType = MediaTypes.InstallRequest,
+      accept = MediaTypes.V1InstallResponse
+    )
 
     assertResult(Status.BadRequest)(response.status)
     assertResult(MediaTypes.ErrorResponse.show)(response.headerMap("Content-Type"))

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/test/CosmosIntegrationTestClient.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/test/CosmosIntegrationTestClient.scala
@@ -83,28 +83,6 @@ object CosmosIntegrationTestClient extends Matchers {
         .getOrElse(throw new AssertionError(s"Missing system property '$property' "))
     }
 
-    def doGet(path: String, accept: MediaType): Response = {
-      submit(CosmosRequest.get(path, accept))
-    }
-
-    def doPost[Req](
-      path: String,
-      requestBody: Req,
-      contentType: MediaType,
-      accept: MediaType
-    )(implicit encoder: Encoder[Req]): Response = {
-      submit(CosmosRequest.post(path, requestBody, contentType, accept))
-    }
-
-    def doPost(
-      path: String,
-      requestBody: String,
-      contentType: Option[String],
-      accept: Option[String]
-    ): Response = {
-      submit(CosmosRequest.post(path, requestBody, contentType, accept))
-    }
-
     def callEndpoint[Req, Res](
       path: String,
       requestBody: Req,
@@ -191,7 +169,7 @@ object CosmosIntegrationTestClient extends Matchers {
       response
     }
 
-    private[this] def submit(req: CosmosRequest): Response = {
+    def submit(req: CosmosRequest): Response = {
       val withPath = RequestBuilder().url(s"$uri/${req.path}")
       val withAuth = Session.authorization.fold(withPath) { auth =>
         withPath.setHeader("Authorization", auth.headerValue)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/test/CosmosIntegrationTestClient.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/test/CosmosIntegrationTestClient.scala
@@ -152,6 +152,14 @@ object CosmosIntegrationTestClient extends Matchers {
       response
     }
 
+    /** Ensures that we create Finagle requests correctly.
+      *
+      * Specifically, prevents confusion around the `uri` parameter of
+      * [[com.twitter.finagle.http.Request.apply()]], which should be the relative path of the
+      * endpoint, and not the full HTTP URI.
+      *
+      * It also includes the Authorization header if provided by configuration.
+      */
     def submit(req: CosmosRequest): Response = {
       val withPath = RequestBuilder().url(s"$uri/${req.path}")
       val withAuth = Session.authorization.fold(withPath) { auth =>
@@ -165,6 +173,7 @@ object CosmosIntegrationTestClient extends Matchers {
       Await.result(client(finagleReq))
     }
 
+    // Do not relax the visibility on this -- use `submit()` instead; see its Scaladoc for why
     private[this] val client = {
       Services.httpClient("cosmosIntegrationTestClient", uri, RequestLogging).get
     }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/test/CosmosRequest.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/test/CosmosRequest.scala
@@ -1,0 +1,43 @@
+package com.mesosphere.cosmos.test
+
+import com.mesosphere.cosmos.http.MediaType
+import com.twitter.finagle.http.Method
+import com.twitter.io.Buf
+import io.circe.Encoder
+import io.circe.syntax._
+
+case class CosmosRequest(
+  method: Method,
+  path: String,
+  body: Option[Buf],
+  contentType: Option[String],
+  accept: Option[String]
+)
+
+object CosmosRequest {
+
+  def get(path: String, accept: MediaType): CosmosRequest = {
+    CosmosRequest(Method.Get, path, body = None, contentType = None, accept = toHeader(accept))
+  }
+
+  def post[A](
+    path: String,
+    body: A,
+    contentType: MediaType,
+    accept: MediaType
+  )(implicit encoder: Encoder[A]): CosmosRequest = {
+    post(path, body.asJson.noSpaces, toHeader(contentType), toHeader(accept))
+  }
+
+  def post(
+    path: String,
+    body: String,
+    contentType: Option[String],
+    accept: Option[String]
+  ): CosmosRequest = {
+    CosmosRequest(Method.Post, path, Some(Buf.Utf8(body)), contentType, accept)
+  }
+
+  private[this] def toHeader(mediaType: MediaType): Option[String] = Some(mediaType.show)
+
+}


### PR DESCRIPTION
All public methods on `CosmosIntegrationTestClient` no longer use Finagle `Request`s or `RequestBuilder`s directly; instead, they take instances of a new `CosmosRequest` class and convert them to Finagle `Request`s in a uniform way.