### PR TITLE
Convenience methods for creating Cosmos endpoint requests

### DIFF
--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageAddSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageAddSpec.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos
 
 import com.mesosphere.cosmos.circe.Decoders.decode
 import com.mesosphere.cosmos.converter.Response._
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.http.MediaType
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
@@ -183,8 +183,8 @@ final class PackageAddSpec extends FreeSpec with BeforeAndAfterAll with BeforeAn
 
 object PackageAddSpec {
 
-  def packageAddRequest(packageData: Buf): CosmosRequest = {
-    CosmosRequest.post(
+  def packageAddRequest(packageData: Buf): HttpRequest = {
+    HttpRequest.post(
       path = "package/add",
       body = packageData,
       contentType = UMediaTypes.PackageZip,
@@ -192,8 +192,8 @@ object PackageAddSpec {
     )
   }
 
-  def packageAddRequest(requestBody: rpc.v1.model.UniverseAddRequest): CosmosRequest = {
-    CosmosRequest.post(
+  def packageAddRequest(requestBody: rpc.v1.model.UniverseAddRequest): HttpRequest = {
+    HttpRequest.post(
       path = "package/add",
       body = requestBody,
       contentType = MediaTypes.AddRequest,
@@ -204,10 +204,10 @@ object PackageAddSpec {
   def packageDescribeRequest(
     packageName: String,
     packageVersion: Option[universe.v3.model.PackageDefinition.Version]
-  ): CosmosRequest = {
+  ): HttpRequest = {
     val oldVersion = packageVersion.as[Option[universe.v2.model.PackageDetailsVersion]]
 
-    CosmosRequest.post(
+    HttpRequest.post(
       path = "package/describe",
       body = rpc.v1.model.DescribeRequest(packageName, oldVersion),
       contentType = MediaTypes.DescribeRequest,

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageAddSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageAddSpec.scala
@@ -2,10 +2,9 @@ package com.mesosphere.cosmos
 
 import com.mesosphere.cosmos.circe.Decoders.decode
 import com.mesosphere.cosmos.converter.Response._
-import com.mesosphere.cosmos.http.HttpRequest
+import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.http.MediaType
 import com.mesosphere.cosmos.rpc.MediaTypes
-import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v2.circe.Decoders._
 import com.mesosphere.cosmos.storage.ObjectStorage
 import com.mesosphere.cosmos.storage.ObjectStorage.ObjectList
@@ -18,11 +17,9 @@ import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.ZooKeeperClient
 import com.mesosphere.cosmos.test.TestUtil
 import com.mesosphere.universe
 import com.mesosphere.universe.bijection.TestUniverseConversions._
-import com.mesosphere.universe.bijection.UniverseConversions._
 import com.mesosphere.universe.test.TestingPackages
 import com.mesosphere.universe.v3.circe.Decoders._
 import com.mesosphere.universe.v3.syntax.PackageDefinitionOps._
-import com.mesosphere.universe.{MediaTypes => UMediaTypes}
 import com.mesosphere.universe.{TestUtil => UTestUtil}
 import com.twitter.bijection.Conversion.asMethod
 import com.twitter.finagle.http.Status
@@ -80,7 +77,7 @@ final class PackageAddSpec extends FreeSpec with BeforeAndAfterAll with BeforeAn
     def assertSuccessfulUniverseAdd(addRequest: rpc.v1.model.UniverseAddRequest): Unit = {
       val expectedPackage = describePackage(addRequest.packageName, addRequest.packageVersion)
 
-      val request = packageAddRequest(addRequest)
+      val request = CosmosRequests.packageAdd(addRequest)
       val response = CosmosClient.submit(request)
 
       assertResult(Status.Accepted)(response.status)
@@ -140,7 +137,8 @@ final class PackageAddSpec extends FreeSpec with BeforeAndAfterAll with BeforeAn
   ): Unit = {
     val (expectedMetadata, _) = expectedV3Package.as[(PackageMetadata, ReleaseVersion)]
 
-    val request = packageAddRequest(Buf.ByteArray.Owned(UTestUtil.buildPackage(expectedMetadata)))
+    val body = Buf.ByteArray.Owned(UTestUtil.buildPackage(expectedMetadata))
+    val request = CosmosRequests.packageAdd(body)
     val response = CosmosClient.submit(request)
     assertResult(Status.Accepted)(response.status)
     val actualV3Package = decode[universe.v3.model.V3Package](response.contentString)
@@ -183,38 +181,6 @@ final class PackageAddSpec extends FreeSpec with BeforeAndAfterAll with BeforeAn
 
 object PackageAddSpec {
 
-  def packageAddRequest(packageData: Buf): HttpRequest = {
-    HttpRequest.post(
-      path = "package/add",
-      body = packageData,
-      contentType = UMediaTypes.PackageZip,
-      accept = MediaTypes.AddResponse
-    )
-  }
-
-  def packageAddRequest(requestBody: rpc.v1.model.UniverseAddRequest): HttpRequest = {
-    HttpRequest.post(
-      path = "package/add",
-      body = requestBody,
-      contentType = MediaTypes.AddRequest,
-      accept = MediaTypes.AddResponse
-    )
-  }
-
-  def packageDescribeRequest(
-    packageName: String,
-    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
-  ): HttpRequest = {
-    val oldVersion = packageVersion.as[Option[universe.v2.model.PackageDetailsVersion]]
-
-    HttpRequest.post(
-      path = "package/describe",
-      body = rpc.v1.model.DescribeRequest(packageName, oldVersion),
-      contentType = MediaTypes.DescribeRequest,
-      accept = MediaTypes.V2DescribeResponse
-    )
-  }
-
   def cleanObjectStorage(storage: ObjectStorage): Unit = {
     def cleanObjectList(objectList: ObjectList): Future[Unit] = {
       // Delete all of the objects
@@ -243,7 +209,7 @@ object PackageAddSpec {
     packageName: String,
     packageVersion: Option[universe.v3.model.PackageDefinition.Version]
   ): rpc.v2.model.DescribeResponse = {
-    val request = packageDescribeRequest(packageName, packageVersion)
+    val request = CosmosRequests.packageDescribeV2(packageName, packageVersion)
     val response = CosmosClient.submit(request)
     decode[rpc.v2.model.DescribeResponse](response.contentString)
   }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -5,7 +5,7 @@ import _root_.io.circe.jawn._
 import _root_.io.circe.syntax._
 import cats.data.Xor
 import cats.data.Xor.Right
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
@@ -106,7 +106,7 @@ final class PackageDescribeSpec extends FreeSpec with TableDrivenPropertyChecks 
   private[this] def describeRequest(
     describeRequest: DescribeRequest
   ): Response = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       DescribeEndpoint,
       describeRequest,
       MediaTypes.DescribeRequest,
@@ -118,7 +118,7 @@ final class PackageDescribeSpec extends FreeSpec with TableDrivenPropertyChecks 
   private[this] def listVersionsRequest(
     listVersionsRequest: ListVersionsRequest
   ): Response = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       ListVersionsEndpoint,
       listVersionsRequest,
       MediaTypes.ListVersionsRequest,

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -6,7 +6,7 @@ import _root_.io.circe.jawn._
 import _root_.io.circe.syntax._
 import cats.data.Xor
 import cats.data.Xor.Right
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.repository.DefaultRepositories
 import com.mesosphere.cosmos.rpc.MediaTypes
@@ -205,7 +205,7 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
 
       val installRequest = InstallRequest("enterprise-security-cli")
 
-      val request = CosmosRequest.post(
+      val request = HttpRequest.post(
         "package/install",
         installRequest,
         MediaTypes.InstallRequest,
@@ -281,7 +281,7 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
   private[this] def installPackage(
     installRequest: InstallRequest
   ): Response = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/install",
       installRequest,
       MediaTypes.InstallRequest,

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -6,12 +6,11 @@ import _root_.io.circe.jawn._
 import _root_.io.circe.syntax._
 import cats.data.Xor
 import cats.data.Xor.Right
-import com.mesosphere.cosmos.http.HttpRequest
+import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.repository.DefaultRepositories
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
-import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.rpc.v1.model.InstallRequest
 import com.mesosphere.cosmos.rpc.v1.model.InstallResponse
@@ -204,13 +203,7 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
       )
 
       val installRequest = InstallRequest("enterprise-security-cli")
-
-      val request = HttpRequest.post(
-        "package/install",
-        installRequest,
-        MediaTypes.InstallRequest,
-        MediaTypes.V2InstallResponse
-      )
+      val request = CosmosRequests.packageInstallV2(installRequest)
       val response = CosmosClient.submit(request)
 
       assertResult(Status.Ok)(response.status)
@@ -251,7 +244,8 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
       case Anything => // Don't care
     }
 
-    val response = installPackage(installRequest)
+    val request = CosmosRequests.packageInstallV1(installRequest)
+    val response = CosmosClient.submit(request)
 
     assertResult(expectedResult.status)(response.status)
     expectedResult match {
@@ -276,18 +270,6 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
       adminRouter.getAppOption(appId)
         .map(_.isDefined)
     }
-  }
-
-  private[this] def installPackage(
-    installRequest: InstallRequest
-  ): Response = {
-    val request = HttpRequest.post(
-      "package/install",
-      installRequest,
-      MediaTypes.InstallRequest,
-      MediaTypes.V1InstallResponse
-    )
-    CosmosClient.submit(request)
   }
 
 }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
@@ -91,8 +91,8 @@ final class PackageListIntegrationSpec
   }
 
   private[this] def withDeletedRepository(repository: PackageRepository)(action: => Unit): Unit = {
-    val request =
-      CosmosRequests.packageRepoDelete(PackageRepositoryDeleteRequest(name = Some(repository.name)))
+    val repoDeleteRequest = PackageRepositoryDeleteRequest(name = Some(repository.name))
+    val request = CosmosRequests.packageRepositoryDelete(repoDeleteRequest)
     val actualDelete = CosmosClient.callEndpoint[PackageRepositoryDeleteResponse](request)
       .withClue("when deleting repo")
 
@@ -104,7 +104,7 @@ final class PackageListIntegrationSpec
       action
     } finally {
       val repoAddRequest = PackageRepositoryAddRequest(repository.name, repository.uri)
-      val request = CosmosRequests.packageRepoAdd(repoAddRequest)
+      val request = CosmosRequests.packageRepositoryAdd(repoAddRequest)
       val actualAdd = CosmosClient.callEndpoint[PackageRepositoryAddResponse](request)
         .withClue("when restoring deleted repo")
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.repository.DefaultRepositories
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
@@ -63,7 +63,7 @@ final class PackageListIntegrationSpec
   }
 
   private[this] def withInstalledPackage(packageName: String)(f: InstallResponse => Unit): Unit = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/install",
       InstallRequest(packageName, appId = Some(AppId(UUID.randomUUID().toString))),
       MediaTypes.InstallRequest,
@@ -75,7 +75,7 @@ final class PackageListIntegrationSpec
       assertResult(packageName)(installResponse.packageName)
       f(installResponse)
     } finally {
-      val request = CosmosRequest.post(
+      val request = HttpRequest.post(
         "package/uninstall",
         UninstallRequest(installResponse.packageName, appId = Some(installResponse.appId), all = None),
         MediaTypes.UninstallRequest,
@@ -93,7 +93,7 @@ final class PackageListIntegrationSpec
   }
 
   private[this] def withDeletedRepository(repository: PackageRepository)(action: => Unit): Unit = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/repository/delete",
       PackageRepositoryDeleteRequest(name = Some(repository.name)),
       MediaTypes.PackageRepositoryDeleteRequest,
@@ -108,7 +108,7 @@ final class PackageListIntegrationSpec
 
       action
     } finally {
-      val request = CosmosRequest.post(
+      val request = HttpRequest.post(
         "package/repository/add",
         PackageRepositoryAddRequest(repository.name, repository.uri),
         MediaTypes.PackageRepositoryAddRequest,
@@ -127,7 +127,7 @@ final class PackageListIntegrationSpec
   private[this] def withInstalledPackageInListResponse(installResponse: InstallResponse)(
     pf: PartialFunction[Option[Installation], Unit]
   ): Unit = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/list",
       ListRequest(),
       MediaTypes.ListRequest,
@@ -161,7 +161,7 @@ final class PackageListIntegrationSpec
   }
 
   private[this] def packageList(): ListResponse = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/list",
       ListRequest(),
       MediaTypes.ListRequest,
@@ -173,7 +173,7 @@ final class PackageListIntegrationSpec
   }
 
   private[this] def packageInstall(packageName: String): InstallResponse = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/install",
       InstallRequest(packageName, appId = Some(AppId(UUID.randomUUID().toString))),
       MediaTypes.InstallRequest,
@@ -187,7 +187,7 @@ final class PackageListIntegrationSpec
   }
 
   private[this] def packageUninstall(installResponse: InstallResponse): Unit = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/uninstall",
       UninstallRequest(installResponse.packageName, appId = Some(installResponse.appId), all = None),
       MediaTypes.UninstallRequest,

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
@@ -1,12 +1,10 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor
-import com.mesosphere.cosmos.http.HttpRequest
+import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.repository.DefaultRepositories
 import com.mesosphere.cosmos.repository.PackageRepositorySpec
-import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
-import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
 import com.netaporter.uri.dsl._
@@ -113,12 +111,7 @@ final class PackageRepositoryIntegrationSpec extends FreeSpec with BeforeAndAfte
 private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyChecks {
 
   private def listRepositories(): Seq[PackageRepository] = {
-    val request = HttpRequest.post(
-      "package/repository/list",
-      PackageRepositoryListRequest(),
-      MediaTypes.PackageRepositoryListRequest,
-      MediaTypes.PackageRepositoryListResponse
-    )
+    val request = CosmosRequests.packageRepoList
     val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryListResponse](request)
     response.repositories
   }
@@ -126,12 +119,8 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
   private def addRepository(
     source: PackageRepository
   ): PackageRepositoryAddResponse = {
-    val request = HttpRequest.post(
-      "package/repository/add",
-      PackageRepositoryAddRequest(source.name, source.uri),
-      MediaTypes.PackageRepositoryAddRequest,
-      MediaTypes.PackageRepositoryAddResponse
-    )
+    val repoAddRequest = PackageRepositoryAddRequest(source.name, source.uri)
+    val request = CosmosRequests.packageRepoAdd(repoAddRequest)
     val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryAddResponse](request)
     response
   }
@@ -139,12 +128,8 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
   private def deleteRepository(
     source: PackageRepository
   ): PackageRepositoryDeleteResponse = {
-    val request = HttpRequest.post(
-      "package/repository/delete",
-      PackageRepositoryDeleteRequest(name = Some(source.name)),
-      MediaTypes.PackageRepositoryDeleteRequest,
-      MediaTypes.PackageRepositoryDeleteResponse
-    )
+    val repoDeleteRequest = PackageRepositoryDeleteRequest(name = Some(source.name))
+    val request = CosmosRequests.packageRepoDelete(repoDeleteRequest)
     val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryDeleteResponse](request)
     response
   }
@@ -152,12 +137,7 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
   private def sendAddRequest(
     addRequest: PackageRepositoryAddRequest
   ): Response = {
-    val request = HttpRequest.post(
-      "package/repository/add",
-      addRequest,
-      MediaTypes.PackageRepositoryAddRequest,
-      MediaTypes.PackageRepositoryAddResponse
-    )
+    val request = CosmosRequests.packageRepoAdd(addRequest)
     CosmosClient.submit(request)
   }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
@@ -111,7 +111,7 @@ final class PackageRepositoryIntegrationSpec extends FreeSpec with BeforeAndAfte
 private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyChecks {
 
   private def listRepositories(): Seq[PackageRepository] = {
-    val request = CosmosRequests.packageRepoList
+    val request = CosmosRequests.packageRepositoryList
     val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryListResponse](request)
     response.repositories
   }
@@ -120,7 +120,7 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
     source: PackageRepository
   ): PackageRepositoryAddResponse = {
     val repoAddRequest = PackageRepositoryAddRequest(source.name, source.uri)
-    val request = CosmosRequests.packageRepoAdd(repoAddRequest)
+    val request = CosmosRequests.packageRepositoryAdd(repoAddRequest)
     val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryAddResponse](request)
     response
   }
@@ -129,7 +129,7 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
     source: PackageRepository
   ): PackageRepositoryDeleteResponse = {
     val repoDeleteRequest = PackageRepositoryDeleteRequest(name = Some(source.name))
-    val request = CosmosRequests.packageRepoDelete(repoDeleteRequest)
+    val request = CosmosRequests.packageRepositoryDelete(repoDeleteRequest)
     val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryDeleteResponse](request)
     response
   }
@@ -137,7 +137,7 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
   private def sendAddRequest(
     addRequest: PackageRepositoryAddRequest
   ): Response = {
-    val request = CosmosRequests.packageRepoAdd(addRequest)
+    val request = CosmosRequests.packageRepositoryAdd(addRequest)
     CosmosClient.submit(request)
   }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageRepositoryIntegrationSpec.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos
 
 import cats.data.Xor
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.repository.DefaultRepositories
 import com.mesosphere.cosmos.repository.PackageRepositorySpec
 import com.mesosphere.cosmos.rpc.MediaTypes
@@ -113,7 +113,7 @@ final class PackageRepositoryIntegrationSpec extends FreeSpec with BeforeAndAfte
 private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyChecks {
 
   private def listRepositories(): Seq[PackageRepository] = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/repository/list",
       PackageRepositoryListRequest(),
       MediaTypes.PackageRepositoryListRequest,
@@ -126,7 +126,7 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
   private def addRepository(
     source: PackageRepository
   ): PackageRepositoryAddResponse = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/repository/add",
       PackageRepositoryAddRequest(source.name, source.uri),
       MediaTypes.PackageRepositoryAddRequest,
@@ -139,7 +139,7 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
   private def deleteRepository(
     source: PackageRepository
   ): PackageRepositoryDeleteResponse = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/repository/delete",
       PackageRepositoryDeleteRequest(name = Some(source.name)),
       MediaTypes.PackageRepositoryDeleteRequest,
@@ -152,7 +152,7 @@ private object PackageRepositoryIntegrationSpec extends TableDrivenPropertyCheck
   private def sendAddRequest(
     addRequest: PackageRepositoryAddRequest
   ): Response = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/repository/add",
       addRequest,
       MediaTypes.PackageRepositoryAddRequest,

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos
 
 import _root_.io.circe.jawn._
 import cats.data.Xor.Right
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
@@ -46,7 +46,7 @@ final class PackageSearchSpec extends FreeSpec {
     status: Status,
     expectedResponse: SearchResponse
   ): Unit = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/search",
       SearchRequest(Some(query)),
       MediaTypes.SearchRequest,

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -2,10 +2,8 @@ package com.mesosphere.cosmos
 
 import _root_.io.circe.jawn._
 import cats.data.Xor.Right
-import com.mesosphere.cosmos.http.HttpRequest
-import com.mesosphere.cosmos.rpc.MediaTypes
+import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
-import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model.SearchRequest
 import com.mesosphere.cosmos.rpc.v1.model.SearchResponse
 import com.mesosphere.cosmos.rpc.v1.model.SearchResult
@@ -46,12 +44,7 @@ final class PackageSearchSpec extends FreeSpec {
     status: Status,
     expectedResponse: SearchResponse
   ): Unit = {
-    val request = HttpRequest.post(
-      "package/search",
-      SearchRequest(Some(query)),
-      MediaTypes.SearchRequest,
-      MediaTypes.SearchResponse
-    )
+    val request = CosmosRequests.packageSearch(SearchRequest(Some(query)))
     val response = CosmosClient.submit(request)
 
     assertResult(status)(response.status)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.handler
 
 import cats.data.Xor
-import com.mesosphere.cosmos.http.HttpRequest
+import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.model.CapabilitiesResponse
@@ -14,8 +14,7 @@ import org.scalatest.FreeSpec
 final class CapabilitiesHandlerSpec extends FreeSpec {
 
   "The capabilities handler should return a document" in {
-    val request = HttpRequest.get("capabilities", MediaTypes.CapabilitiesResponse)
-    val response = CosmosClient.submit(request)
+    val response = CosmosClient.submit(CosmosRequests.capabilities)
 
     assertResult(Status.Ok)(response.status)
     assertResult(MediaTypes.CapabilitiesResponse.show)(response.headerMap("Content-Type"))

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.handler
 
 import cats.data.Xor
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.model.CapabilitiesResponse
@@ -14,7 +14,7 @@ import org.scalatest.FreeSpec
 final class CapabilitiesHandlerSpec extends FreeSpec {
 
   "The capabilities handler should return a document" in {
-    val request = CosmosRequest.get("capabilities", MediaTypes.CapabilitiesResponse)
+    val request = HttpRequest.get("capabilities", MediaTypes.CapabilitiesResponse)
     val response = CosmosClient.submit(request)
 
     assertResult(Status.Ok)(response.status)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.handler
 
 import cats.data.Xor
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
@@ -95,7 +95,7 @@ class PackageRenderHandlerSpec extends FreeSpec {
 object PackageRenderHandlerSpec {
 
   def packageRender(renderRequest: RenderRequest): Response = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/render",
       renderRequest,
       MediaTypes.RenderRequest,

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
@@ -1,10 +1,9 @@
 package com.mesosphere.cosmos.handler
 
 import cats.data.Xor
-import com.mesosphere.cosmos.http.HttpRequest
+import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
-import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.rpc.v1.model.RenderRequest
 import com.mesosphere.cosmos.rpc.v1.model.RenderResponse
@@ -95,12 +94,7 @@ class PackageRenderHandlerSpec extends FreeSpec {
 object PackageRenderHandlerSpec {
 
   def packageRender(renderRequest: RenderRequest): Response = {
-    val request = HttpRequest.post(
-      "package/render",
-      renderRequest,
-      MediaTypes.RenderRequest,
-      MediaTypes.RenderResponse
-    )
+    val request = CosmosRequests.packageRender(renderRequest)
     CosmosClient.submit(request)
   }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/RequestErrorsSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/RequestErrorsSpec.scala
@@ -2,17 +2,17 @@ package com.mesosphere.cosmos.handler
 
 import cats.data.Xor
 import com.mesosphere.cosmos.http.CompoundMediaTypeParser
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepositoryAddRequest
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.http.Status
-import io.circe.jawn._
-import io.circe.syntax._
 import io.circe.Json
 import io.circe.JsonObject
+import io.circe.jawn._
+import io.circe.syntax._
 import org.scalatest.FreeSpec
 import scala.language.implicitConversions
 
@@ -32,7 +32,7 @@ class RequestErrorsSpec extends FreeSpec {
           Some(0)
         ).asJson
 
-        val request = CosmosRequest.post(
+        val request = HttpRequest.post(
           "package/install",
           body.noSpaces,
           Some(MediaTypes.DescribeRequest.show),
@@ -89,7 +89,7 @@ class RequestErrorsSpec extends FreeSpec {
       }
 
       "Missing Accept, Missing Content-Type, Missing body" in {
-        val request = CosmosRequest.post(
+        val request = HttpRequest.post(
           path = "package/install",
           body = "",
           contentType = None,

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.handler
 
 import cats.data.Xor
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
@@ -22,7 +22,7 @@ final class UninstallHandlerSpec extends FreeSpec {
   "The uninstall handler should" - {
     "be able to uninstall a service" in {
       val appId = AppId("cassandra" / "uninstall-test")
-      val installRequest = CosmosRequest.post(
+      val installRequest = HttpRequest.post(
         "package/install",
         s"""{"packageName":"cassandra", "appId":"${appId.toString}"}""",
         Some(MediaTypes.InstallRequest.show),
@@ -36,7 +36,7 @@ final class UninstallHandlerSpec extends FreeSpec {
 
       //TODO: Assert framework starts up
 
-      val uninstallRequest = CosmosRequest.post(
+      val uninstallRequest = HttpRequest.post(
         "package/uninstall",
         """{"packageName":"cassandra"}""",
         Some(MediaTypes.UninstallRequest.show),
@@ -53,7 +53,7 @@ final class UninstallHandlerSpec extends FreeSpec {
     "be able to uninstall multiple packages when 'all' is specified" in {
       // install 'helloworld' twice
       val installBody1 = s"""{"packageName":"helloworld", "appId":"${UUID.randomUUID()}"}"""
-      val installRequest1 = CosmosRequest.post(
+      val installRequest1 = HttpRequest.post(
         "package/install",
         installBody1,
         Some(MediaTypes.InstallRequest.show),
@@ -63,7 +63,7 @@ final class UninstallHandlerSpec extends FreeSpec {
       assertResult(Status.Ok, s"install failed: $installBody1")(installResponse1.status)
 
       val installBody2 = s"""{"packageName":"helloworld", "appId":"${UUID.randomUUID()}"}"""
-      val installRequest2 = CosmosRequest.post(
+      val installRequest2 = HttpRequest.post(
         "package/install",
         installBody2,
         Some(MediaTypes.InstallRequest.show),
@@ -72,7 +72,7 @@ final class UninstallHandlerSpec extends FreeSpec {
       val installResponse2 = CosmosClient.submit(installRequest2)
       assertResult(Status.Ok, s"install failed: $installBody2")(installResponse2.status)
 
-      val uninstallRequest = CosmosRequest.post(
+      val uninstallRequest = HttpRequest.post(
         "package/uninstall",
         """{"packageName":"helloworld", "all":true}""",
         Some(MediaTypes.UninstallRequest.show),
@@ -87,7 +87,7 @@ final class UninstallHandlerSpec extends FreeSpec {
       // install 'helloworld' twice
       val appId1 = UUID.randomUUID()
       val installBody1 = s"""{"packageName":"helloworld", "appId":"$appId1"}"""
-      val installRequest1 = CosmosRequest.post(
+      val installRequest1 = HttpRequest.post(
         "package/install",
         installBody1,
         Some(MediaTypes.InstallRequest.show),
@@ -98,7 +98,7 @@ final class UninstallHandlerSpec extends FreeSpec {
 
       val appId2 = UUID.randomUUID()
       val installBody2 = s"""{"packageName":"helloworld", "appId":"$appId2"}"""
-      val installRequest2 = CosmosRequest.post(
+      val installRequest2 = HttpRequest.post(
         "package/install",
         installBody2,
         Some(MediaTypes.InstallRequest.show),
@@ -107,7 +107,7 @@ final class UninstallHandlerSpec extends FreeSpec {
       val installResponse2 = CosmosClient.submit(installRequest2)
       assertResult(Status.Ok, s"install failed: $installBody2")(installResponse2.status)
 
-      val uninstallRequest = CosmosRequest.post(
+      val uninstallRequest = HttpRequest.post(
         "package/uninstall",
         """{"packageName":"helloworld"}""",
         Some(MediaTypes.UninstallRequest.show),
@@ -120,7 +120,7 @@ final class UninstallHandlerSpec extends FreeSpec {
       val Xor.Right(err) = decode[ErrorResponse](uninstallResponseBody)
       assertResult(s"Multiple apps named [helloworld] are installed: [/$appId1, /$appId2]")(err.message)
 
-      val cleanupRequest = CosmosRequest.post(
+      val cleanupRequest = HttpRequest.post(
         "package/uninstall",
         """{"packageName":"helloworld", "all":true}""",
         Some(MediaTypes.UninstallRequest.show),

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
@@ -2,12 +2,18 @@ package com.mesosphere.cosmos.http
 
 import com.mesosphere.cosmos.rpc
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
+import com.mesosphere.cosmos.rpc.v1.model.PackageRepositoryListRequest
+import com.mesosphere.cosmos.rpc.v1.model.RenderRequest
 import com.mesosphere.universe
 import com.mesosphere.universe.bijection.UniverseConversions._
 import com.twitter.bijection.Conversion.asMethod
 import com.twitter.io.Buf
 
 object CosmosRequests {
+
+  val capabilities: HttpRequest = {
+    HttpRequest.get(path = "capabilities", accept = rpc.MediaTypes.CapabilitiesResponse)
+  }
 
   def packageAdd(packageData: Buf): HttpRequest = {
     HttpRequest.post(
@@ -70,6 +76,24 @@ object CosmosRequests {
     )
   }
 
+  def packageRender(renderRequest: RenderRequest): HttpRequest = {
+    HttpRequest.post(
+      path = "package/render",
+      body = renderRequest,
+      contentType = rpc.MediaTypes.RenderRequest,
+      accept = rpc.MediaTypes.RenderResponse
+    )
+  }
+
+  def packageSearch(searchRequest: rpc.v1.model.SearchRequest): HttpRequest = {
+    HttpRequest.post(
+      path = "package/search",
+      body = searchRequest,
+      contentType = rpc.MediaTypes.SearchRequest,
+      accept = rpc.MediaTypes.SearchResponse
+    )
+  }
+
   def packageRepoAdd(repoAddRequest: rpc.v1.model.PackageRepositoryAddRequest): HttpRequest = {
     HttpRequest.post(
       path = "package/repository/add",
@@ -83,10 +107,19 @@ object CosmosRequests {
     repoDeleteRequest: rpc.v1.model.PackageRepositoryDeleteRequest
   ): HttpRequest = {
     HttpRequest.post(
-      "package/repository/delete",
-      repoDeleteRequest,
-      rpc.MediaTypes.PackageRepositoryDeleteRequest,
-      rpc.MediaTypes.PackageRepositoryDeleteResponse
+      path = "package/repository/delete",
+      body = repoDeleteRequest,
+      contentType = rpc.MediaTypes.PackageRepositoryDeleteRequest,
+      accept = rpc.MediaTypes.PackageRepositoryDeleteResponse
+    )
+  }
+
+  val packageRepoList: HttpRequest = {
+    HttpRequest.post(
+      path = "package/repository/list",
+      body = PackageRepositoryListRequest(),
+      contentType = rpc.MediaTypes.PackageRepositoryListRequest,
+      accept = rpc.MediaTypes.PackageRepositoryListResponse
     )
   }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
@@ -1,0 +1,88 @@
+package com.mesosphere.cosmos.http
+
+import com.mesosphere.cosmos.rpc
+import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
+import com.mesosphere.universe
+import com.mesosphere.universe.bijection.UniverseConversions._
+import com.twitter.bijection.Conversion.asMethod
+import com.twitter.io.Buf
+
+object CosmosRequests {
+
+  def packageAdd(packageData: Buf): HttpRequest = {
+    HttpRequest.post(
+      path = "package/add",
+      body = packageData,
+      contentType = universe.MediaTypes.PackageZip,
+      accept = rpc.MediaTypes.AddResponse
+    )
+  }
+
+  def packageAdd(requestBody: rpc.v1.model.UniverseAddRequest): HttpRequest = {
+    HttpRequest.post(
+      path = "package/add",
+      body = requestBody,
+      contentType = rpc.MediaTypes.AddRequest,
+      accept = rpc.MediaTypes.AddResponse
+    )
+  }
+
+  def packageDescribeV1(describeRequest: rpc.v1.model.DescribeRequest): HttpRequest = {
+    packageDescribe(describeRequest, accept = rpc.MediaTypes.V1DescribeResponse)
+  }
+
+  def packageDescribeV2(
+    packageName: String,
+    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+  ): HttpRequest = {
+    val oldVersion = packageVersion.as[Option[universe.v2.model.PackageDetailsVersion]]
+    val describeRequest = rpc.v1.model.DescribeRequest(packageName, oldVersion)
+    packageDescribeV2(describeRequest)
+  }
+
+  def packageDescribeV2(describeRequest: rpc.v1.model.DescribeRequest): HttpRequest = {
+    packageDescribe(describeRequest, accept = rpc.MediaTypes.V2DescribeResponse)
+  }
+
+  def packageInstallV1(installRequest: rpc.v1.model.InstallRequest): HttpRequest = {
+    packageInstall(installRequest, accept = rpc.MediaTypes.V1InstallResponse)
+  }
+
+  def packageInstallV2(installRequest: rpc.v1.model.InstallRequest): HttpRequest = {
+    packageInstall(installRequest, accept = rpc.MediaTypes.V2InstallResponse)
+  }
+
+  def packageListVersions(listVersionsRequest: rpc.v1.model.ListVersionsRequest): HttpRequest = {
+    HttpRequest.post(
+      path = "package/list-versions",
+      body = listVersionsRequest,
+      contentType = rpc.MediaTypes.ListVersionsRequest,
+      accept = rpc.MediaTypes.ListVersionsResponse
+    )
+  }
+
+  private def packageDescribe(
+    describeRequest: rpc.v1.model.DescribeRequest,
+    accept: MediaType
+  ): HttpRequest = {
+    HttpRequest.post(
+      path = "package/describe",
+      body = describeRequest,
+      contentType = rpc.MediaTypes.DescribeRequest,
+      accept = accept
+    )
+  }
+
+  private def packageInstall(
+    installRequest: rpc.v1.model.InstallRequest,
+    accept: MediaType
+  ): HttpRequest = {
+    HttpRequest.post(
+      path = "package/install",
+      body = installRequest,
+      contentType = rpc.MediaTypes.InstallRequest,
+      accept = accept
+    )
+  }
+
+}

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
@@ -52,12 +52,50 @@ object CosmosRequests {
     packageInstall(installRequest, accept = rpc.MediaTypes.V2InstallResponse)
   }
 
+  def packageList(listRequest: rpc.v1.model.ListRequest): HttpRequest = {
+    HttpRequest.post(
+      "package/list",
+      listRequest,
+      rpc.MediaTypes.ListRequest,
+      rpc.MediaTypes.ListResponse
+    )
+  }
+
   def packageListVersions(listVersionsRequest: rpc.v1.model.ListVersionsRequest): HttpRequest = {
     HttpRequest.post(
       path = "package/list-versions",
       body = listVersionsRequest,
       contentType = rpc.MediaTypes.ListVersionsRequest,
       accept = rpc.MediaTypes.ListVersionsResponse
+    )
+  }
+
+  def packageRepoAdd(repoAddRequest: rpc.v1.model.PackageRepositoryAddRequest): HttpRequest = {
+    HttpRequest.post(
+      path = "package/repository/add",
+      body = repoAddRequest,
+      contentType = rpc.MediaTypes.PackageRepositoryAddRequest,
+      accept = rpc.MediaTypes.PackageRepositoryAddResponse
+    )
+  }
+
+  def packageRepoDelete(
+    repoDeleteRequest: rpc.v1.model.PackageRepositoryDeleteRequest
+  ): HttpRequest = {
+    HttpRequest.post(
+      "package/repository/delete",
+      repoDeleteRequest,
+      rpc.MediaTypes.PackageRepositoryDeleteRequest,
+      rpc.MediaTypes.PackageRepositoryDeleteResponse
+    )
+  }
+
+  def packageUninstall(uninstallRequest: rpc.v1.model.UninstallRequest): HttpRequest = {
+    HttpRequest.post(
+      path = "package/uninstall",
+      body = uninstallRequest,
+      contentType = rpc.MediaTypes.UninstallRequest,
+      accept = rpc.MediaTypes.UninstallResponse
     )
   }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
@@ -94,27 +94,29 @@ object CosmosRequests {
     )
   }
 
-  def packageRepoAdd(repoAddRequest: rpc.v1.model.PackageRepositoryAddRequest): HttpRequest = {
+  def packageRepositoryAdd(
+    repositoryAddRequest: rpc.v1.model.PackageRepositoryAddRequest
+  ): HttpRequest = {
     HttpRequest.post(
       path = "package/repository/add",
-      body = repoAddRequest,
+      body = repositoryAddRequest,
       contentType = rpc.MediaTypes.PackageRepositoryAddRequest,
       accept = rpc.MediaTypes.PackageRepositoryAddResponse
     )
   }
 
-  def packageRepoDelete(
-    repoDeleteRequest: rpc.v1.model.PackageRepositoryDeleteRequest
+  def packageRepositoryDelete(
+    repositoryDeleteRequest: rpc.v1.model.PackageRepositoryDeleteRequest
   ): HttpRequest = {
     HttpRequest.post(
       path = "package/repository/delete",
-      body = repoDeleteRequest,
+      body = repositoryDeleteRequest,
       contentType = rpc.MediaTypes.PackageRepositoryDeleteRequest,
       accept = rpc.MediaTypes.PackageRepositoryDeleteResponse
     )
   }
 
-  val packageRepoList: HttpRequest = {
+  val packageRepositoryList: HttpRequest = {
     HttpRequest.post(
       path = "package/repository/list",
       body = PackageRepositoryListRequest(),

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
@@ -7,7 +7,7 @@ import _root_.io.circe.jawn._
 import _root_.io.circe.syntax._
 import cats.data.Xor
 import com.mesosphere.cosmos._
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
@@ -318,7 +318,7 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
     val repositoriesBeforeAdd = listRepos()
 
     assertResult(expectedErrorMessage) {
-      val request = CosmosRequest.post(
+      val request = HttpRequest.post(
         "package/repository/add",
         PackageRepositoryAddRequest(repository.name, repository.uri),
         MediaTypes.PackageRepositoryAddRequest,
@@ -336,7 +336,7 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
   }
 
   private def addRepo(addRequest: PackageRepositoryAddRequest): PackageRepositoryAddResponse  = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/repository/add",
       addRequest,
       MediaTypes.PackageRepositoryAddRequest,
@@ -350,7 +350,7 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
     deleteRequest: PackageRepositoryDeleteRequest,
     status: Status = Status.Ok
   ): Xor[ErrorResponse, PackageRepositoryDeleteResponse]  = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/repository/delete",
       deleteRequest,
       MediaTypes.PackageRepositoryDeleteRequest,
@@ -360,7 +360,7 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
   }
 
   private def listRepos(): PackageRepositoryListResponse = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/repository/list",
       PackageRepositoryListRequest(),
       MediaTypes.PackageRepositoryListRequest,
@@ -371,7 +371,7 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
   }
 
   private def searchPackages(req: SearchRequest): Response = {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/search",
       req,
       MediaTypes.SearchRequest,

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/PackageRepositorySpec.scala
@@ -7,10 +7,8 @@ import _root_.io.circe.jawn._
 import _root_.io.circe.syntax._
 import cats.data.Xor
 import com.mesosphere.cosmos._
-import com.mesosphere.cosmos.http.HttpRequest
-import com.mesosphere.cosmos.rpc.MediaTypes
+import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
-import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
 import com.mesosphere.universe.common.circe.Encoders._
@@ -318,12 +316,8 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
     val repositoriesBeforeAdd = listRepos()
 
     assertResult(expectedErrorMessage) {
-      val request = HttpRequest.post(
-        "package/repository/add",
-        PackageRepositoryAddRequest(repository.name, repository.uri),
-        MediaTypes.PackageRepositoryAddRequest,
-        MediaTypes.PackageRepositoryAddResponse
-      )
+      val repoAddRequest = PackageRepositoryAddRequest(repository.name, repository.uri)
+      val request = CosmosRequests.packageRepositoryAdd(repoAddRequest)
       val response = CosmosClient.submit(request)
       assertResult(Status.BadRequest)(response.status)
       val Xor.Right(err) = decode[ErrorResponse](response.contentString)
@@ -336,12 +330,7 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
   }
 
   private def addRepo(addRequest: PackageRepositoryAddRequest): PackageRepositoryAddResponse  = {
-    val request = HttpRequest.post(
-      "package/repository/add",
-      addRequest,
-      MediaTypes.PackageRepositoryAddRequest,
-      MediaTypes.PackageRepositoryAddResponse
-    )
+    val request = CosmosRequests.packageRepositoryAdd(addRequest)
     val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryAddResponse](request)
     response
   }
@@ -350,33 +339,18 @@ object PackageRepositorySpec extends FreeSpec with TableDrivenPropertyChecks {
     deleteRequest: PackageRepositoryDeleteRequest,
     status: Status = Status.Ok
   ): Xor[ErrorResponse, PackageRepositoryDeleteResponse]  = {
-    val request = HttpRequest.post(
-      "package/repository/delete",
-      deleteRequest,
-      MediaTypes.PackageRepositoryDeleteRequest,
-      MediaTypes.PackageRepositoryDeleteResponse
-    )
+    val request = CosmosRequests.packageRepositoryDelete(deleteRequest)
     CosmosClient.callEndpoint[PackageRepositoryDeleteResponse](request, status)
   }
 
   private def listRepos(): PackageRepositoryListResponse = {
-    val request = HttpRequest.post(
-      "package/repository/list",
-      PackageRepositoryListRequest(),
-      MediaTypes.PackageRepositoryListRequest,
-      MediaTypes.PackageRepositoryListResponse
-    )
+    val request = CosmosRequests.packageRepositoryList
     val Xor.Right(response) = CosmosClient.callEndpoint[PackageRepositoryListResponse](request)
     response
   }
 
   private def searchPackages(req: SearchRequest): Response = {
-    val request = HttpRequest.post(
-      "package/search",
-      req,
-      MediaTypes.SearchRequest,
-      MediaTypes.SearchResponse
-    )
+    val request = CosmosRequests.packageSearch(req)
     CosmosClient.submit(request)
   }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/rpc/v1/model/ErrorResponseSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/rpc/v1/model/ErrorResponseSpec.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.rpc.v1.model
 
 import cats.data.Xor
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
@@ -12,7 +12,7 @@ import org.scalatest.FreeSpec
 class ErrorResponseSpec extends FreeSpec {
 
   "An ErrorResponse should be returned as the body when a request can't be parsed" in {
-    val request = CosmosRequest.post(
+    val request = HttpRequest.post(
       "package/install",
       Map("invalid" -> true),
       MediaTypes.InstallRequest,

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/test/CosmosIntegrationTestClient.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/test/CosmosIntegrationTestClient.scala
@@ -11,15 +11,13 @@ import com.mesosphere.cosmos.Trys
 import com.mesosphere.cosmos.Uris
 import com.mesosphere.cosmos.dcosUri
 import com.mesosphere.cosmos.http.Authorization
-import com.mesosphere.cosmos.http.CosmosRequest
+import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.model.ZooKeeperUri
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model._
-import com.mesosphere.universe.v3.model.Repository
-import com.mesosphere.universe.{MediaTypes => UMediaTypes}
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
 import com.twitter.finagle.Service
@@ -83,7 +81,7 @@ object CosmosIntegrationTestClient extends Matchers {
 
     val uri: String = getClientProperty("CosmosClient", "uri")
 
-    def callEndpoint[Res](request: CosmosRequest, expectedStatus: Status = Status.Ok)(implicit
+    def callEndpoint[Res](request: HttpRequest, expectedStatus: Status = Status.Ok)(implicit
       decoder: Decoder[Res]
     ): ErrorResponse Xor Res = {
       val response = submit(request)
@@ -103,7 +101,7 @@ object CosmosIntegrationTestClient extends Matchers {
     }
 
     def packageSearch(requestBody: SearchRequest): SearchResponse = {
-      val request = CosmosRequest.post(
+      val request = HttpRequest.post(
         "package/search",
         requestBody,
         MediaTypes.SearchRequest,
@@ -114,7 +112,7 @@ object CosmosIntegrationTestClient extends Matchers {
     }
 
     def packageRepositoryAdd(requestBody: PackageRepositoryAddRequest): PackageRepositoryAddResponse = {
-      val request = CosmosRequest.post(
+      val request = HttpRequest.post(
         "package/repository/add",
         requestBody,
         MediaTypes.PackageRepositoryAddRequest,
@@ -125,7 +123,7 @@ object CosmosIntegrationTestClient extends Matchers {
     }
 
     def packageRepositoryDelete(requestBody: PackageRepositoryDeleteRequest): PackageRepositoryDeleteResponse = {
-      val request = CosmosRequest.post(
+      val request = HttpRequest.post(
         "package/repository/delete",
         requestBody,
         MediaTypes.PackageRepositoryDeleteRequest,
@@ -143,7 +141,7 @@ object CosmosIntegrationTestClient extends Matchers {
       *
       * It also includes the Authorization header if provided by configuration.
       */
-    def submit(req: CosmosRequest): Response = {
+    def submit(req: HttpRequest): Response = {
       val reqWithAuth = Session.authorization match {
         case Some(auth) =>
           req.copy(headers = req.headers + (Fields.Authorization -> auth.headerValue))
@@ -151,7 +149,7 @@ object CosmosIntegrationTestClient extends Matchers {
           req
       }
 
-      val finagleReq = CosmosRequest.toFinagle(reqWithAuth)
+      val finagleReq = HttpRequest.toFinagle(reqWithAuth)
       Await.result(client(finagleReq))
     }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/test/CosmosIntegrationTestClient.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/test/CosmosIntegrationTestClient.scala
@@ -11,12 +11,11 @@ import com.mesosphere.cosmos.Trys
 import com.mesosphere.cosmos.Uris
 import com.mesosphere.cosmos.dcosUri
 import com.mesosphere.cosmos.http.Authorization
+import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.model.ZooKeeperUri
-import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
-import com.mesosphere.cosmos.rpc.v1.circe.Encoders._
 import com.mesosphere.cosmos.rpc.v1.model._
 import com.netaporter.uri.Uri
 import com.netaporter.uri.dsl._
@@ -101,34 +100,19 @@ object CosmosIntegrationTestClient extends Matchers {
     }
 
     def packageSearch(requestBody: SearchRequest): SearchResponse = {
-      val request = HttpRequest.post(
-        "package/search",
-        requestBody,
-        MediaTypes.SearchRequest,
-        MediaTypes.SearchResponse
-      )
+      val request = CosmosRequests.packageSearch(requestBody)
       val Xor.Right(response) = callEndpoint[SearchResponse](request)
       response
     }
 
     def packageRepositoryAdd(requestBody: PackageRepositoryAddRequest): PackageRepositoryAddResponse = {
-      val request = HttpRequest.post(
-        "package/repository/add",
-        requestBody,
-        MediaTypes.PackageRepositoryAddRequest,
-        MediaTypes.PackageRepositoryAddResponse
-      )
+      val request = CosmosRequests.packageRepositoryAdd(requestBody)
       val Xor.Right(response) = callEndpoint[PackageRepositoryAddResponse](request)
       response
     }
 
     def packageRepositoryDelete(requestBody: PackageRepositoryDeleteRequest): PackageRepositoryDeleteResponse = {
-      val request = HttpRequest.post(
-        "package/repository/delete",
-        requestBody,
-        MediaTypes.PackageRepositoryDeleteRequest,
-        MediaTypes.PackageRepositoryDeleteResponse
-      )
+      val request = CosmosRequests.packageRepositoryDelete(requestBody)
       val Xor.Right(response) = callEndpoint[PackageRepositoryDeleteResponse](request)
       response
     }


### PR DESCRIPTION
The methods are on a new `CosmosRequests` object. To prevent confusion, I renamed the existing `CosmosRequest` class to `HttpRequest`, which is arguably a more accurate name.

This should simplify writing integration tests!