### PR TITLE
Script for generating API documentation

### DIFF
--- a/build/generate_api.sh
+++ b/build/generate_api.sh
@@ -11,16 +11,22 @@ mkdir -p "$TARGET_DIR"
 # Build a docker image with raml2html
 sudo docker build --tag ramltools "$REPO_DIR/docker/ramltools"
 
-# Generate the API HTML using the built docker image
-sudo docker run --volume="$REPO_DIR":/src:ro --rm ramltools /usr/local/bin/raml2html \
-  /src/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/api.raml \
-  > "$TARGET_DIR/api.html"
+for SERVICE in capabilities service package
+do
+  # Generate the API HTML using the built docker image
+  echo "Generating $SERVICE.html"
+  sudo docker run --volume="$REPO_DIR":/src:ro --rm ramltools /usr/local/bin/raml2html \
+    "/src/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/$SERVICE.raml" \
+    > "$TARGET_DIR/$SERVICE.html"
 
-# Generate the API Swagger using the built docker image
-sudo docker run --volume="$REPO_DIR":/src:ro --rm ramltools /usr/local/bin/raml2swagger \
-  /src/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/api.raml \
-  > "$TARGET_DIR/api.swagger"
+  # Generate the API Swagger using the built docker image
+  echo "Generating $SERVICE.swagger"
+  sudo docker run --volume="$REPO_DIR":/src:ro --rm ramltools /usr/local/bin/raml2swagger \
+    "/src/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/$SERVICE.raml" \
+    > "$TARGET_DIR/$SERVICE.swagger"
 
-# Copy the API RAML
-cp "$REPO_DIR/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/api.raml" \
-  "$TARGET_DIR/api.raml"
+  # Copy the API RAML
+  echo "Copying $SERVICE.raml"
+  cp "$REPO_DIR/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/$SERVICE.raml" \
+    "$TARGET_DIR/$SERVICE.raml"
+done

--- a/build/generate_api.sh
+++ b/build/generate_api.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Used to generate the API HTML
+
+set -e -o pipefail
+
+REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+TARGET_DIR="$REPO_DIR/cosmos-server/target"
+mkdir -p "$TARGET_DIR"
+
+# Build a docker image with raml2html
+sudo docker image build --tag ramltools "$REPO_DIR/docker/ramltools"
+
+# Generate the API HTML using the built docker image
+sudo docker container run --volume=$REPO_DIR:/src --rm ramltools /usr/local/bin/raml2html \
+  /src/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/api.raml \
+  > "$TARGET_DIR/api.html"
+
+# Generate the API Swagger using the built docker image
+sudo docker container run --volume=$REPO_DIR:/src --rm ramltools /usr/local/bin/raml2swagger \
+  /src/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/api.raml \
+  > "$TARGET_DIR/api.swagger"
+
+# Copy the API RAML
+cp "$REPO_DIR/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/api.raml" \
+  "$TARGET_DIR/api.raml"

--- a/build/generate_api.sh
+++ b/build/generate_api.sh
@@ -12,12 +12,12 @@ mkdir -p "$TARGET_DIR"
 sudo docker image build --tag ramltools "$REPO_DIR/docker/ramltools"
 
 # Generate the API HTML using the built docker image
-sudo docker container run --volume=$REPO_DIR:/src --rm ramltools /usr/local/bin/raml2html \
+sudo docker container run --volume="$REPO_DIR":/src:ro --rm ramltools /usr/local/bin/raml2html \
   /src/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/api.raml \
   > "$TARGET_DIR/api.html"
 
 # Generate the API Swagger using the built docker image
-sudo docker container run --volume=$REPO_DIR:/src --rm ramltools /usr/local/bin/raml2swagger \
+sudo docker container run --volume="$REPO_DIR":/src:ro --rm ramltools /usr/local/bin/raml2swagger \
   /src/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/api.raml \
   > "$TARGET_DIR/api.swagger"
 

--- a/build/generate_api.sh
+++ b/build/generate_api.sh
@@ -9,15 +9,15 @@ TARGET_DIR="$REPO_DIR/cosmos-server/target"
 mkdir -p "$TARGET_DIR"
 
 # Build a docker image with raml2html
