### PR TITLE
Disable warnings for unresolved documentation links

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -201,6 +201,8 @@ object CosmosBuild extends Build {
 
     scalacOptions in (Test, console) ~= (_ filterNot (_ == "-Ywarn-unused-import")),
 
+    scalacOptions in (Compile, doc) += "-no-link-warnings",
+
     // Publishing options:
     publishMavenStyle := true,
 


### PR DESCRIPTION
These warnings have been around for a while, but in #570 the `-Xfatal-warnings` compiler flag was added, causing our [JAR publishing build](https://teamcity.mesosphere.io/viewType.html?buildTypeId=DcosIo_Cosmos_MavenCentral_SnapshotMaster) to fail. While we could try to have the links resolve correctly, that would be [more work](https://issues.scala-lang.org/browse/SI-9311), with not much benefit for now (is anyone using our Scaladoc?).

I've also updated our [CI build](https://teamcity.mesosphere.io/viewType.html?buildTypeId=DcosIo_Cosmos_Ci) to generate documentation, so we can catch problems like this at the PR stage.