### PR TITLE
Add ServiceAlreadyStarted error

### DIFF
--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
@@ -126,7 +126,7 @@ final class ServiceStartSpec extends FreeSpec with InstallQueueFixture with Befo
       assertResult(Some(rpc.MediaTypes.ErrorResponse.show))(startAgainResponse.contentType)
 
       val typedErrorResponse = decode[ErrorResponse](startAgainResponse.contentString)
-      assertResult(classOf[ServiceAlreadyStarted])(typedErrorResponse.`type`)
+      assertResult("ServiceAlreadyStarted")(typedErrorResponse.`type`)
     }
 
   }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
@@ -102,7 +102,7 @@ final class ServiceStartSpec extends FreeSpec with InstallQueueFixture with Befo
     }
 
     "return a ServiceAlreadyStarted when trying to start a service twice" in {
-      val packageName = "bitbucket"
+      val packageName = "kafka"
       val addResponse = addUniversePackage(packageName)
       assertResult(Status.Accepted)(addResponse.status)
 
@@ -116,7 +116,7 @@ final class ServiceStartSpec extends FreeSpec with InstallQueueFixture with Befo
       assertResult(packageName)(typedResponse.packageName)
 
       val Some(appId) = typedResponse.appId
-      assertResult("/bitbucket")(appId.toString)
+      assertResult("/kafka")(appId.toString)
 
       val marathonApp = getMarathonApp(appId)
       assertResult(appId)(marathonApp.id)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
@@ -126,7 +126,7 @@ final class ServiceStartSpec extends FreeSpec with InstallQueueFixture with Befo
       assertResult(Some(rpc.MediaTypes.ErrorResponse.show))(startAgainResponse.contentType)
 
       val typedErrorResponse = decode[ErrorResponse](startAgainResponse.contentString)
-      assertResult("ServiceAlreadyStarted")(typedErrorResponse.`type`)
+      assertResult(classOf[ServiceAlreadyStarted].getSimpleName)(typedErrorResponse.`type`)
     }
 
   }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
@@ -102,7 +102,7 @@ final class ServiceStartSpec extends FreeSpec with InstallQueueFixture with Befo
     }
 
     "return a ServiceAlreadyStarted when trying to start a service twice" in {
-      val packageName = "linkerd"
+      val packageName = "bitbucket"
       val addResponse = addUniversePackage(packageName)
       assertResult(Status.Accepted)(addResponse.status)
 
@@ -116,7 +116,7 @@ final class ServiceStartSpec extends FreeSpec with InstallQueueFixture with Befo
       assertResult(packageName)(typedResponse.packageName)
 
       val Some(appId) = typedResponse.appId
-      assertResult("/linkerd")(appId.toString)
+      assertResult("/bitbucket")(appId.toString)
 
       val marathonApp = getMarathonApp(appId)
       assertResult(appId)(marathonApp.id)

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -62,6 +62,9 @@ case class PackageFileSchemaMismatch(fileName: String, decodingFailure: Decoding
 case class PackageAlreadyInstalled() extends CosmosError {
   override val status = Status.Conflict
 }
+case class ServiceAlreadyStarted() extends CosmosError {
+  override val status = Status.Conflict
+}
 
 case class MarathonBadResponse(marathonError: MarathonError) extends CosmosError {
   override def getData: Option[JsonObject] = {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonPackageRunner.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonPackageRunner.scala
@@ -19,7 +19,7 @@ final class MarathonPackageRunner(adminRouter: AdminRouter) extends PackageRunne
       .map { response =>
         response.status match {
           case Status.Conflict =>
-            throw PackageAlreadyInstalled()
+            throw ServiceAlreadyStarted()
           case status if (400 until 500).contains(status.code) =>
             Try(decode[MarathonError](response.contentString)) match {
               case Success(marathonError) =>

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -252,6 +252,8 @@ object Encoders extends LowPriorityImplicits {
         s"Package file [$fileName] does not match schema"
       case PackageAlreadyInstalled() =>
         "Package is already installed"
+      case ServiceAlreadyStarted() =>
+        "The DC/OS service has already been started"
       case MarathonBadResponse(marathonErr) => marathonErr.message
       case MarathonGenericError(marathonStatus) =>
         s"Received response status code ${marathonStatus.code} from Marathon"


### PR DESCRIPTION
Add a new error called AlreadyStarted to Cosmos so that the CLI will print a better error when a package is already running. The current error has the word 'installed' in it, which does not conform to the new verbs.