-sudo docker image build --tag ramltools "$REPO_DIR/docker/ramltools"
+sudo docker build --tag ramltools "$REPO_DIR/docker/ramltools"
 
 # Generate the API HTML using the built docker image
-sudo docker container run --volume="$REPO_DIR":/src:ro --rm ramltools /usr/local/bin/raml2html \
+sudo docker run --volume="$REPO_DIR":/src:ro --rm ramltools /usr/local/bin/raml2html \
   /src/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/api.raml \
   > "$TARGET_DIR/api.html"
 
 # Generate the API Swagger using the built docker image
-sudo docker container run --volume="$REPO_DIR":/src:ro --rm ramltools /usr/local/bin/raml2swagger \
+sudo docker run --volume="$REPO_DIR":/src:ro --rm ramltools /usr/local/bin/raml2swagger \
   /src/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/api.raml \
   > "$TARGET_DIR/api.swagger"
 

--- a/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/capabilities.raml
+++ b/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/capabilities.raml
@@ -1,0 +1,19 @@
+#%RAML 1.0
+title: DC/OS Capabilities
+/capabilities:
+  get:
+    description: List all of the capabilities supported by DC/OS.
+    headers:
+      Accept:
+        enum: [application/vnd.dcos.capabilities+json;charset=utf-8;version=v1]
+    responses:
+      200:
+        body:
+          application/vnd.dcos.capabilities+json;charset=utf-8;version=v1:
+            type: !include ../../../../../../../../cosmos-model/src/main/resources/com/mesosphere/cosmos/rpc/v1/model/CapabilitiesResponse-schema.json
+            example:
+              capabilities:
+                - name: PACKAGE_MANAGEMENT
+                - name: SUPPORT_CLUSTER_REPORT
+                - name: METRONOME
+                - name: LOGGING

--- a/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/package.raml
+++ b/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/package.raml
@@ -1,5 +1,5 @@
 #%RAML 1.0
-title: DC/OS Package and Service
+title: DC/OS Package
 /package:
   description: Implements all packaging operations required for managing packages in DC/OS.
   /install:
@@ -279,43 +279,3 @@ title: DC/OS Package and Service
                   repositories:
                     - name: Universe
                       uri: https://universe.mesosphere.com/repo
-/capabilities:
-  get:
-    description: List all of the capabilities supported by DC/OS.
-    headers:
-      Accept:
-        enum: [application/vnd.dcos.capabilities+json;charset=utf-8;version=v1]
-    responses:
-      200:
-        body:
-          application/vnd.dcos.capabilities+json;charset=utf-8;version=v1:
-            type: !include ../../../../../../../../cosmos-model/src/main/resources/com/mesosphere/cosmos/rpc/v1/model/CapabilitiesResponse-schema.json
-            example:
-              capabilities:
-                - name: PACKAGE_MANAGEMENT
-                - name: SUPPORT_CLUSTER_REPORT
-                - name: METRONOME
-                - name: LOGGING
-/service:
-  /start:
-    post:
-      description: |
-        **Experimental.** Starts a DC/OS Service from a DC/OS package.
-      headers:
-        Accept:
-          enum: [application/vnd.dcos.sevice.start-response+json;charset=utf-8;version=v1]
-      body:
-        application/vnd.dcos.sevice.start-request+json;charset=utf-8;version=v1:
-          type: !include ../../../../../../../../cosmos-model/src/main/resources/com/mesosphere/cosmos/rpc/v1/model/ServiceStartRequest-schema.json
-          example:
-            packageName: cassandra
-            packageVersion: 1.0.24-3.0.10
-      responses:
-        200:
-          body:
-            application/vnd.dcos.sevice.start-response+json;charset=utf-8;version=v1:
-              type: !include ../../../../../../../../cosmos-model/src/main/resources/com/mesosphere/cosmos/rpc/v1/model/ServiceStartResponse-schema.json
-              example:
-                packageName: cassandra
-                packageVersion: 1.0.24-3.0.10
-                appId: /cassandra

