### PR TITLE
Add getCreationTime to ObjectStorage

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageAddHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageAddHandler.scala
@@ -92,7 +92,7 @@ final class PackageAddHandler(
         if (zipEntry.isEmpty) {
           throw new Error("metadata.json not found in zip file")
         }
-        !zipEntry.map(_.getName).contains("matadata.json")
+        !zipEntry.map(_.getName).contains("metadata.json")
       }){}
 
       val metadataBytes = StreamIO.buffer(packageZip).toByteArray

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
@@ -22,6 +22,7 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.BasicFileAttributes
+import java.time.Instant
 import scala.collection.JavaConverters._
 import scala.collection.breakOut
 import scala.util.control.NonFatal
@@ -136,13 +137,13 @@ final class LocalObjectStorage private(storageDir: Path, scratchDir: Path, stats
 
   override def getUrl(name: String): Option[Uri] = None
 
-  override def getCreationTime(name: String): Future[Option[Long]] = {
+  override def getCreationTime(name: String): Future[Option[Instant]] = {
     pool {
       val absolutePath = storageDir.resolve(name)
       val attr = Try {
         Files.readAttributes(absolutePath, classOf[BasicFileAttributes])
       }
-      attr.toOption.map(_.creationTime().toMillis)
+      attr.toOption.map(_.creationTime().toInstant)
     }
   }
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
@@ -92,7 +92,10 @@ final class LocalObjectStorage private(storageDir: Path, scratchDir: Path, stats
               .toList
 
           pathsToDelete.foldLeft(Try(())) { (status, path) =>
-            status.map{ _ => Files.deleteIfExists(path); ()}
+            status.map{ _ =>
+              Files.deleteIfExists(path)
+              ()
+            }
           }.handle {
             case _: DirectoryNotEmptyException => ()
           }.get()

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
@@ -134,7 +134,7 @@ final class LocalObjectStorage private(storageDir: Path, scratchDir: Path, stats
     )
   }
 
-  override def getUrl(name: String): Future[Option[Uri]] = Future.value(None)
+  override def getUrl(name: String): Option[Uri] = None
 
   override def getCreationTime(name: String): Future[Option[Long]] = {
     pool {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
@@ -97,16 +97,12 @@ final class LocalObjectStorage private(storageDir: Path, scratchDir: Path, stats
       Iterator
         .iterate(fullName)(_.getParent)
         .takeWhile(_ != storageDir)
-        .toList
 
-    pathsToDelete.foldLeft(Try(())) { (status, path) =>
-      status.map { _ =>
-        Files.deleteIfExists(path)
-        ()
-      }
-    }.handle {
+    try {
+      pathsToDelete.foreach(Files.deleteIfExists)
+    } catch {
       case _: DirectoryNotEmptyException => ()
-    }.get()
+    }
   }
 
   override def list(directory: String): Future[LocalObjectStorage.ObjectList] = {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
@@ -136,10 +136,16 @@ final class LocalObjectStorage private(storageDir: Path, scratchDir: Path, stats
   override def getCreationTime(name: String): Future[Option[Instant]] = {
     pool {
       val absolutePath = storageDir.resolve(name)
-      val attr = Try {
-        Files.readAttributes(absolutePath, classOf[BasicFileAttributes])
+      try {
+        val creationTime =
+          Files
+          .readAttributes(absolutePath, classOf[BasicFileAttributes])
+          .creationTime
+          .toInstant
+        Some(creationTime)
+      } catch {
+        case _: NoSuchFileException => None
       }
-      attr.toOption.map(_.creationTime().toInstant)
     }
   }
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
@@ -127,9 +127,9 @@ final class LocalObjectStorage private(storageDir: Path, scratchDir: Path, stats
     )
   }
 
-  override def getUrl(name: String): Option[Uri] = None
+  override def getUrl(name: String): Future[Option[Uri]] = Future.value(None)
 
-  def getCreationTime(name: String): Future[Option[Long]] = {
+  override def getCreationTime(name: String): Future[Option[Long]] = {
     pool {
       val absolutePath = storageDir.resolve(name)
       val attr = Try {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/LocalObjectStorage.scala
@@ -85,9 +85,7 @@ final class LocalObjectStorage private(storageDir: Path, scratchDir: Path, stats
     Stat.timeFuture(stats.stat("delete")) {
       pool {
         val fullName = storageDir.resolve(name)
-        if (Files.exists(fullName)) {
-          deleteFileAndEmptyParents(fullName)
-        }
+        deleteFileAndEmptyParents(fullName)
       }
     }
   }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/ObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/ObjectStorage.scala
@@ -10,6 +10,7 @@ import com.netaporter.uri.Uri
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.util.Future
 import java.io.InputStream
+import java.time.Instant
 
 /**
  * General interface for storing and retrieving objects
@@ -76,7 +77,7 @@ trait ObjectStorage {
     * Gets the creation time of the object in the store. Returns None if the object does not
     * exist.
     */
-  def getCreationTime(name: String): Future[Option[Long]]
+  def getCreationTime(name: String): Future[Option[Instant]]
 }
 
 object ObjectStorage {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/ObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/ObjectStorage.scala
@@ -70,7 +70,7 @@ trait ObjectStorage {
   /**
    * Get the URL for an object if the backing store supports it.
    */
-  def getUrl(name: String): Future[Option[Uri]]
+  def getUrl(name: String): Option[Uri]
 
   /**
     * Gets the creation time of the object in the store. Returns None if the object does not

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/ObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/ObjectStorage.scala
@@ -70,7 +70,13 @@ trait ObjectStorage {
   /**
    * Get the URL for an object if the backing store supports it.
    */
-  def getUrl(name: String): Option[Uri]
+  def getUrl(name: String): Future[Option[Uri]]
+
+  /**
+    * Gets the creation time of the object in the store. Returns None if the object does not
+    * exist.
+    */
+  def getCreationTime(name: String): Future[Option[Long]]
 }
 
 object ObjectStorage {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/S3ObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/S3ObjectStorage.scala
@@ -123,13 +123,11 @@ final class S3ObjectStorage(
     Stat.timeFuture(stats.stat("getCreationTime")) {
       pool {
         try {
-          Some(
-            Instant.ofEpochMilli(
-              client
-                .getObjectMetadata(new GetObjectMetadataRequest(bucket, fullPath(name)))
-                .getLastModified.getTime
-            )
-          )
+          val creationTimeInMillis =
+            client
+            .getObjectMetadata(new GetObjectMetadataRequest(bucket, fullPath(name)))
+            .getLastModified.getTime
+          Some(Instant.ofEpochMilli(creationTimeInMillis))
         } catch {
           case e: AmazonS3Exception if e.getErrorCode == "NoSuchKey" =>
             None

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/S3ObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/S3ObjectStorage.scala
@@ -16,6 +16,8 @@ import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.util.Future
 import com.twitter.util.FuturePool
 import java.io.InputStream
+import java.time.Instant
+
 import scala.collection.JavaConverters._
 import scala.collection.breakOut
 
@@ -117,15 +119,16 @@ final class S3ObjectStorage(
     Some(Uri(client.getUrl(bucket, fullPath(name)).toURI))
   }
 
-  override def getCreationTime(name: String): Future[Option[Long]] = {
+  override def getCreationTime(name: String): Future[Option[Instant]] = {
     Stat.timeFuture(stats.stat("getCreationTime")) {
       pool {
         try {
           Some(
-            client
-              .getObjectMetadata(new GetObjectMetadataRequest(bucket, fullPath(name)))
-              .getLastModified
-              .getTime
+            Instant.ofEpochMilli(
+              client
+                .getObjectMetadata(new GetObjectMetadataRequest(bucket, fullPath(name)))
+                .getLastModified.getTime
+            )
           )
         } catch {
           case e: AmazonS3Exception if e.getErrorCode == "NoSuchKey" =>

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/S3ObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/S3ObjectStorage.scala
@@ -16,7 +16,6 @@ import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.util.Future
 import com.twitter.util.FuturePool
 import java.io.InputStream
-
 import scala.collection.JavaConverters._
 import scala.collection.breakOut
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/S3ObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/S3ObjectStorage.scala
@@ -123,11 +123,11 @@ final class S3ObjectStorage(
     Stat.timeFuture(stats.stat("getCreationTime")) {
       pool {
         try {
-          val creationTimeInMillis =
+          val creationTime =
             client
             .getObjectMetadata(new GetObjectMetadataRequest(bucket, fullPath(name)))
-            .getLastModified.getTime
-          Some(Instant.ofEpochMilli(creationTimeInMillis))
+            .getLastModified.toInstant
+          Some(creationTime)
         } catch {
           case e: AmazonS3Exception if e.getErrorCode == "NoSuchKey" =>
             None

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/S3ObjectStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/storage/S3ObjectStorage.scala
@@ -113,7 +113,7 @@ final class S3ObjectStorage(
     }
   }
 
-  override def getUrl(name: String): Future[Option[Uri]] = Future.value {
+  override def getUrl(name: String): Option[Uri] = {
     Some(Uri(client.getUrl(bucket, fullPath(name)).toURI))
   }
 

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
@@ -185,7 +185,6 @@ object LocalObjectStorageSpec {
 
   def isValidPath(s: String): Boolean =
     s.nonEmpty &&
-      !s.forall(_ == '/') &&
       !s.startsWith("/") &&
       !s.contains("//") &&
       !s.endsWith("/")

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
@@ -135,7 +135,7 @@ final class LocalObjectStorageSpec extends FreeSpec with PropertyChecks {
         Await.result {
           for {
             _ <- localStorage.write(path, dataToWrite)
-            url <- localStorage.getUrl(path)
+            url <- Future(localStorage.getUrl(path))
             _ <- Future(assertResult(None)(url))
           } yield ()
         }

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
@@ -1,8 +1,11 @@
 package com.mesosphere.cosmos.storage
 
+import com.mesosphere.cosmos.http.MediaType
+import com.mesosphere.cosmos.http.MediaTypes
 import com.mesosphere.cosmos.test.TestUtil
 import com.twitter.io.StreamIO
 import com.twitter.util.Await
+import com.twitter.util.Future
 import java.io.ByteArrayInputStream
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
@@ -14,31 +17,147 @@ final class LocalObjectStorageSpec extends FreeSpec with PropertyChecks {
   import LocalObjectStorageSpec._
 
   "read() on a nonexistent file returns Future(None)" in {
-    TestUtil.withLocalObjectStorage { localStorage =>
-      forAll (genPath) { path =>
-        whenever (isValidPath(path)) {
-          assertResult(None) {
-            Await.result(localStorage.read(path))
-          }
+    forAll(genPath) { path =>
+      TestUtil.withLocalObjectStorage { localStorage =>
+        assertResult(None) {
+          Await.result(localStorage.read(path))
         }
       }
     }
   }
 
   "read() cannot observe partial writes to a file" in {
-    forAll (genPath, arbitrary[Array[Byte]]) { (path, dataToWrite) =>
-      whenever (isValidPath(path)) {
-        TestUtil.withLocalObjectStorage { localStorage =>
-          val writeStream = new ByteArrayInputStream(dataToWrite)
-          val contentLength = dataToWrite.length.toLong
+    forAll(genPath, arbitrary[Array[Byte]]) { (path, dataToWrite) =>
+      TestUtil.withLocalObjectStorage { localStorage =>
+        val writeOp = localStorage.write(path, dataToWrite)
+        val readOp = TestUtil.eventualFuture(() => localStorage.readAsArray(path))
+        val (_, (_, dataFromRead)) = Await.result(writeOp.join(readOp))
+        assertResult(dataToWrite)(dataFromRead)
+      }
+    }
+  }
 
-          val writeOp = localStorage.write(path, writeStream, contentLength)
-          val readOp = TestUtil.eventualFuture(() => localStorage.read(path))
-          val (_, (_, readStream)) = Await.result(writeOp.join(readOp))
-          val dataFromRead = StreamIO.buffer(readStream).toByteArray
+  "read() on a deleted file returns Future(None)" in {
+    forAll(genPath, arbitrary[Array[Byte]]) { (path, dataToWrite) =>
+      TestUtil.withLocalObjectStorage { localStorage =>
+        Await.result {
+          for {
+            _ <- localStorage.write(path, dataToWrite)
+            Some((_, dataFromRead)) <- localStorage.readAsArray(path)
+            _ <- Future(assertResult(dataToWrite)(dataFromRead))
+            _ <- localStorage.delete(path)
+            failedRead <- localStorage.readAsArray(path)
+            _ <- Future(assertResult(None)(failedRead))
+          } yield ()
+        }
+      }
+    }
+  }
 
-          assertResult(contentLength)(dataFromRead.length.toLong)
-          assertResult(dataToWrite)(dataFromRead)
+  "read() returns the previously written MediaType" in {
+    forAll(genPath, arbitrary[Array[Byte]], genMediaType) { (path, dataToWrite, mediaTypeToWrite) =>
+      TestUtil.withLocalObjectStorage { localStorage =>
+        Await.result {
+          for {
+            _ <- localStorage.write(path, dataToWrite, Some(mediaTypeToWrite))
+            Some((mediaTypeFromRead, _)) <- localStorage.readAsArray(path)
+            _ <- Future(assertResult(mediaTypeToWrite)(mediaTypeFromRead))
+          } yield ()
+        }
+      }
+    }
+  }
+
+  "write() stores applicationOctetStream as default MediaType" in {
+    forAll(genPath, arbitrary[Array[Byte]]) { (path, dataToWrite) =>
+      TestUtil.withLocalObjectStorage { localStorage =>
+        Await.result {
+          for {
+            _ <- localStorage.write(path, dataToWrite)
+            Some((mediaType, _)) <- localStorage.readAsArray(path)
+            _ <- Future(assertResult(MediaTypes.applicationOctetStream)(mediaType))
+          } yield ()
+        }
+      }
+    }
+  }
+
+  "delete() removes all empty parent directories" in {
+    forAll(genObjectStorageState) { objectStorageState =>
+      TestUtil.withLocalObjectStorage { localStorage =>
+        Await.result {
+          for {
+            _ <- localStorage.writeAll(objectStorageState)
+            _ <- localStorage.deleteAll(objectStorageState.map(_.name))
+            objects <- localStorage.list("")
+            _ <- Future(assertResult(List())(objects.directories))
+          } yield ()
+        }
+      }
+    }
+  }
+
+  "write() must not change the case of paths" in {
+    val name1 = "B/nR/xyharPhq"
+    val name2 = "b/5nRzknggv/ilygo3oj"
+    val badName1 = "b/nR/xyharphq"
+    TestUtil.withLocalObjectStorage { localStorage =>
+      Await.result {
+        for {
+          _ <- localStorage.write(name1, Array[Byte]())
+          _ <- localStorage.write(name2, Array[Byte]())
+          itemAtBadName <- localStorage.readAsArray(badName1)
+          _ <- Future(assertResult(None)(itemAtBadName))
+        } yield ()
+      }
+    }
+  }
+
+  "list() returns all objects written" in {
+    forAll(genObjectStorageState) { objectStorageState =>
+      TestUtil.withLocalObjectStorage { localStorage =>
+        Await.result {
+          val namesToWrite = objectStorageState.map(_.name)
+          for {
+            _ <- localStorage.writeAll(objectStorageState)
+            namesInStorage <- localStorage.listAll("")
+            _ <- Future(assertResult(namesToWrite.sorted)(namesInStorage.sorted))
+            _ <- localStorage.deleteAll(objectStorageState.map(_.name))
+          } yield ()
+        }
+      }
+    }
+  }
+
+  "getUrl() return None for all objects" in {
+    forAll(genPath, arbitrary[Array[Byte]]) { (path, dataToWrite) =>
+      TestUtil.withLocalObjectStorage { localStorage =>
+        Await.result {
+          for {
+            _ <- localStorage.write(path, dataToWrite)
+            url <- Future(localStorage.getUrl(path))
+            _ <- Future(assertResult(None)(url))
+          } yield ()
+        }
+      }
+    }
+  }
+
+  "getCreationTime returns the time the object was created" in {
+    forAll(genPath, arbitrary[Array[Byte]]) { (path, dataToWrite) =>
+      TestUtil.withLocalObjectStorage { localStorage =>
+        Await.result {
+          val twoSeconds = 2000
+          for {
+            timeBefore <- Future(System.currentTimeMillis() - twoSeconds)
+            _ <- localStorage.write(path, dataToWrite)
+            creationTime <- localStorage.getCreationTime(path)
+            timeAfter <- Future(System.currentTimeMillis() + twoSeconds)
+            _ <- Future(assert(
+              timeBefore < creationTime.get && creationTime.get < timeAfter,
+              List(timeBefore, creationTime, timeAfter)
+            ))
+          } yield ()
         }
       }
     }
@@ -48,20 +167,100 @@ final class LocalObjectStorageSpec extends FreeSpec with PropertyChecks {
 
 object LocalObjectStorageSpec {
 
+  case class ObjectStorageItem(name: String, content: Array[Byte], mediaType: Option[MediaType])
+
+  type ObjectStorageState = List[ObjectStorageItem]
+
   val genPath: Gen[String] = {
     val maxSegments = 10
     val maxSegmentLength = 10
     val genSegment = Gen.choose(1, maxSegmentLength)
       .flatMap(Gen.buildableOfN[String, Char](_, Gen.alphaNumChar))
 
-    for {
+    (for {
       numSegments <- Gen.choose(1, maxSegments)
       segments <- Gen.listOfN(numSegments, genSegment)
       path = segments.mkString("/")
-      if isValidPath(path)
-    } yield path
+    } yield path).suchThat(isValidPath)
   }
 
-  def isValidPath(s: String): Boolean = s.nonEmpty && !s.forall(_ == '/') && !s.startsWith("/")
+  def isValidPath(s: String): Boolean =
+    s.nonEmpty &&
+      !s.forall(_ == '/') &&
+      !s.startsWith("/") &&
+      !s.contains("//") &&
+      !s.endsWith("/")
+
+  val genMediaType: Gen[MediaType] = {
+    val mediaTypes = Array(
+      MediaTypes.applicationJson,
+      MediaTypes.applicationOctetStream,
+      MediaTypes.OperationStatus,
+      MediaTypes.RepositoryList
+    )
+    Gen.choose(0, mediaTypes.length - 1).map(mediaTypes)
+  }
+
+  val genObjectStorageItem: Gen[ObjectStorageItem] = {
+    for {
+      path <- genPath
+      mediaType <- Gen.option(genMediaType)
+      data <- arbitrary[Array[Byte]]
+    } yield ObjectStorageItem(path, data, mediaType)
+  }
+
+  val genObjectStorageState: Gen[ObjectStorageState] = {
+    Gen.listOf(genObjectStorageItem).suchThat { state =>
+      !pathsConflict(state.map(_.name))
+    }
+  }
+
+  def pathsConflict(paths: List[String]): Boolean = {
+    paths.combinations(2).exists { case List(a, b) =>
+      a.startsWith(b) || b.startsWith(a)
+    }
+  }
+
+  implicit class ObjectStorageNoStreams(objectStorage: LocalObjectStorage) {
+
+    def write(name: String, content: Array[Byte], mediaType: Option[MediaType] = None): Future[Unit] = {
+      val body = new ByteArrayInputStream(content)
+      val contentLength = content.length.toLong
+      objectStorage.write(name, body, contentLength, mediaType)
+    }
+
+    def readAsArray(name: String): Future[Option[(MediaType, Array[Byte])]] = {
+      objectStorage.read(name).map(_.map { case (mediaType, readStream) =>
+        (mediaType, StreamIO.buffer(readStream).toByteArray)
+      })
+    }
+
+    def listAll(base: String): Future[List[String]] = {
+      objectStorage.list(base).flatMap { objectList =>
+        Future.collect(
+          objectList.directories
+            .map(listAll)
+        ).map { rest =>
+          (objectList.objects :: rest.toList).flatten
+        }
+      }
+    }
+
+    def writeAll(objectStorageItems: List[ObjectStorageItem]): Future[Unit] = {
+      Future.collect(
+        objectStorageItems.map { objectStorageItem =>
+          write(objectStorageItem.name, objectStorageItem.content, objectStorageItem.mediaType)
+        }
+      ).map(_ => ())
+    }
+
+    def deleteAll(names: List[String]): Future[Unit] = {
+      Future.collect(
+        names.map { name =>
+          objectStorage.delete(name)
+        }
+      ).map(_ => ())
+    }
+  }
 
 }

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
@@ -138,7 +138,7 @@ final class LocalObjectStorageSpec extends FreeSpec with PropertyChecks {
     }
   }
 
-  "delete() does not delete any other elements parents" in {
+  "delete() does not delete any other object's parents" in {
     forAll(genObjectStorageItemPairAndSharedParents) { case (parents, item1, item2) =>
       TestUtil.withLocalObjectStorage { storage =>
         val objects = Await.result {
@@ -182,7 +182,7 @@ final class LocalObjectStorageSpec extends FreeSpec with PropertyChecks {
     }
   }
 
-  "getCreationTime() return none in the file does not exist" in {
+  "getCreationTime() returns None if object does not exist" in {
     forAll(genPath) { name =>
       TestUtil.withLocalObjectStorage { storage =>
         val creationTime = Await.result {

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
@@ -142,7 +142,7 @@ final class LocalObjectStorageSpec extends FreeSpec with PropertyChecks {
     }
   }
 
-  "getCreationTime returns the time the object was created" in {
+  "getCreationTime() returns the time the object was created" in {
     forAll(genPath, arbitrary[Array[Byte]]) { (path, dataToWrite) =>
       TestUtil.withLocalObjectStorage { localStorage =>
         Await.result {
@@ -156,6 +156,19 @@ final class LocalObjectStorageSpec extends FreeSpec with PropertyChecks {
               timeBefore.isBefore(creationTime.get) && timeAfter.isAfter(creationTime.get),
               List(timeBefore, creationTime, timeAfter)
             ))
+          } yield ()
+        }
+      }
+    }
+  }
+
+  "getCreationTime() return none in the file does not exist" in {
+    forAll(genPath) { path =>
+      TestUtil.withLocalObjectStorage { localStorage =>
+        Await.result {
+          for {
+            creationTime <- localStorage.getCreationTime(path)
+            _ <- Future(assertResult(None)(creationTime))
           } yield ()
         }
       }

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
@@ -97,15 +97,13 @@ final class LocalObjectStorageSpec extends FreeSpec with PropertyChecks {
     }
   }
 
-  "write() must not change the case of paths" in {
+  "write() and read() must be case sensitive" in {
     val name1 = "B/nR/xyharPhq"
-    val name2 = "b/5nRzknggv/ilygo3oj"
     val badName1 = "b/nR/xyharphq"
     TestUtil.withLocalObjectStorage { localStorage =>
       Await.result {
         for {
           _ <- localStorage.write(name1, Array[Byte]())
-          _ <- localStorage.write(name2, Array[Byte]())
           itemAtBadName <- localStorage.readAsArray(badName1)
           _ <- Future(assertResult(None)(itemAtBadName))
         } yield ()

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
@@ -135,7 +135,7 @@ final class LocalObjectStorageSpec extends FreeSpec with PropertyChecks {
         Await.result {
           for {
             _ <- localStorage.write(path, dataToWrite)
-            url <- Future(localStorage.getUrl(path))
+            url <- localStorage.getUrl(path)
             _ <- Future(assertResult(None)(url))
           } yield ()
         }

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/LocalObjectStorageSpec.scala
@@ -219,7 +219,7 @@ object LocalObjectStorageSpec {
     }
   }
 
-  implicit class ObjectStorageNoStreams(objectStorage: LocalObjectStorage) {
+  implicit class ObjectStorageNoStreams(val objectStorage: LocalObjectStorage) extends AnyVal {
 
     def write(name: String, content: Array[Byte], mediaType: Option[MediaType] = None): Future[Unit] = {
       val body = new ByteArrayInputStream(content)


### PR DESCRIPTION
This PR will add a method getCreationTime to the ObjectStorage. This will be used for the garbage collection algorithm to determine whether a staging object should be removed or not.