### PR TITLE
Ensure kafka service gets cleaned up after test

### DIFF
--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
@@ -28,7 +28,7 @@ final class ServiceStartSpec extends FreeSpec with InstallQueueFixture with Befo
     val uninstallCassandra =
       rpc.v1.model.UninstallRequest("cassandra", appId = None, all = Some(true))
     val uninstallLinkerd =
-      rpc.v1.model.UninstallRequest("linkerd", appId = None, all = Some(true))
+      rpc.v1.model.UninstallRequest("kafka", appId = None, all = Some(true))
     val uninstallHelloworld =
       rpc.v1.model.UninstallRequest("helloworld", appId = None, all = Some(true))
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/ServiceStartSpec.scala
@@ -27,13 +27,13 @@ final class ServiceStartSpec extends FreeSpec with InstallQueueFixture with Befo
   after {
     val uninstallCassandra =
       rpc.v1.model.UninstallRequest("cassandra", appId = None, all = Some(true))
-    val uninstallLinkerd =
+    val uninstallKafka =
       rpc.v1.model.UninstallRequest("kafka", appId = None, all = Some(true))
     val uninstallHelloworld =
       rpc.v1.model.UninstallRequest("helloworld", appId = None, all = Some(true))
 
     CosmosClient.submit(CosmosRequests.packageUninstall(uninstallCassandra))
-    CosmosClient.submit(CosmosRequests.packageUninstall(uninstallLinkerd))
+    CosmosClient.submit(CosmosRequests.packageUninstall(uninstallKafka))
     val _ = CosmosClient.submit(CosmosRequests.packageUninstall(uninstallHelloworld))
 
     // TODO package-add: Remove uploaded packages from storage


### PR DESCRIPTION
When running the integration tests locally, I've noticed that they would leave a Kafka instance in the cluster after they finished. This would result in some tests failing on the next run. It's been happening for at least a few weeks, and it got annoying enough that I decided to just fix it.