--- a/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/service.raml
+++ b/cosmos-server/src/main/resources/com/mesosphere/cosmos/handler/service.raml
@@ -1,0 +1,25 @@
+#%RAML 1.0
+title: DC/OS Service
+/service:
+  /start:
+    post:
+      description: |
+        **Experimental.** Starts a DC/OS Service from a DC/OS package.
+      headers:
+        Accept:
+          enum: [application/vnd.dcos.sevice.start-response+json;charset=utf-8;version=v1]
+      body:
+        application/vnd.dcos.sevice.start-request+json;charset=utf-8;version=v1:
+          type: !include ../../../../../../../../cosmos-model/src/main/resources/com/mesosphere/cosmos/rpc/v1/model/ServiceStartRequest-schema.json
+          example:
+            packageName: cassandra
+            packageVersion: 1.0.24-3.0.10
+      responses:
+        200:
+          body:
+            application/vnd.dcos.sevice.start-response+json;charset=utf-8;version=v1:
+              type: !include ../../../../../../../../cosmos-model/src/main/resources/com/mesosphere/cosmos/rpc/v1/model/ServiceStartResponse-schema.json
+              example:
+                packageName: cassandra
+                packageVersion: 1.0.24-3.0.10
+                appId: /cassandra

--- a/dcos-image/publish-package.bash
+++ b/dcos-image/publish-package.bash
@@ -23,6 +23,9 @@ function copy {(
 
   mkdir -p ${TARGET_DIR}
   cp ${PROJECT_DIR}/cosmos-server/target/scala-2.11/cosmos-server_2.11-*-one-jar.jar ${TARGET_DIR}/${ONE_JAR}
+  cp ${PROJECT_DIR}/cosmos-server/target/api.html ${TARGET_DIR}
+  cp ${PROJECT_DIR}/cosmos-server/target/api.raml ${TARGET_DIR}
+  cp ${PROJECT_DIR}/cosmos-server/target/api.swagger ${TARGET_DIR}
 
 )}
 
