### PR TITLE
Set Cosmos version to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The following table outlines which version of Cosmos is bundled with each versio
 | 1.6.1                 | 0.1.2          |
 | 1.7.x                 | 0.1.5          |
 | 1.8.x                 | 0.2.0          |
+| 1.9.x                 | 0.3.0          |
 
 ### Universe
 
@@ -122,6 +123,7 @@ The below table is a compatibility matrix between Cosmos and Universe repository
 | ----- | ----------------------------- | ---------------------------------------------------------------- |
 | 0.1.x | Supported                     | Not Supported                                                    |
 | 0.2.0 | Supported                     | Supported                                                        |
+| 0.3.0 | Supported                     | Supported                                                        |
 
 
 #### Packaging Version
@@ -134,6 +136,7 @@ The below table is a compatibility matrix between Cosmos and Universe packaging 
 | ----- | --------- | ------------- |
 | 0.1.x | Supported | Not Supported |
 | 0.2.0 | Supported | Supported     |
+| 0.3.0 | Supported | Supported     |
 
 ### API Method Version Compatibility
 

--- a/project/build.scala
+++ b/project/build.scala
@@ -9,7 +9,7 @@ import sbt._
 object CosmosBuild extends Build {
 
   lazy val projectScalaVersion = "2.11.7"
-  lazy val projectVersion = "0.3.0-SNAPSHOT"
+  lazy val projectVersion = "0.3.0"
 
   object V {
     val bijection = "0.9.2"


### PR DESCRIPTION
I'll tag the release commit once this is merged. Then I'll cherry-pick this change to `master`, but set the version to `0.4.0-SNAPSHOT` instead.