@@ -51,6 +54,11 @@ function deploy {(
   info "Uploading artifact to: ${url}"
   aws s3 cp ${TARGET_DIR}/${ONE_JAR} ${S3_DEPLOY_BUCKET}/${ONE_JAR}
   aws s3 cp ${TARGET_DIR}/${SHA1_FILE} ${S3_DEPLOY_BUCKET}/${SHA1_FILE}
+
+  # Copy the documentation to S3
+  aws s3 cp ${TARGET_DIR}/api.html ${S3_DEPLOY_BUCKET}/
+  aws s3 cp ${TARGET_DIR}/api.raml ${S3_DEPLOY_BUCKET}/
+  aws s3 cp ${TARGET_DIR}/api.swagger ${S3_DEPLOY_BUCKET}/
 
   info "Generating buildinfo.json"
   cat ${DCOS_IMAGE_DIR}/buildinfo.json | \

--- a/dcos-image/publish-package.bash
+++ b/dcos-image/publish-package.bash
@@ -57,9 +57,12 @@ function deploy {(
 
   # Copy the documentation to S3
   info "Uploading documentation to: ${S3_DEPLOY_BUCKET}"
-  aws s3 cp "${TARGET_DIR}/*.html" ${S3_DEPLOY_BUCKET}/
-  aws s3 cp "${TARGET_DIR}/*.raml" ${S3_DEPLOY_BUCKET}/
-  aws s3 cp "${TARGET_DIR}/*.swagger" ${S3_DEPLOY_BUCKET}/
+  for SERVICE in capabilities service package
+  do
+    aws s3 cp "${TARGET_DIR}/$SERVICE.html" ${S3_DEPLOY_BUCKET}/
+    aws s3 cp "${TARGET_DIR}/$SERVICE.raml" ${S3_DEPLOY_BUCKET}/
+    aws s3 cp "${TARGET_DIR}/$SERVICE.swagger" ${S3_DEPLOY_BUCKET}/
+  done
 
   info "Generating buildinfo.json"
   cat ${DCOS_IMAGE_DIR}/buildinfo.json | \

--- a/dcos-image/publish-package.bash
+++ b/dcos-image/publish-package.bash
@@ -23,9 +23,9 @@ function copy {(
 
   mkdir -p ${TARGET_DIR}
   cp ${PROJECT_DIR}/cosmos-server/target/scala-2.11/cosmos-server_2.11-*-one-jar.jar ${TARGET_DIR}/${ONE_JAR}
-  cp ${PROJECT_DIR}/cosmos-server/target/api.html ${TARGET_DIR}
-  cp ${PROJECT_DIR}/cosmos-server/target/api.raml ${TARGET_DIR}
-  cp ${PROJECT_DIR}/cosmos-server/target/api.swagger ${TARGET_DIR}
+  cp ${PROJECT_DIR}/cosmos-server/target/*.html ${TARGET_DIR}
+  cp ${PROJECT_DIR}/cosmos-server/target/*.raml ${TARGET_DIR}
+  cp ${PROJECT_DIR}/cosmos-server/target/*.swagger ${TARGET_DIR}
 
 )}
 
@@ -56,9 +56,10 @@ function deploy {(
   aws s3 cp ${TARGET_DIR}/${SHA1_FILE} ${S3_DEPLOY_BUCKET}/${SHA1_FILE}
 
   # Copy the documentation to S3
-  aws s3 cp ${TARGET_DIR}/api.html ${S3_DEPLOY_BUCKET}/
-  aws s3 cp ${TARGET_DIR}/api.raml ${S3_DEPLOY_BUCKET}/
-  aws s3 cp ${TARGET_DIR}/api.swagger ${S3_DEPLOY_BUCKET}/
+  info "Uploading documentation to: ${S3_DEPLOY_BUCKET}"
+  aws s3 cp "${TARGET_DIR}/*.html" ${S3_DEPLOY_BUCKET}/
+  aws s3 cp "${TARGET_DIR}/*.raml" ${S3_DEPLOY_BUCKET}/
+  aws s3 cp "${TARGET_DIR}/*.swagger" ${S3_DEPLOY_BUCKET}/
 
   info "Generating buildinfo.json"
   cat ${DCOS_IMAGE_DIR}/buildinfo.json | \

--- a/docker/ramltools/Dockerfile
+++ b/docker/ramltools/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:4.8
+RUN npm install -g raml2html && \
+    npm install -g https://github.com/stoplightio/api-spec-converter
+COPY raml2swagger.js /usr/local/bin/raml2swagger
+ENTRYPOINT ["nodejs"]

--- a/docker/ramltools/raml2swagger.js
+++ b/docker/ramltools/raml2swagger.js
@@ -1,0 +1,26 @@
+var transformer = require('/usr/local/lib/node_modules/api-spec-transformer');
+
+var ramlToSwagger = new transformer.Converter(
+    transformer.Formats.RAML10,
+    transformer.Formats.SWAGGER
+);
+
+var source = process.argv[2];
+
+ramlToSwagger.loadFile(source, function(err) {
+  if (err) {
+    process.stderr.write(err.stack);
+    exit(1);
+  }
+
+  ramlToSwagger.convert('yaml')
+    .then(function(convertedData) {
+      // convertedData is swagger YAML string
+      process.stdout.write(convertedData);
+      process.stdout.write('\n');
+    })
+  .catch(function(err){
+    process.stderr.write(err.stack);
+    exit(1);
+  });
+});

--- a/docker/ramltools/raml2swagger.js
+++ b/docker/ramltools/raml2swagger.js
@@ -5,6 +5,11 @@ var ramlToSwagger = new transformer.Converter(
     transformer.Formats.SWAGGER
 );
 
+/* Based on how this script get called:
+ * process.argv[0] == nodejs
+ * process.argv[1] == raml2swagger
+ * process.argv[2] == <the path to the RAML file>
+ */
 var source = process.argv[2];
 
 ramlToSwagger.loadFile(source, function(err) {


### PR DESCRIPTION
- [x] Split the documentation into 3 files: package, service, capabilities
- [x] Fix the generation script to generate all the documentation for all of the 3 files.
- [x] Fix the CI save an artifact for all of the generated files
- [x] Fix the release CI to copy all of the files to S3
- [x] Fix the snapshot CI to copy all of the files to S3
