### PR TITLE
Move out PackageDefinition Inner classes and objects

### DIFF
--- a/cosmos-bijection/src/main/scala/com/mesosphere/universe/bijection/UniverseConversions.scala
+++ b/cosmos-bijection/src/main/scala/com/mesosphere/universe/bijection/UniverseConversions.scala
@@ -178,11 +178,11 @@ object UniverseConversions {
 
   implicit val v2PackageDetailsVersionToV3PackageDefinitionVersion:
     Bijection[universe.v2.model.PackageDetailsVersion,
-      universe.v3.model.PackageDefinition.Version] = {
+      universe.v3.model.Version] = {
     Bijection.build {
-      x: universe.v2.model.PackageDetailsVersion => universe.v3.model.PackageDefinition.Version(x.toString)
+      x: universe.v2.model.PackageDetailsVersion => universe.v3.model.Version(x.toString)
     } {
-      x: universe.v3.model.PackageDefinition.Version => universe.v2.model.PackageDetailsVersion(x.toString)
+      x: universe.v3.model.Version => universe.v2.model.PackageDetailsVersion(x.toString)
     }
   }
 

--- a/cosmos-bijection/src/main/scala/com/mesosphere/universe/bijection/UniverseConversions.scala
+++ b/cosmos-bijection/src/main/scala/com/mesosphere/universe/bijection/UniverseConversions.scala
@@ -75,9 +75,9 @@ object UniverseConversions {
     Bijection.build(fwd)(rev)
   }
 
-  implicit val v3ReleaseVersionToLong: Injection[universe.v3.model.PackageDefinition.ReleaseVersion, Long] = {
-    val fwd = (x: universe.v3.model.PackageDefinition.ReleaseVersion) => x.value
-    val rev = (universe.v3.model.PackageDefinition.ReleaseVersion.apply _).andThen(
+  implicit val v3ReleaseVersionToLong: Injection[universe.v3.model.ReleaseVersion, Long] = {
+    val fwd = (x: universe.v3.model.ReleaseVersion) => x.value
+    val rev = (universe.v3.model.ReleaseVersion.apply _).andThen(
       BijectionUtils.twitterTryToScalaTry
     )
 
@@ -85,20 +85,20 @@ object UniverseConversions {
   }
 
   implicit val v3ReleaseVersionToString:
-    Injection[universe.v3.model.PackageDefinition.ReleaseVersion, String] = {
-    Injection.connect[universe.v3.model.PackageDefinition.ReleaseVersion, Long, String]
+    Injection[universe.v3.model.ReleaseVersion, String] = {
+    Injection.connect[universe.v3.model.ReleaseVersion, Long, String]
   }
 
   implicit val v3ReleaseVersionToV2ReleaseVersion:
-    Injection[universe.v3.model.PackageDefinition.ReleaseVersion,
+    Injection[universe.v3.model.ReleaseVersion,
       universe.v2.model.ReleaseVersion] = {
-    Injection.connect[universe.v3.model.PackageDefinition.ReleaseVersion,
+    Injection.connect[universe.v3.model.ReleaseVersion,
       String,
       universe.v2.model.ReleaseVersion]
   }
 
   implicit val v3MetadataToV3Package:
-    Conversion[(universe.v3.model.Metadata, universe.v3.model.PackageDefinition.ReleaseVersion),
+    Conversion[(universe.v3.model.Metadata, universe.v3.model.ReleaseVersion),
       universe.v3.model.V3Package] = Conversion.fromFunction { case (metadata, releaseVersion) =>
     universe.v3.model.V3Package(
       packagingVersion=metadata.packagingVersion,

--- a/cosmos-bijection/src/main/scala/com/mesosphere/universe/bijection/UniverseConversions.scala
+++ b/cosmos-bijection/src/main/scala/com/mesosphere/universe/bijection/UniverseConversions.scala
@@ -187,10 +187,10 @@ object UniverseConversions {
   }
 
   implicit val v3PackageDefinitionTagToString:
-    Injection[universe.v3.model.PackageDefinition.Tag,
+    Injection[universe.v3.model.Tag,
       String /* "Tag" in universe.v2.model.PackageDefinition is only a String */] = {
-    val fwd = (x: universe.v3.model.PackageDefinition.Tag) => x.value
-    val rev = (universe.v3.model.PackageDefinition.Tag.apply _).andThen(BijectionUtils.twitterTryToScalaTry)
+    val fwd = (x: universe.v3.model.Tag) => x.value
+    val rev = (universe.v3.model.Tag.apply _).andThen(BijectionUtils.twitterTryToScalaTry)
 
     Injection.build(fwd)(rev)
   }

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/ReleaseVersionConverterSpec.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/ReleaseVersionConverterSpec.scala
@@ -25,19 +25,19 @@ final class ReleaseVersionConverterSpec extends FreeSpec {
   "v3ReleaseVersionToLong should" - {
 
     "always succeed in the forward direction" in {
-      val version = universe.v3.model.PackageDefinition.ReleaseVersion(2).get
+      val version = universe.v3.model.ReleaseVersion(2).get
       assertResult(2)(version.as[Long])
     }
 
     "succeed in the reverse direction on nonnegative numbers" in {
-      val version = universe.v3.model.PackageDefinition.ReleaseVersion(0).get
+      val version = universe.v3.model.ReleaseVersion(0).get
       assertResult(Success(version))(
-        0L.as[Try[universe.v3.model.PackageDefinition.ReleaseVersion]]
+        0L.as[Try[universe.v3.model.ReleaseVersion]]
       )
     }
 
     "fail in the reverse direction on negative numbers" in {
-      val Failure(iae) = (-1L).as[Try[universe.v3.model.PackageDefinition.ReleaseVersion]]
+      val Failure(iae) = (-1L).as[Try[universe.v3.model.ReleaseVersion]]
       val expectedMessage = "Expected integer value >= 0 for release version, but found [-1]"
       assertResult(expectedMessage)(iae.getMessage)
     }
@@ -53,32 +53,32 @@ final class ReleaseVersionConverterSpec extends FreeSpec {
   }
 
   private[this] def v3ReleaseVersionStringConversions[A](implicit
-    versionToA: Injection[universe.v3.model.PackageDefinition.ReleaseVersion, A],
+    versionToA: Injection[universe.v3.model.ReleaseVersion, A],
     aToString: Bijection[A, String]
   ): Unit = {
 
     "always succeed in the forward direction" in {
       val version = 42L
       assertResult("42") {
-        universe.v3.model.PackageDefinition.ReleaseVersion(version).get.as[A].as[String]
+        universe.v3.model.ReleaseVersion(version).get.as[A].as[String]
       }
     }
 
     "succeed in the reverse direction on nonnegative version numbers" in {
       val version = 24L
-      assertResult(Success(universe.v3.model.PackageDefinition.ReleaseVersion(version).get)) {
-        "24".as[A].as[Try[universe.v3.model.PackageDefinition.ReleaseVersion]]
+      assertResult(Success(universe.v3.model.ReleaseVersion(version).get)) {
+        "24".as[A].as[Try[universe.v3.model.ReleaseVersion]]
       }
     }
 
     "fail in the reverse direction on negative version numbers" in {
-      val Failure(iae) = "-2".as[A].as[Try[universe.v3.model.PackageDefinition.ReleaseVersion]]
+      val Failure(iae) = "-2".as[A].as[Try[universe.v3.model.ReleaseVersion]]
       val message = "Expected integer value >= 0 for release version, but found [-2]"
       assertResult(message)(iae.getMessage)
     }
 
     "fail in the reverse direction on non-number values" in {
-      val Failure(iae) = "foo".as[A].as[Try[universe.v3.model.PackageDefinition.ReleaseVersion]]
+      val Failure(iae) = "foo".as[A].as[Try[universe.v3.model.ReleaseVersion]]
       val message = "Failed to invert: foo"
       assertResult(message)(iae.getMessage)
     }

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/TestUniverseConversions.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/TestUniverseConversions.scala
@@ -7,7 +7,7 @@ object TestUniverseConversions {
 
   implicit val v3PackageToV3Metadata:
     Conversion[universe.v3.model.V3Package,
-      (universe.v3.model.Metadata, universe.v3.model.PackageDefinition.ReleaseVersion)] = {
+      (universe.v3.model.Metadata, universe.v3.model.ReleaseVersion)] = {
     Conversion.fromFunction { v3Package =>
       val metadata = universe.v3.model.Metadata(
         packagingVersion = v3Package.packagingVersion,

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/UniverseConversionsSpec.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/UniverseConversionsSpec.scala
@@ -128,14 +128,14 @@ final class UniverseConversionsSpec extends FreeSpec with Matchers {
     assertResult(v2)(v3FromV2.as[universe.v2.model.Resource])
   }
 
-  "Bijection[universe.v2.model.PackageDetailsVersion, universe.v3.model.PackageDefinition.Version]" in {
+  "Bijection[universe.v2.model.PackageDetailsVersion, universe.v3.model.Version]" in {
     val v2: universe.v2.model.PackageDetailsVersion = universe.v2.model.PackageDetailsVersion("2.0")
-    val v3FromV2 = v2.as[universe.v3.model.PackageDefinition.Version]
+    val v3FromV2 = v2.as[universe.v3.model.Version]
     assertResult(v2)(v3FromV2.as[universe.v2.model.PackageDetailsVersion])
 
-    val v3: universe.v3.model.PackageDefinition.Version = universe.v3.model.PackageDefinition.Version("3.0")
+    val v3: universe.v3.model.Version = universe.v3.model.Version("3.0")
     val v2FromV3 = v3.as[universe.v2.model.PackageDetailsVersion]
-    assertResult(v3)(v2FromV3.as[universe.v3.model.PackageDefinition.Version])
+    assertResult(v3)(v2FromV3.as[universe.v3.model.Version])
   }
 
   private[this] def expectV3(v2model: universe.v2.model.PackageDetails): universe.v2.model.PackageDetails = v2model.copy(

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/UniverseConversionsSpec.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/UniverseConversionsSpec.scala
@@ -32,22 +32,22 @@ final class UniverseConversionsSpec extends FreeSpec with Matchers {
   "(Metadata, ReleaseVersion) => V3Package => (Metadata, ReleaseVersion) is the identity fn" - {
 
     "Max metadata" in {
-      val releaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(Long.MaxValue).get
+      val releaseVersion = universe.v3.model.ReleaseVersion(Long.MaxValue).get
       testCase((MaximalV3ModelMetadata, releaseVersion))
     }
 
     "Min metadata" in {
-      val releaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(0L).get
+      val releaseVersion = universe.v3.model.ReleaseVersion(0L).get
       testCase((MinimalV3ModelMetadata, releaseVersion))
     }
 
     def testCase(
-      value: (universe.v3.model.Metadata, universe.v3.model.PackageDefinition.ReleaseVersion)
+      value: (universe.v3.model.Metadata, universe.v3.model.ReleaseVersion)
     ): Assertion = {
       assertResult(value) {
         value
           .as[universe.v3.model.V3Package]
-          .as[(universe.v3.model.Metadata, universe.v3.model.PackageDefinition.ReleaseVersion)]
+          .as[(universe.v3.model.Metadata, universe.v3.model.ReleaseVersion)]
       }
     }
 
@@ -68,7 +68,7 @@ final class UniverseConversionsSpec extends FreeSpec with Matchers {
       val command = v3Package.command
 
       val roundTrip = v3Package
-        .as[(universe.v3.model.Metadata, universe.v3.model.PackageDefinition.ReleaseVersion)]
+        .as[(universe.v3.model.Metadata, universe.v3.model.ReleaseVersion)]
         .as[universe.v3.model.V3Package]
 
       assert(roundTrip.selected.isEmpty)

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/UniverseConversionsSpec.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/UniverseConversionsSpec.scala
@@ -93,10 +93,10 @@ final class UniverseConversionsSpec extends FreeSpec with Matchers {
   }
 
   "Injection[universe.v3.model.PackageDefinition.Tag, String]" in {
-    val tag = universe.v3.model.PackageDefinition.Tag("foobar").get
+    val tag = universe.v3.model.Tag("foobar").get
     val stringFromTag = tag.as[String]
-    assertResult(Success(tag))(Injection.invert[universe.v3.model.PackageDefinition.Tag, String](stringFromTag))
-    assertResult(true)(Injection.invert[universe.v3.model.PackageDefinition.Tag, String]("foo bar\nfar").isFailure)
+    assertResult(Success(tag))(Injection.invert[universe.v3.model.Tag, String](stringFromTag))
+    assertResult(true)(Injection.invert[universe.v3.model.Tag, String]("foo bar\nfar").isFailure)
     assertResult("foobar")(tag.as[String])
   }
 

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/test/TestingPackages.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/test/TestingPackages.scala
@@ -89,7 +89,7 @@ object TestingPackages {
     PackagingVersion,
     Name,
     Version,
-    releaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(Long.MaxValue).get,
+    releaseVersion = universe.v3.model.ReleaseVersion(Long.MaxValue).get,
     Maintainer,
     Description,
     Tags,
@@ -114,7 +114,7 @@ object TestingPackages {
     packagingVersion = universe.v3.model.V3PackagingVersion,
     name = "minimal",
     version = universe.v3.model.Version("1.2.3"),
-    releaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(0).get,
+    releaseVersion = universe.v3.model.ReleaseVersion(0).get,
     maintainer = "minimal@mesosphere.io",
     description = "A minimal package definition"
   )
@@ -276,7 +276,7 @@ object TestingPackages {
   val HelloWorldV3Package: universe.v3.model.V3Package = universe.v3.model.V3Package(
     name = "helloworld",
     version = universe.v3.model.Version("0.1.0"),
-    releaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(0L).get(),
+    releaseVersion = universe.v3.model.ReleaseVersion(0L).get(),
     website = Some("https://github.com/mesosphere/dcos-helloworld"),
     maintainer = "support@mesosphere.io",
     description = "Example DCOS application package",

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/test/TestingPackages.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/test/TestingPackages.scala
@@ -18,7 +18,7 @@ object TestingPackages {
     v2AppMustacheTemplate = ByteBuffer.wrap("marathon template".getBytes(StandardCharsets.UTF_8))
   ))
   val Tags = List("all", "the", "things").map(
-    s => universe.v3.model.PackageDefinition.Tag(s).get
+    s => universe.v3.model.Tag(s).get
   )
   val Scm = Some("git")
   val Website = Some("mesosphere.com")
@@ -283,7 +283,7 @@ object TestingPackages {
     preInstallNotes = Some("A sample pre-installation message"),
     postInstallNotes = Some("A sample post-installation message"),
     tags = List("mesosphere", "example", "subcommand")
-      .map(s => universe.v3.model.PackageDefinition.Tag(s).get()),
+      .map(s => universe.v3.model.Tag(s).get()),
     marathon = Some(universe.v3.model.Marathon(HelloWorldMarathonTemplate)),
     config = Some(JsonObject.fromMap(Map(
       "$schema" -> "http://json-schema.org/schema#".asJson,

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/test/TestingPackages.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/test/TestingPackages.scala
@@ -11,7 +11,7 @@ import java.nio.charset.StandardCharsets
 object TestingPackages {
   val PackagingVersion = universe.v3.model.V3PackagingVersion
   val Name = "MAXIMAL"
-  val Version = universe.v3.model.PackageDefinition.Version("9.87.654.3210")
+  val Version = universe.v3.model.Version("9.87.654.3210")
   val Maintainer = "max@mesosphere.io"
   val Description = "A complete package definition"
   val MarathonTemplate = Some(universe.v3.model.Marathon(
@@ -113,7 +113,7 @@ object TestingPackages {
   val MinimalV3ModelV3PackageDefinition: universe.v3.model.V3Package = universe.v3.model.V3Package(
     packagingVersion = universe.v3.model.V3PackagingVersion,
     name = "minimal",
-    version = universe.v3.model.PackageDefinition.Version("1.2.3"),
+    version = universe.v3.model.Version("1.2.3"),
     releaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(0).get,
     maintainer = "minimal@mesosphere.io",
     description = "A minimal package definition"
@@ -275,7 +275,7 @@ object TestingPackages {
 
   val HelloWorldV3Package: universe.v3.model.V3Package = universe.v3.model.V3Package(
     name = "helloworld",
-    version = universe.v3.model.PackageDefinition.Version("0.1.0"),
+    version = universe.v3.model.Version("0.1.0"),
     releaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(0L).get(),
     website = Some("https://github.com/mesosphere/dcos-helloworld"),
     maintainer = "support@mesosphere.io",

--- a/cosmos-json/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/Decoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/Decoders.scala
@@ -13,8 +13,8 @@ import io.circe.generic.semiauto._
 import scala.util.Left
 
 object Decoders {
-  implicit val keyDecodePackageDefinitionVersion: KeyDecoder[universe.v3.model.PackageDefinition.Version] = {
-    KeyDecoder.instance { s => Some(universe.v3.model.PackageDefinition.Version(s)) }
+  implicit val keyDecodePackageDefinitionVersion: KeyDecoder[universe.v3.model.Version] = {
+    KeyDecoder.instance { s => Some(universe.v3.model.Version(s)) }
   }
 
   implicit val decodeSearchResult: Decoder[SearchResult] = deriveDecoder[SearchResult]

--- a/cosmos-json/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/Encoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/Encoders.scala
@@ -13,7 +13,7 @@ import io.circe.generic.semiauto._
 import io.circe.syntax._
 
 object Encoders {
-  implicit val keyEncodePackageDefinitionVersion: KeyEncoder[universe.v3.model.PackageDefinition.Version] = {
+  implicit val keyEncodePackageDefinitionVersion: KeyEncoder[universe.v3.model.Version] = {
     KeyEncoder.instance(_.toString)
   }
   implicit val encodePackageDefinitionReleaseVersion: Encoder[universe.v3.model.PackageDefinition.ReleaseVersion] = {

--- a/cosmos-json/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/Encoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/cosmos/rpc/v1/circe/Encoders.scala
@@ -16,7 +16,7 @@ object Encoders {
   implicit val keyEncodePackageDefinitionVersion: KeyEncoder[universe.v3.model.Version] = {
     KeyEncoder.instance(_.toString)
   }
-  implicit val encodePackageDefinitionReleaseVersion: Encoder[universe.v3.model.PackageDefinition.ReleaseVersion] = {
+  implicit val encodePackageDefinitionReleaseVersion: Encoder[universe.v3.model.ReleaseVersion] = {
     Encoder.instance { rv => rv.value.asJson }
   }
 

--- a/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Decoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Decoders.scala
@@ -40,8 +40,8 @@ object Decoders {
   implicit val decodeMarathon: Decoder[Marathon] = deriveDecoder[Marathon]
   implicit val decodePlatforms: Decoder[Platforms] = deriveDecoder[Platforms]
 
-  implicit val decodePackageDefinitionVersion: Decoder[PackageDefinition.Version] = {
-    Decoder.decodeString.map(PackageDefinition.Version)
+  implicit val decodePackageDefinitionVersion: Decoder[Version] = {
+    Decoder.decodeString.map(Version)
   }
 
   implicit val decodePackageDefinitionTag: Decoder[Tag] =

--- a/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Decoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Decoders.scala
@@ -44,9 +44,9 @@ object Decoders {
     Decoder.decodeString.map(PackageDefinition.Version)
   }
 
-  implicit val decodePackageDefinitionTag: Decoder[PackageDefinition.Tag] =
-    Decoder.instance[PackageDefinition.Tag] { (c: HCursor) =>
-      c.as[String].map(PackageDefinition.Tag(_)).flatMap {
+  implicit val decodePackageDefinitionTag: Decoder[Tag] =
+    Decoder.instance[Tag] { (c: HCursor) =>
+      c.as[String].map(Tag(_)).flatMap {
         case Return(r) => Right(r)
         case Throw(ex) =>
           val msg = ex.getMessage.replaceAllLiterally("assertion failed: ", "")

--- a/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Decoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Decoders.scala
@@ -54,9 +54,9 @@ object Decoders {
       }
     }
 
-  implicit val decodePackageDefinitionReleaseVersion: Decoder[PackageDefinition.ReleaseVersion] =
-    Decoder.instance[PackageDefinition.ReleaseVersion] { (c: HCursor) =>
-      c.as[Long].map(PackageDefinition.ReleaseVersion(_)).flatMap {
+  implicit val decodePackageDefinitionReleaseVersion: Decoder[ReleaseVersion] =
+    Decoder.instance[ReleaseVersion] { (c: HCursor) =>
+      c.as[Long].map(ReleaseVersion(_)).flatMap {
         case Return(v) => Right(v)
         case Throw(e) => Left(DecodingFailure(e.getMessage, c.history))
       }

--- a/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Encoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Encoders.scala
@@ -39,7 +39,7 @@ object Encoders {
   implicit val encodePackageDefinitionTag: Encoder[Tag] = {
     Encoder.instance(_.value.asJson)
   }
-  implicit val encodePackageDefinitionReleaseVersion: Encoder[PackageDefinition.ReleaseVersion] = {
+  implicit val encodePackageDefinitionReleaseVersion: Encoder[ReleaseVersion] = {
     Encoder.instance(_.value.asJson)
   }
   implicit val encodeRepository: Encoder[Repository] = deriveEncoder[Repository]

--- a/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Encoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Encoders.scala
@@ -33,7 +33,7 @@ object Encoders {
 
   implicit val encodePlatforms: Encoder[Platforms] = deriveEncoder[Platforms]
 
-  implicit val encodePackageDefinitionVersion: Encoder[PackageDefinition.Version] = {
+  implicit val encodePackageDefinitionVersion: Encoder[Version] = {
     Encoder.instance(_.toString.asJson)
   }
   implicit val encodePackageDefinitionTag: Encoder[Tag] = {

--- a/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Encoders.scala
+++ b/cosmos-json/src/main/scala/com/mesosphere/universe/v3/circe/Encoders.scala
@@ -36,7 +36,7 @@ object Encoders {
   implicit val encodePackageDefinitionVersion: Encoder[PackageDefinition.Version] = {
     Encoder.instance(_.toString.asJson)
   }
-  implicit val encodePackageDefinitionTag: Encoder[PackageDefinition.Tag] = {
+  implicit val encodePackageDefinitionTag: Encoder[Tag] = {
     Encoder.instance(_.value.asJson)
   }
   implicit val encodePackageDefinitionReleaseVersion: Encoder[PackageDefinition.ReleaseVersion] = {

--- a/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/RepositoryEncoderDecoderSpec.scala
+++ b/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/RepositoryEncoderDecoderSpec.scala
@@ -2,7 +2,6 @@ package com.mesosphere.universe.v3.circe
 
 import com.mesosphere.universe.v3.circe.Decoders._
 import com.mesosphere.universe.v3.circe.Encoders._
-import com.mesosphere.universe.v3.model.PackageDefinition._
 import com.mesosphere.universe.v3.model._
 import io.circe.Json
 import io.circe.jawn.parse

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/AddRequest.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/AddRequest.scala
@@ -6,7 +6,7 @@ sealed trait AddRequest
 
 case class UniverseAddRequest(
   packageName: String,
-  packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+  packageVersion: Option[universe.v3.model.Version]
 ) extends AddRequest
 
 case class UploadAddRequest(packageData: Array[Byte]) extends AddRequest

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/LocalPackage.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/LocalPackage.scala
@@ -37,7 +37,7 @@ object LocalPackage {
       case Invalid(_, packageCoordinate) => packageCoordinate.name
     }
 
-    def packageVersion: universe.v3.model.PackageDefinition.Version = value match {
+    def packageVersion: universe.v3.model.Version = value match {
       case NotInstalled(pkg) => pkg.version
       case Installed(pkg) => pkg.version
       case Installing(pkg) => pkg.version

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/PackageCoordinate.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/PackageCoordinate.scala
@@ -2,4 +2,4 @@ package com.mesosphere.cosmos.rpc.v1.model
 
 import com.mesosphere.universe
 
-final case class PackageCoordinate(name: String, version: universe.v3.model.PackageDefinition.Version)
+final case class PackageCoordinate(name: String, version: universe.v3.model.Version)

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/SearchResult.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/SearchResult.scala
@@ -5,7 +5,7 @@ import com.mesosphere.universe
 case class SearchResult(
   name: String,
   currentVersion: universe.v3.model.Version,
-  versions: Map[universe.v3.model.Version, universe.v3.model.PackageDefinition.ReleaseVersion],
+  versions: Map[universe.v3.model.Version, universe.v3.model.ReleaseVersion],
   description: String,
   framework: Boolean,
   tags: List[universe.v3.model.Tag],

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/SearchResult.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/SearchResult.scala
@@ -4,8 +4,8 @@ import com.mesosphere.universe
 
 case class SearchResult(
   name: String,
-  currentVersion: universe.v3.model.PackageDefinition.Version,
-  versions: Map[universe.v3.model.PackageDefinition.Version, universe.v3.model.PackageDefinition.ReleaseVersion],
+  currentVersion: universe.v3.model.Version,
+  versions: Map[universe.v3.model.Version, universe.v3.model.PackageDefinition.ReleaseVersion],
   description: String,
   framework: Boolean,
   tags: List[universe.v3.model.Tag],

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/SearchResult.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/SearchResult.scala
@@ -8,7 +8,7 @@ case class SearchResult(
   versions: Map[universe.v3.model.PackageDefinition.Version, universe.v3.model.PackageDefinition.ReleaseVersion],
   description: String,
   framework: Boolean,
-  tags: List[universe.v3.model.PackageDefinition.Tag],
+  tags: List[universe.v3.model.Tag],
   selected: Option[Boolean] = None,
   images: Option[universe.v3.model.Images] = None
 )

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/ServiceStartRequest.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/ServiceStartRequest.scala
@@ -5,6 +5,6 @@ import io.circe.JsonObject
 
 case class ServiceStartRequest(
   packageName: String,
-  packageVersion: Option[universe.v3.model.PackageDefinition.Version] = None,
+  packageVersion: Option[universe.v3.model.Version] = None,
   options: Option[JsonObject] = None
 )

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/ServiceStartResponse.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/ServiceStartResponse.scala
@@ -5,6 +5,6 @@ import com.mesosphere.universe
 
 case class ServiceStartResponse(
   packageName: String,
-  packageVersion: universe.v3.model.PackageDefinition.Version,
+  packageVersion: universe.v3.model.Version,
   appId: Option[AppId] = None
 )

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/DescribeResponse.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/DescribeResponse.scala
@@ -6,7 +6,7 @@ import io.circe.JsonObject
 case class DescribeResponse(
   packagingVersion: universe.v3.model.PackagingVersion,
   name: String,
-  version: universe.v3.model.PackageDefinition.Version,
+  version: universe.v3.model.Version,
   maintainer: String,
   description: String,
   tags: List[universe.v3.model.Tag] = Nil,

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/DescribeResponse.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/DescribeResponse.scala
@@ -9,7 +9,7 @@ case class DescribeResponse(
   version: universe.v3.model.PackageDefinition.Version,
   maintainer: String,
   description: String,
-  tags: List[universe.v3.model.PackageDefinition.Tag] = Nil,
+  tags: List[universe.v3.model.Tag] = Nil,
   selected: Boolean = false,
   scm: Option[String] = None,
   website: Option[String] = None,

--- a/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/InstallResponse.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/cosmos/rpc/v2/model/InstallResponse.scala
@@ -5,7 +5,7 @@ import com.mesosphere.universe
 
 case class InstallResponse(
   packageName: String,
-  packageVersion: universe.v3.model.PackageDefinition.Version,
+  packageVersion: universe.v3.model.Version,
   appId: Option[AppId] = None,
   postInstallNotes: Option[String] = None,
   cli: Option[universe.v3.model.Cli] = None

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionParser.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionParser.scala
@@ -1,6 +1,5 @@
 package com.mesosphere.universe.v3.model
 
-import com.mesosphere.universe.v3.model.DcosReleaseVersion.{Suffix, Version}
 import com.twitter.util.{Return, Throw, Try}
 
 import java.util.regex.Pattern
@@ -42,12 +41,12 @@ object DcosReleaseVersionParser {
   }
 
   private[this] def parseVersion(s: String): Try[DcosReleaseVersion.Version] = Try {
-    Version(s.toInt)
+    DcosReleaseVersion.Version(s.toInt)
   }
 
   private[this] def parseSuffix(s: Option[String]): Try[Option[DcosReleaseVersion.Suffix]] = s match {
     case None => Return(None)
-    case Some(suff) => Return(Some(Suffix(suff)))
+    case Some(suff) => Return(Some(DcosReleaseVersion.Suffix(suff)))
   }
 
   private[this] def parseVersionSuffix(version: String, suffix: Option[String], errMsg: String): Try[DcosReleaseVersion] = {

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/Metadata.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/Metadata.scala
@@ -8,7 +8,7 @@ case class Metadata(
   version: PackageDefinition.Version,
   maintainer: String,
   description: String,
-  tags: List[PackageDefinition.Tag] = Nil,
+  tags: List[Tag] = Nil,
   scm: Option[String] = None,
   website: Option[String] = None,
   framework: Option[Boolean] = None,

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/Metadata.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/Metadata.scala
@@ -5,7 +5,7 @@ import io.circe.JsonObject
 case class Metadata(
   packagingVersion: V3PackagingVersion.type = V3PackagingVersion,
   name: String,
-  version: PackageDefinition.Version,
+  version: Version,
   maintainer: String,
   description: String,
   tags: List[Tag] = Nil,

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/PackageDefinition.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/PackageDefinition.scala
@@ -30,7 +30,7 @@ object PackageDefinition {
       aReleaseVersion.value.compare(bReleaseVersion.value)
     }
   }
-  
+
 }
 
 /**

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/PackageDefinition.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/PackageDefinition.scala
@@ -8,7 +8,6 @@ import io.circe.JsonObject
 
 sealed abstract class PackageDefinition
 object PackageDefinition {
-  final case class Version(override val toString: String) extends AnyVal
 
   final class ReleaseVersion private(val value: Long) extends AnyVal
 
@@ -61,7 +60,7 @@ object PackageDefinition {
 case class V2Package(
   packagingVersion: V2PackagingVersion.type = V2PackagingVersion,
   name: String,
-  version: PackageDefinition.Version,
+  version: Version,
   releaseVersion: PackageDefinition.ReleaseVersion,
   maintainer: String,
   description: String,
@@ -93,7 +92,7 @@ case class V2Package(
 case class V3Package(
   packagingVersion: V3PackagingVersion.type = V3PackagingVersion,
   name: String,
-  version: PackageDefinition.Version,
+  version: Version,
   releaseVersion: PackageDefinition.ReleaseVersion,
   maintainer: String,
   description: String,

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/PackageDefinition.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/PackageDefinition.scala
@@ -5,27 +5,10 @@ import com.twitter.util.Return
 import com.twitter.util.Throw
 import com.twitter.util.Try
 import io.circe.JsonObject
-import java.util.regex.Pattern
 
 sealed abstract class PackageDefinition
 object PackageDefinition {
   final case class Version(override val toString: String) extends AnyVal
-
-  final class Tag private(val value: String) extends AnyVal {
-    override def toString: String = value
-  }
-  object Tag {
-    val packageDetailsTagRegex = "^[^\\s]+$"
-    val packageDetailsTagPattern = Pattern.compile(packageDetailsTagRegex)
-
-    def apply(s: String): Try[Tag] = {
-      if (packageDetailsTagPattern.matcher(s).matches()) {
-        Return(new Tag(s))
-      } else {
-        Throw(new IllegalArgumentException(s"Value '$s' does not conform to expected format $packageDetailsTagRegex"))
-      }
-    }
-  }
 
   final class ReleaseVersion private(val value: Long) extends AnyVal
 
@@ -83,7 +66,7 @@ case class V2Package(
   maintainer: String,
   description: String,
   marathon: Marathon,
-  tags: List[PackageDefinition.Tag] = Nil,
+  tags: List[Tag] = Nil,
   selected: Option[Boolean] = None,
   scm: Option[String] = None,
   website: Option[String] = None,
@@ -114,7 +97,7 @@ case class V3Package(
   releaseVersion: PackageDefinition.ReleaseVersion,
   maintainer: String,
   description: String,
-  tags: List[PackageDefinition.Tag] = Nil,
+  tags: List[Tag] = Nil,
   selected: Option[Boolean] = None,
   scm: Option[String] = None,
   website: Option[String] = None,

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/PackageDefinition.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/PackageDefinition.scala
@@ -1,32 +1,10 @@
 package com.mesosphere.universe.v3.model
 
 import com.mesosphere.universe.v3.syntax.PackageDefinitionOps._
-import com.twitter.util.Return
-import com.twitter.util.Throw
-import com.twitter.util.Try
 import io.circe.JsonObject
 
 sealed abstract class PackageDefinition
 object PackageDefinition {
-
-  final class ReleaseVersion private(val value: Long) extends AnyVal
-
-  object ReleaseVersion {
-
-    def apply(value: Long): Try[ReleaseVersion] = {
-      if (value >= 0) {
-        Return(new ReleaseVersion(value))
-      } else {
-        val message = s"Expected integer value >= 0 for release version, but found [$value]"
-        Throw(new IllegalArgumentException(message))
-      }
-    }
-
-    implicit val packageDefinitionReleaseVersionOrdering: Ordering[ReleaseVersion] = {
-      Ordering.by(_.value)
-    }
-
-  }
 
   implicit val packageDefinitionOrdering = new Ordering[PackageDefinition] {
     override def compare(a: PackageDefinition, b: PackageDefinition): Int = {
@@ -52,6 +30,7 @@ object PackageDefinition {
       aReleaseVersion.value.compare(bReleaseVersion.value)
     }
   }
+  
 }
 
 /**
@@ -61,7 +40,7 @@ case class V2Package(
   packagingVersion: V2PackagingVersion.type = V2PackagingVersion,
   name: String,
   version: Version,
-  releaseVersion: PackageDefinition.ReleaseVersion,
+  releaseVersion: ReleaseVersion,
   maintainer: String,
   description: String,
   marathon: Marathon,
@@ -93,7 +72,7 @@ case class V3Package(
   packagingVersion: V3PackagingVersion.type = V3PackagingVersion,
   name: String,
   version: Version,
-  releaseVersion: PackageDefinition.ReleaseVersion,
+  releaseVersion: ReleaseVersion,
   maintainer: String,
   description: String,
   tags: List[Tag] = Nil,

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/ReleaseVersion.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/ReleaseVersion.scala
@@ -1,0 +1,24 @@
+package com.mesosphere.universe.v3.model
+
+import com.twitter.util.Return
+import com.twitter.util.Throw
+import com.twitter.util.Try
+
+final class ReleaseVersion private(val value: Long) extends AnyVal
+
+object ReleaseVersion {
+
+  def apply(value: Long): Try[ReleaseVersion] = { //TODO: do not return Try. Most call sites do .get
+    if (value >= 0) {
+      Return(new ReleaseVersion(value))
+    } else {
+      val message = s"Expected integer value >= 0 for release version, but found [$value]"
+      Throw(new IllegalArgumentException(message))
+    }
+  }
+
+  implicit val packageDefinitionReleaseVersionOrdering: Ordering[ReleaseVersion] = {
+    Ordering.by(_.value)
+  }
+
+}

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/ReleaseVersion.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/ReleaseVersion.scala
@@ -8,7 +8,7 @@ final class ReleaseVersion private(val value: Long) extends AnyVal
 
 object ReleaseVersion {
 
-  def apply(value: Long): Try[ReleaseVersion] = { //TODO: do not return Try. Most call sites do .get
+  def apply(value: Long): Try[ReleaseVersion] = {
     if (value >= 0) {
       Return(new ReleaseVersion(value))
     } else {

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/Tag.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/Tag.scala
@@ -1,0 +1,29 @@
+package com.mesosphere.universe.v3.model
+
+import com.twitter.util.Return
+import com.twitter.util.Throw
+import com.twitter.util.Try
+import java.util.regex.Pattern
+
+final class Tag private(val value: String) extends AnyVal {
+
+  override def toString: String = value
+
+}
+
+object Tag {
+
+  val packageDetailsTagRegex: String = "^[^\\s]+$"
+  val packageDetailsTagPattern: Pattern = Pattern.compile(packageDetailsTagRegex)
+
+  def apply(s: String): Try[Tag] = { //TODO: Get rid of this Try. Most call sites do .get
+    if (packageDetailsTagPattern.matcher(s).matches()) {
+      Return(new Tag(s))
+    } else {
+      Throw(new IllegalArgumentException(
+        s"Value '$s' does not conform to expected format $packageDetailsTagRegex"
+      ))
+    }
+  }
+
+}

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/Tag.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/Tag.scala
@@ -16,7 +16,7 @@ object Tag {
   val packageDetailsTagRegex: String = "^[^\\s]+$"
   val packageDetailsTagPattern: Pattern = Pattern.compile(packageDetailsTagRegex)
 
-  def apply(s: String): Try[Tag] = { //TODO: Get rid of this Try. Most call sites do .get
+  def apply(s: String): Try[Tag] = {
     if (packageDetailsTagPattern.matcher(s).matches()) {
       Return(new Tag(s))
     } else {

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/Version.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/model/Version.scala
@@ -1,0 +1,3 @@
+package com.mesosphere.universe.v3.model
+
+final case class Version(override val toString: String) extends AnyVal

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/syntax/PackageDefinitionOps.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/syntax/PackageDefinitionOps.scala
@@ -1,7 +1,6 @@
 package com.mesosphere.universe.v3.syntax
 
 import com.mesosphere.cosmos.rpc.v1.model.PackageCoordinate
-import com.mesosphere.universe.v3.model.PackageDefinition.Tag
 import com.mesosphere.universe.v3.model._
 import io.circe.JsonObject
 

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/syntax/PackageDefinitionOps.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/syntax/PackageDefinitionOps.scala
@@ -29,7 +29,7 @@ final class PackageDefinitionOps(val pkgDef: PackageDefinition) extends AnyVal {
   }
 
   //noinspection MutatorLikeMethodIsParameterless
-  def releaseVersion: PackageDefinition.ReleaseVersion = pkgDef match {
+  def releaseVersion: ReleaseVersion = pkgDef match {
     case v2: V2Package => v2.releaseVersion
     case v3: V3Package => v3.releaseVersion
   }

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/v3/syntax/PackageDefinitionOps.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/v3/syntax/PackageDefinitionOps.scala
@@ -23,7 +23,7 @@ final class PackageDefinitionOps(val pkgDef: PackageDefinition) extends AnyVal {
     case v3: V3Package => v3.name
   }
 
-  def version: PackageDefinition.Version = pkgDef match {
+  def version: Version = pkgDef match {
     case v2: V2Package => v2.version
     case v3: V3Package => v3.version
   }

--- a/cosmos-model/src/test/scala/com/mesosphere/Generators.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/Generators.scala
@@ -50,8 +50,8 @@ object Generators {
     } yield universe.v3.model.SemVer(major, minor, patch, preReleases, build)
   }
 
-  private val genVersion: Gen[universe.v3.model.PackageDefinition.Version] = {
-    genSemVer.map(_.toString).map(universe.v3.model.PackageDefinition.Version)
+  private val genVersion: Gen[universe.v3.model.Version] = {
+    genSemVer.map(_.toString).map(universe.v3.model.Version)
   }
 
   private val genReleaseVersion: Gen[universe.v3.model.PackageDefinition.ReleaseVersion] = for {

--- a/cosmos-model/src/test/scala/com/mesosphere/Generators.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/Generators.scala
@@ -54,9 +54,9 @@ object Generators {
     genSemVer.map(_.toString).map(universe.v3.model.Version)
   }
 
-  private val genReleaseVersion: Gen[universe.v3.model.PackageDefinition.ReleaseVersion] = for {
+  private val genReleaseVersion: Gen[universe.v3.model.ReleaseVersion] = for {
     num <- Gen.posNum[Long]
-  } yield universe.v3.model.PackageDefinition.ReleaseVersion(num).get
+  } yield universe.v3.model.ReleaseVersion(num).get
 
   val genV3Package: Gen[universe.v3.model.V3Package] = {
     val maxPackageNameLength = 64

--- a/cosmos-model/src/test/scala/com/mesosphere/Generators.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/Generators.scala
@@ -94,10 +94,10 @@ object Generators {
     Gen.nonEmptyContainerOf[Array, Char](genChar).map(new String(_))
   }
 
-  private val genTag: Gen[universe.v3.model.PackageDefinition.Tag] = {
+  private val genTag: Gen[universe.v3.model.Tag] = {
     val genTagChar = arbitrary[Char].suchThat(!_.isWhitespace)
     val genTagString = genNonEmptyString(genTagChar)
-    genTagString.map(universe.v3.model.PackageDefinition.Tag(_).get)
+    genTagString.map(universe.v3.model.Tag(_).get)
   }
 
   private val genUri: Gen[Uri] = {
@@ -119,7 +119,7 @@ object Generators {
 
   object Implicits {
 
-    implicit val arbTag: Arbitrary[universe.v3.model.PackageDefinition.Tag] = Arbitrary(genTag)
+    implicit val arbTag: Arbitrary[universe.v3.model.Tag] = Arbitrary(genTag)
 
     implicit val arbUri: Arbitrary[Uri] = Arbitrary(genUri)
 

--- a/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionParserSpec.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionParserSpec.scala
@@ -1,7 +1,5 @@
 package com.mesosphere.universe.v3.model
 
-import com.mesosphere.universe.v3.model.DcosReleaseVersion.Suffix
-import com.mesosphere.universe.v3.model.DcosReleaseVersion.Version
 import com.twitter.util.Return
 import com.twitter.util.Throw
 import com.twitter.util.Try
@@ -15,16 +13,16 @@ class DcosReleaseVersionParserSpec extends FreeSpec {
     "succeed for" - {
       "1" in {
         val Return(parse) = DcosReleaseVersionParser.parse("1")
-        assertResult(DcosReleaseVersion(Version(1)))(parse)
+        assertResult(DcosReleaseVersion(DcosReleaseVersion.Version(1)))(parse)
       }
 
       // scalastyle:off magic.number
       "10.200.3000.40000.500000-oneMillion" in {
         val Return(parse) = DcosReleaseVersionParser.parse("10.200.3000.40000.500000-oneMillion")
         val expected = DcosReleaseVersion(
-          Version(10),
-          List(Version(200), Version(3000), Version(40000), Version(500000)),
-          Some(Suffix("oneMillion"))
+          DcosReleaseVersion.Version(10),
+          List(DcosReleaseVersion.Version(200), DcosReleaseVersion.Version(3000), DcosReleaseVersion.Version(40000), DcosReleaseVersion.Version(500000)),
+          Some(DcosReleaseVersion.Suffix("oneMillion"))
         )
         assertResult(expected)(parse)
       }
@@ -33,9 +31,9 @@ class DcosReleaseVersionParserSpec extends FreeSpec {
       "1-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" in {
         val Return(parse) = DcosReleaseVersionParser.parse("1-ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
         val expected = DcosReleaseVersion(
-          Version(1),
+          DcosReleaseVersion.Version(1),
           List.empty,
-          Some(Suffix("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"))
+          Some(DcosReleaseVersion.Suffix("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"))
         )
         assertResult(expected)(parse)
       }

--- a/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionSpec.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionSpec.scala
@@ -1,7 +1,5 @@
 package com.mesosphere.universe.v3.model
 
-import com.mesosphere.universe.v3.model.DcosReleaseVersion.Suffix
-import com.mesosphere.universe.v3.model.DcosReleaseVersion.Version
 import com.twitter.util.Return
 import com.twitter.util.Throw
 import com.twitter.util.Try
@@ -20,8 +18,8 @@ class DcosReleaseVersionSpec extends FreeSpec {
     "Ordering should" - {
       "make operators available" - {
         import DcosReleaseVersion._
-        val left = DcosReleaseVersion(Version(1), List(Version(0)))
-        val right = DcosReleaseVersion(Version(1), List(Version(0), Version(1)))
+        val left = DcosReleaseVersion(DcosReleaseVersion.Version(1), List(DcosReleaseVersion.Version(0)))
+        val right = DcosReleaseVersion(DcosReleaseVersion.Version(1), List(DcosReleaseVersion.Version(0), DcosReleaseVersion.Version(1)))
         "<=" in {
           assert(left <= right)
         }
@@ -127,72 +125,78 @@ class DcosReleaseVersionSpec extends FreeSpec {
     // scalastyle:off magic.number
     "show should render correctly" - {
       "1.0.0-beta" in {
-        val test = DcosReleaseVersion(Version(1), List(Version(0), Version(0)), Some(Suffix("beta")))
+        val test = DcosReleaseVersion(
+          DcosReleaseVersion.Version(1),
+          List(
+            DcosReleaseVersion.Version(0),
+            DcosReleaseVersion.Version(0)
+          ),
+          Some(DcosReleaseVersion.Suffix("beta")))
         assertResult("1.0.0-beta")(test.show)
       }
       "1" in {
-        val test = DcosReleaseVersion(Version(1))
+        val test = DcosReleaseVersion(DcosReleaseVersion.Version(1))
         assertResult("1")(test.show)
       }
       "10-dev" in {
-        val test = DcosReleaseVersion(Version(10), List.empty, Some(Suffix("dev")))
+        val test = DcosReleaseVersion(DcosReleaseVersion.Version(10), List.empty, Some(DcosReleaseVersion.Suffix("dev")))
         assertResult("10-dev")(test.show)
       }
     }
 
-    "Version" - {
+    "DcosReleaseVersion.Version" - {
       "should enforce that values are >= 0" - {
         "-1" in {
           assertAssertionError("assertion failed: Value -1 is not >= 0") {
-            Version(-1)
+            DcosReleaseVersion.Version(-1)
           }
         }
 
         "-100" in {
           assertAssertionError("assertion failed: Value -100 is not >= 0") {
-            Version(-100)
+            DcosReleaseVersion.Version(-100)
           }
         }
 
         "0" in {
-          assertResult(0)(Version(0).value)
+          assertResult(0)(DcosReleaseVersion.Version(0).value)
         }
 
         "1" in {
-          assertResult(1)(Version(1).value)
+          assertResult(1)(DcosReleaseVersion.Version(1).value)
         }
 
         "100" in {
-          assertResult(100)(Version(100).value)
+          assertResult(100)(DcosReleaseVersion.Version(100).value)
         }
       }
     }
     // scalastyle:on magic.number
 
-    "Suffix" - {
+    "DcosReleaseVersion.Suffix" - {
       "enforces format constraints" - {
         "pass for" - {
           "beta" in {
-            assertResult("beta")(Suffix("beta").value)
+            assertResult("beta")(DcosReleaseVersion.Suffix("beta").value)
           }
           "BETA" in {
-            assertResult("BETA")(Suffix("BETA").value)
+            assertResult("BETA")(DcosReleaseVersion.Suffix("BETA").value)
           }
         }
         "fail for" - {
           "!" in {
             assertAssertionError("assertion failed: Value '!' does not conform to expected format ^[A-Za-z0-9]+$") {
-              Suffix("!")
+              DcosReleaseVersion.Suffix("!")
             }
           }
           "-" in {
             assertAssertionError("assertion failed: Value '-' does not conform to expected format ^[A-Za-z0-9]+$") {
-              Suffix("-")
+              DcosReleaseVersion.Suffix("-")
             }
           }
           "." in {
             assertAssertionError("assertion failed: Value '.' does not conform to expected format ^[A-Za-z0-9]+$") {
-              Suffix(".")
+              DcosReleaseVersion.Suffix(".")
             }
           }
         }

--- a/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackageDefinitionSpec.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackageDefinitionSpec.scala
@@ -14,7 +14,7 @@ final class PackageDefinitionSpec extends FreeSpec with PropertyChecks {
       "succeed on non-negative numbers" in {
         forAll (nonNegNum[Long]) { n =>
           whenever (n >= 0) {
-            assert(PackageDefinition.ReleaseVersion(n).isReturn)
+            assert(ReleaseVersion(n).isReturn)
           }
         }
       }
@@ -22,7 +22,7 @@ final class PackageDefinitionSpec extends FreeSpec with PropertyChecks {
       "fail on negative numbers" in {
         forAll (Gen.negNum[Long]) { n =>
           whenever (n < 0) {
-            assert(PackageDefinition.ReleaseVersion(n).isThrow)
+            assert(ReleaseVersion(n).isThrow)
           }
         }
       }
@@ -31,18 +31,18 @@ final class PackageDefinitionSpec extends FreeSpec with PropertyChecks {
 
     "ReleaseVersion.value" in {
       forAll (nonNegNum[Long]) { n =>
-        assertResult(n)(PackageDefinition.ReleaseVersion(n).get.value)
+        assertResult(n)(ReleaseVersion(n).get.value)
       }
     }
 
     "ReleaseVersion$.ordering orders by value" in {
       forAll (nonNegNum[Long], nonNegNum[Long]) { (a, b) =>
         whenever (a >= 0 && b >= 0) {
-          val aVersion = PackageDefinition.ReleaseVersion(a).get
-          val bVersion = PackageDefinition.ReleaseVersion(b).get
+          val aVersion = ReleaseVersion(a).get
+          val bVersion = ReleaseVersion(b).get
 
           assertResult(Ordering[Long].compare(a, b)) {
-            Ordering[PackageDefinition.ReleaseVersion].compare(aVersion, bVersion)
+            Ordering[ReleaseVersion].compare(aVersion, bVersion)
           }
         }
       }

--- a/cosmos-render/src/test/scala/com/mesosphere/cosmos/render/MarathonLabelsSpec.scala
+++ b/cosmos-render/src/test/scala/com/mesosphere/cosmos/render/MarathonLabelsSpec.scala
@@ -118,7 +118,7 @@ final class MarathonLabelsSpec extends FreeSpec with Matchers {
     val Success(resultPackagingVersion) =
       result.packagingVersion.as[Try[universe.v3.model.PackagingVersion]]
 
-    val resultTags = result.tags.map(tag => universe.v3.model.PackageDefinition.Tag(tag).get)
+    val resultTags = result.tags.map(tag => universe.v3.model.Tag(tag).get)
     val resultLicenses = result.licenses.map { licenses =>
       licenses.map { case universe.v2.model.License(name, url) =>
         universe.v3.model.License(name, Uri.parse(url))

--- a/cosmos-render/src/test/scala/com/mesosphere/cosmos/render/MarathonLabelsSpec.scala
+++ b/cosmos-render/src/test/scala/com/mesosphere/cosmos/render/MarathonLabelsSpec.scala
@@ -127,7 +127,7 @@ final class MarathonLabelsSpec extends FreeSpec with Matchers {
 
     assertResult(original.packagingVersion)(resultPackagingVersion)
     assertResult(original.name)(result.name)
-    assertResult(original.version)(result.version.as[universe.v3.model.PackageDefinition.Version])
+    assertResult(original.version)(result.version.as[universe.v3.model.Version])
     assertResult(original.maintainer)(result.maintainer)
     assertResult(original.description)(result.description)
     assertResult(original.tags)(resultTags)

--- a/cosmos-render/src/test/scala/com/mesosphere/cosmos/render/PackageDefinitionRendererSpec.scala
+++ b/cosmos-render/src/test/scala/com/mesosphere/cosmos/render/PackageDefinitionRendererSpec.scala
@@ -98,7 +98,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
         val packageDefinition = V3Package(
           packagingVersion = V3PackagingVersion,
           name = packageName,
-          version = PackageDefinition.Version("1.2.3"),
+          version = Version("1.2.3"),
           maintainer = "Mesosphere",
           description = "Testing user options",
           releaseVersion = PackageDefinition.ReleaseVersion(0).get,
@@ -149,7 +149,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
 
       val pkg = V2Package(
         name = "test",
-        version = PackageDefinition.Version("1.2.3"),
+        version = Version("1.2.3"),
         releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description",
@@ -208,7 +208,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
     "result in error if no marathon template defined" in {
       val pkg = V3Package(
         name = "test",
-        version = PackageDefinition.Version("1.2.3"),
+        version = Version("1.2.3"),
         releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description"
@@ -223,7 +223,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       val mustacheBytes = ByteBuffer.wrap(mustache.getBytes(StandardCharsets.UTF_8))
       val pkg = V3Package(
         name = "test",
-        version = PackageDefinition.Version("1.2.3"),
+        version = Version("1.2.3"),
         releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description",
@@ -244,7 +244,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       val mustacheBytes = ByteBuffer.wrap(mustache.getBytes(StandardCharsets.UTF_8))
       val pkg = V3Package(
         name = "test",
-        version = PackageDefinition.Version("1.2.3"),
+        version = Version("1.2.3"),
         releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description",
@@ -261,7 +261,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       val mustacheBytes = ByteBuffer.wrap(mustache.getBytes(StandardCharsets.UTF_8))
       val pkg = V3Package(
         name = "test",
-        version = PackageDefinition.Version("1.2.3"),
+        version = Version("1.2.3"),
         releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description",
@@ -277,7 +277,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       val mustacheBytes = ByteBuffer.wrap(mustache.getBytes(StandardCharsets.UTF_8))
       val pkg = V2Package(
         name = "test",
-        version = PackageDefinition.Version("1.2.3"),
+        version = Version("1.2.3"),
         releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description",
@@ -316,7 +316,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
         val mustacheBytes = ByteBuffer.wrap(mustache.getBytes(StandardCharsets.UTF_8))
         val pkg = V2Package(
           name = "test",
-          version = PackageDefinition.Version("1.2.3"),
+          version = Version("1.2.3"),
           releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
           maintainer = "maintainer",
           description = "description",
@@ -344,7 +344,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
         val mustacheBytes = ByteBuffer.wrap(mustache.getBytes(StandardCharsets.UTF_8))
         val pkg = V3Package(
           name = "test",
-          version = PackageDefinition.Version("1.2.3"),
+          version = Version("1.2.3"),
           releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
           maintainer = "maintainer",
           description = "description",
@@ -462,7 +462,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
     V3Package(
       packagingVersion = V3PackagingVersion,
       name = "testing",
-      version = PackageDefinition.Version("a.b.c"),
+      version = Version("a.b.c"),
       maintainer = "foo@bar.baz",
       description = "blah",
       releaseVersion = PackageDefinition.ReleaseVersion(0).get,

--- a/cosmos-render/src/test/scala/com/mesosphere/cosmos/render/PackageDefinitionRendererSpec.scala
+++ b/cosmos-render/src/test/scala/com/mesosphere/cosmos/render/PackageDefinitionRendererSpec.scala
@@ -101,7 +101,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
           version = Version("1.2.3"),
           maintainer = "Mesosphere",
           description = "Testing user options",
-          releaseVersion = PackageDefinition.ReleaseVersion(0).get,
+          releaseVersion = ReleaseVersion(0).get,
           marathon = Some(Marathon(mustacheBytes)),
           config = Some(buildConfig(Json.fromJsonObject(defaultsJson)))
         )
@@ -150,7 +150,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       val pkg = V2Package(
         name = "test",
         version = Version("1.2.3"),
-        releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
+        releaseVersion = ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description",
         marathon = Marathon(mustacheBytes),
@@ -209,7 +209,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       val pkg = V3Package(
         name = "test",
         version = Version("1.2.3"),
-        releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
+        releaseVersion = ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description"
       )
@@ -224,7 +224,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       val pkg = V3Package(
         name = "test",
         version = Version("1.2.3"),
-        releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
+        releaseVersion = ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description",
         marathon = Some(Marathon(mustacheBytes))
@@ -245,7 +245,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       val pkg = V3Package(
         name = "test",
         version = Version("1.2.3"),
-        releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
+        releaseVersion = ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description",
         marathon = Some(Marathon(mustacheBytes))
@@ -262,7 +262,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       val pkg = V3Package(
         name = "test",
         version = Version("1.2.3"),
-        releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
+        releaseVersion = ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description",
         marathon = Some(Marathon(mustacheBytes))
@@ -278,7 +278,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       val pkg = V2Package(
         name = "test",
         version = Version("1.2.3"),
-        releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
+        releaseVersion = ReleaseVersion(0).get(),
         maintainer = "maintainer",
         description = "description",
         marathon = Marathon(mustacheBytes),
@@ -317,7 +317,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
         val pkg = V2Package(
           name = "test",
           version = Version("1.2.3"),
-          releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
+          releaseVersion = ReleaseVersion(0).get(),
           maintainer = "maintainer",
           description = "description",
           marathon = Marathon(mustacheBytes),
@@ -345,7 +345,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
         val pkg = V3Package(
           name = "test",
           version = Version("1.2.3"),
-          releaseVersion = PackageDefinition.ReleaseVersion(0).get(),
+          releaseVersion = ReleaseVersion(0).get(),
           maintainer = "maintainer",
           description = "description",
           marathon = Some(Marathon(mustacheBytes)),
@@ -465,7 +465,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with TableDrivenPropertyChe
       version = Version("a.b.c"),
       maintainer = "foo@bar.baz",
       description = "blah",
-      releaseVersion = PackageDefinition.ReleaseVersion(0).get,
+      releaseVersion = ReleaseVersion(0).get,
       marathon = Some(Marathon(ByteBuffer.wrap(mustache.getBytes(StandardCharsets.UTF_8))))
     )
   }

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageAddSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageAddSpec.scala
@@ -70,13 +70,13 @@ final class PackageAddSpec
     }
 
     "by name and version" in {
-      val version = universe.v3.model.PackageDefinition.Version("2.2.5-0.2.0")
+      val version = universe.v3.model.Version("2.2.5-0.2.0")
       val addRequest = rpc.v1.model.UniverseAddRequest("cassandra", Some(version))
       assertSuccessfulUniverseAdd(addRequest)
     }
 
     "results in error when trying to add a version 2 package" in {
-      val version = universe.v3.model.PackageDefinition.Version("0.2.0-2")
+      val version = universe.v3.model.Version("0.2.0-2")
       val addRequest = rpc.v1.model.UniverseAddRequest("cassandra", Some(version))
 
       val response = CosmosClient.submit(CosmosRequests.packageAdd(addRequest))
@@ -208,7 +208,7 @@ object PackageAddSpec {
 
   def describePackage(
     packageName: String,
-    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+    packageVersion: Option[universe.v3.model.Version]
   ): rpc.v2.model.DescribeResponse = {
     val request = CosmosRequests.packageDescribeV2(packageName, packageVersion)
     val response = CosmosClient.submit(request)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageAddSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageAddSpec.scala
@@ -175,7 +175,7 @@ final class PackageAddSpec
     v3Package: universe.v3.model.V3Package
   ): universe.v3.model.V3Package = {
     // TODO package-add: Get release version from creation time in object storage
-    val fakeReleaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(0L).get()
+    val fakeReleaseVersion = universe.v3.model.ReleaseVersion(0L).get()
     v3Package.copy(command = None, releaseVersion = fakeReleaseVersion, selected = None)
   }
 

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -187,7 +187,7 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
       import com.mesosphere.universe.v3.model._
       val expectedBody = rpc.v2.model.InstallResponse(
         "enterprise-security-cli",
-        universe.v3.model.PackageDefinition.Version("0.8.0"),
+        universe.v3.model.Version("0.8.0"),
         cli = Some(Cli(Some(Platforms(
           None,
           Some(Architectures(Binary(

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -58,10 +58,10 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
 
   val ArangodbSearchResult = SearchResult(
     name = "arangodb",
-    currentVersion = universe.v3.model.PackageDefinition.Version("0.3.0"),
+    currentVersion = universe.v3.model.Version("0.3.0"),
     versions = Map(
-      universe.v3.model.PackageDefinition.Version("0.2.1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get,
-      universe.v3.model.PackageDefinition.Version("0.3.0") -> universe.v3.model.PackageDefinition.ReleaseVersion(1).get),
+      universe.v3.model.Version("0.2.1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get,
+      universe.v3.model.Version("0.3.0") -> universe.v3.model.PackageDefinition.ReleaseVersion(1).get),
     description = "A distributed free and open-source database with a flexible data model for documents, graphs, and key-values. " +
       "Build high performance applications using a convenient SQL-like query language or JavaScript extensions.",
     framework = true,
@@ -78,16 +78,16 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
 
   val CassandraSearchResult = SearchResult(
     name = "cassandra",
-    currentVersion = universe.v3.model.PackageDefinition.Version("1.0.6-2.2.5"),
+    currentVersion = universe.v3.model.Version("1.0.6-2.2.5"),
     versions = Map(
       // scalastyle:off magic.number
-      universe.v3.model.PackageDefinition.Version("0.2.0-1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get,
-      universe.v3.model.PackageDefinition.Version("0.2.0-2") -> universe.v3.model.PackageDefinition.ReleaseVersion(1).get,
-      universe.v3.model.PackageDefinition.Version("1.0.5-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(7).get,
-      universe.v3.model.PackageDefinition.Version("1.0.2-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(4).get,
-      universe.v3.model.PackageDefinition.Version("2.2.5-0.2.0") -> universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
-      universe.v3.model.PackageDefinition.Version("1.0.6-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(8).get,
-      universe.v3.model.PackageDefinition.Version("1.0.4-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(5).get
+      universe.v3.model.Version("0.2.0-1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get,
+      universe.v3.model.Version("0.2.0-2") -> universe.v3.model.PackageDefinition.ReleaseVersion(1).get,
+      universe.v3.model.Version("1.0.5-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(7).get,
+      universe.v3.model.Version("1.0.2-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(4).get,
+      universe.v3.model.Version("2.2.5-0.2.0") -> universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
+      universe.v3.model.Version("1.0.6-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(8).get,
+      universe.v3.model.Version("1.0.4-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(5).get
       // scalastyle:on magic.number
     ),
     description = "Apache Cassandra running on DC/OS",
@@ -104,8 +104,8 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
 
   val CrateSearchResult = SearchResult(
     name = "crate",
-    currentVersion = universe.v3.model.PackageDefinition.Version("0.1.0"),
-    versions = Map(universe.v3.model.PackageDefinition.Version("0.1.0") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get),
+    currentVersion = universe.v3.model.Version("0.1.0"),
+    versions = Map(universe.v3.model.Version("0.1.0") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get),
     description = "A Mesos Framework that allows running and resizing one or multiple Crate database clusters.",
     framework = true,
     tags = List(
@@ -123,8 +123,8 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
 
   val MemsqlSearchResult = SearchResult(
     name = "memsql",
-    currentVersion = universe.v3.model.PackageDefinition.Version("0.0.1"),
-    versions = Map(universe.v3.model.PackageDefinition.Version("0.0.1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get),
+    currentVersion = universe.v3.model.Version("0.0.1"),
+    versions = Map(universe.v3.model.Version("0.0.1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get),
     description =
       "MemSQL running on Apache Mesos. This framework provides the ability to create and manage " +
         "a set of MemSQL clusters, each running with the MemSQL Ops management tool.",
@@ -141,8 +141,8 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
 
   val MysqlSearchResult = SearchResult(
     name = "mysql",
-    currentVersion = universe.v3.model.PackageDefinition.Version("5.7.12"),
-    versions = Map(universe.v3.model.PackageDefinition.Version("5.7.12") -> universe.v3.model.PackageDefinition.ReleaseVersion(1).get),
+    currentVersion = universe.v3.model.Version("5.7.12"),
+    versions = Map(universe.v3.model.Version("5.7.12") -> universe.v3.model.PackageDefinition.ReleaseVersion(1).get),
     description =
       "MySQL is the world's most popular open source database. With its proven performance, " +
         "reliability and ease-of-use, MySQL has become the leading database choice for " +
@@ -157,8 +157,8 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
 
   val RiakSearchResult = SearchResult(
     name = "riak",
-    currentVersion = universe.v3.model.PackageDefinition.Version("0.1.1"),
-    versions = Map(universe.v3.model.PackageDefinition.Version("0.1.1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get),
+    currentVersion = universe.v3.model.Version("0.1.1"),
+    versions = Map(universe.v3.model.Version("0.1.1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get),
     description = "A distributed NoSQL key-value data store that offers high availability, fault tolerance, operational simplicity, and scalability.",
     framework = true,
     tags = List(

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -60,8 +60,8 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
     name = "arangodb",
     currentVersion = universe.v3.model.Version("0.3.0"),
     versions = Map(
-      universe.v3.model.Version("0.2.1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get,
-      universe.v3.model.Version("0.3.0") -> universe.v3.model.PackageDefinition.ReleaseVersion(1).get),
+      universe.v3.model.Version("0.2.1") -> universe.v3.model.ReleaseVersion(0).get,
+      universe.v3.model.Version("0.3.0") -> universe.v3.model.ReleaseVersion(1).get),
     description = "A distributed free and open-source database with a flexible data model for documents, graphs, and key-values. " +
       "Build high performance applications using a convenient SQL-like query language or JavaScript extensions.",
     framework = true,
@@ -81,13 +81,13 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
     currentVersion = universe.v3.model.Version("1.0.6-2.2.5"),
     versions = Map(
       // scalastyle:off magic.number
-      universe.v3.model.Version("0.2.0-1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get,
-      universe.v3.model.Version("0.2.0-2") -> universe.v3.model.PackageDefinition.ReleaseVersion(1).get,
-      universe.v3.model.Version("1.0.5-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(7).get,
-      universe.v3.model.Version("1.0.2-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(4).get,
-      universe.v3.model.Version("2.2.5-0.2.0") -> universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
-      universe.v3.model.Version("1.0.6-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(8).get,
-      universe.v3.model.Version("1.0.4-2.2.5") -> universe.v3.model.PackageDefinition.ReleaseVersion(5).get
+      universe.v3.model.Version("0.2.0-1") -> universe.v3.model.ReleaseVersion(0).get,
+      universe.v3.model.Version("0.2.0-2") -> universe.v3.model.ReleaseVersion(1).get,
+      universe.v3.model.Version("1.0.5-2.2.5") -> universe.v3.model.ReleaseVersion(7).get,
+      universe.v3.model.Version("1.0.2-2.2.5") -> universe.v3.model.ReleaseVersion(4).get,
+      universe.v3.model.Version("2.2.5-0.2.0") -> universe.v3.model.ReleaseVersion(3).get,
+      universe.v3.model.Version("1.0.6-2.2.5") -> universe.v3.model.ReleaseVersion(8).get,
+      universe.v3.model.Version("1.0.4-2.2.5") -> universe.v3.model.ReleaseVersion(5).get
       // scalastyle:on magic.number
     ),
     description = "Apache Cassandra running on DC/OS",
@@ -105,7 +105,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
   val CrateSearchResult = SearchResult(
     name = "crate",
     currentVersion = universe.v3.model.Version("0.1.0"),
-    versions = Map(universe.v3.model.Version("0.1.0") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get),
+    versions = Map(universe.v3.model.Version("0.1.0") -> universe.v3.model.ReleaseVersion(0).get),
     description = "A Mesos Framework that allows running and resizing one or multiple Crate database clusters.",
     framework = true,
     tags = List(
@@ -124,7 +124,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
   val MemsqlSearchResult = SearchResult(
     name = "memsql",
     currentVersion = universe.v3.model.Version("0.0.1"),
-    versions = Map(universe.v3.model.Version("0.0.1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get),
+    versions = Map(universe.v3.model.Version("0.0.1") -> universe.v3.model.ReleaseVersion(0).get),
     description =
       "MemSQL running on Apache Mesos. This framework provides the ability to create and manage " +
         "a set of MemSQL clusters, each running with the MemSQL Ops management tool.",
@@ -142,7 +142,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
   val MysqlSearchResult = SearchResult(
     name = "mysql",
     currentVersion = universe.v3.model.Version("5.7.12"),
-    versions = Map(universe.v3.model.Version("5.7.12") -> universe.v3.model.PackageDefinition.ReleaseVersion(1).get),
+    versions = Map(universe.v3.model.Version("5.7.12") -> universe.v3.model.ReleaseVersion(1).get),
     description =
       "MySQL is the world's most popular open source database. With its proven performance, " +
         "reliability and ease-of-use, MySQL has become the leading database choice for " +
@@ -158,7 +158,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
   val RiakSearchResult = SearchResult(
     name = "riak",
     currentVersion = universe.v3.model.Version("0.1.1"),
-    versions = Map(universe.v3.model.Version("0.1.1") -> universe.v3.model.PackageDefinition.ReleaseVersion(0).get),
+    versions = Map(universe.v3.model.Version("0.1.1") -> universe.v3.model.ReleaseVersion(0).get),
     description = "A distributed NoSQL key-value data store that offers high availability, fault tolerance, operational simplicity, and scalability.",
     framework = true,
     tags = List(

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/PackageSearchSpec.scala
@@ -66,7 +66,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
       "Build high performance applications using a convenient SQL-like query language or JavaScript extensions.",
     framework = true,
     tags = List("arangodb", "NoSQL", "database")
-      .map(universe.v3.model.PackageDefinition.Tag(_).get),
+      .map(universe.v3.model.Tag(_).get),
     selected = Some(true),
     images = Some(universe.v3.model.Images(
       iconSmall = Some("https://raw.githubusercontent.com/arangodb/arangodb-dcos/master/icons/arangodb_small.png"),
@@ -92,7 +92,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
     ),
     description = "Apache Cassandra running on DC/OS",
     framework = true,
-    tags = List("data", "database", "nosql").map(universe.v3.model.PackageDefinition.Tag(_).get),
+    tags = List("data", "database", "nosql").map(universe.v3.model.Tag(_).get),
     selected = Some(true),
     images = Some(universe.v3.model.Images(
       iconSmall = Some("https://downloads.mesosphere.com/cassandra-mesos/assets/cassandra-small.png"),
@@ -111,7 +111,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
     tags = List(
       "database",
       "nosql"
-    ).map(universe.v3.model.PackageDefinition.Tag(_).get),
+    ).map(universe.v3.model.Tag(_).get),
     selected = None,
     images = Some(universe.v3.model.Images(
       Some("https://downloads.mesosphere.com/universe/assets/icon-service-crate-small.png"),
@@ -129,7 +129,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
       "MemSQL running on Apache Mesos. This framework provides the ability to create and manage " +
         "a set of MemSQL clusters, each running with the MemSQL Ops management tool.",
     framework = true,
-    tags = List("mysql", "database", "rdbms").map(universe.v3.model.PackageDefinition.Tag(_).get),
+    tags = List("mysql", "database", "rdbms").map(universe.v3.model.Tag(_).get),
     selected = None,
     images = Some(universe.v3.model.Images(
       Some("https://downloads.mesosphere.com/universe/assets/icon-service-memsql-small.png"),
@@ -150,7 +150,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
         "via e-commerce and information services, all the way to high profile web properties " +
         "including Facebook, Twitter, YouTube, Yahoo! and many more.",
     framework = false,
-    tags = List("database", "mysql", "sql").map(universe.v3.model.PackageDefinition.Tag(_).get),
+    tags = List("database", "mysql", "sql").map(universe.v3.model.Tag(_).get),
     selected = None,
     images = None
   )
@@ -165,7 +165,7 @@ private object PackageSearchSpec extends TableDrivenPropertyChecks {
       "database",
       "riak",
       "NoSql"
-    ).map(universe.v3.model.PackageDefinition.Tag(_).get),
+    ).map(universe.v3.model.Tag(_).get),
     selected = None,
     images = Some(universe.v3.model.Images(
       Some("https://downloads.mesosphere.com/universe/assets/icon-service-riak-small.png"),

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
@@ -39,7 +39,7 @@ object CosmosRequests {
 
   def packageDescribeV2(
     packageName: String,
-    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+    packageVersion: Option[universe.v3.model.Version]
   ): HttpRequest = {
     val oldVersion = packageVersion.as[Option[universe.v2.model.PackageDetailsVersion]]
     val describeRequest = rpc.v1.model.DescribeRequest(packageName, oldVersion)

--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/UniverseClientSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/repository/UniverseClientSpec.scala
@@ -6,7 +6,7 @@ import java.net.MalformedURLException
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
 import com.mesosphere.cosmos.{GenericHttpError, RepositoryUriConnection, RepositoryUriSyntax}
-import com.mesosphere.universe.v3.model.PackageDefinition.Version
+import com.mesosphere.universe.v3.model.Version
 import com.mesosphere.universe.v3.model.{DcosReleaseVersion, DcosReleaseVersionParser}
 import com.mesosphere.universe.v3.syntax.PackageDefinitionOps._
 import com.netaporter.uri.Uri

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/CosmosError.scala
@@ -62,7 +62,7 @@ case class PackageNotFound(packageName: String) extends CosmosError {
 
 case class VersionNotFound(
   packageName: String,
-  packageVersion: universe.v3.model.PackageDefinition.Version
+  packageVersion: universe.v3.model.Version
 ) extends CosmosError {
   override val getData: Option[JsonObject] = {
     Some(
@@ -462,7 +462,7 @@ case class ConversionError(failure: String) extends CosmosError {
 
 case class ServiceMarathonTemplateNotFound(
   packageName: String,
-  packageVersion: universe.v3.model.PackageDefinition.Version
+  packageVersion: universe.v3.model.Version
 ) extends CosmosError {
   override val getData: Option[JsonObject] = {
     Some(

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/MultiRepository.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/MultiRepository.scala
@@ -36,7 +36,7 @@ final class MultiRepository(
 
   override def getPackageByPackageVersion(
       packageName: String,
-      packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+      packageVersion: Option[universe.v3.model.Version]
   )(implicit session: RequestSession): Future[(universe.v3.model.PackageDefinition, Uri)] = {
     /* Fold over all the results in order and ignore PackageNotFound and VersionNotFound errors.
      * We have found our answer when we find a PackageDefinition or a generic exception.

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -192,7 +192,7 @@ object Encoders {
         s"Package [$packageName] not found"
       case VersionNotFound(
         packageName,
-        com.mesosphere.universe.v3.model.PackageDefinition.Version(packageVersion)
+        com.mesosphere.universe.v3.model.Version(packageVersion)
       ) =>
         s"Version [$packageVersion] of package [$packageName] not found"
       case PackageFileMissing(fileName, _) =>
@@ -307,7 +307,7 @@ object Encoders {
             s"Unsupported redirect scheme - supported: $supportedMsg"
         }
       case ConversionError(failure) => failure
-      case ServiceMarathonTemplateNotFound(name, universe.v3.model.PackageDefinition.Version(version)) =>
+      case ServiceMarathonTemplateNotFound(name, universe.v3.model.Version(version)) =>
         s"Package: [$name] version: [$version] does not have a Marathon template defined and can not be rendered"
       case EnvelopeError(msg) => msg
       case InstallQueueError(msg) => msg

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ListHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ListHandler.scala
@@ -28,7 +28,7 @@ private[cosmos] final class ListHandler(
   private case class App(
     id: thirdparty.marathon.model.AppId,
     pkgName: String,
-    pkgReleaseVersion: universe.v3.model.PackageDefinition.ReleaseVersion,
+    pkgReleaseVersion: universe.v3.model.ReleaseVersion,
     repoUri: PackageOrigin,
     pkgMetadata: label.v1.model.PackageMetadata
   )

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageAddHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageAddHandler.scala
@@ -80,7 +80,7 @@ final class PackageAddHandler(
       // TODO package-add: Get creation time from storage
       packageMetadata.map { packageMetadata =>
         val timeOfAdd = Instant.now().getEpochSecond
-        val releaseVersion = universe.v3.model.PackageDefinition.ReleaseVersion(timeOfAdd).get()
+        val releaseVersion = universe.v3.model.ReleaseVersion(timeOfAdd).get()
         (packageMetadata, releaseVersion).as[universe.v3.model.V3Package]
       }
     }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageDescribeHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageDescribeHandler.scala
@@ -18,7 +18,7 @@ private[cosmos] final class PackageDescribeHandler(
   ): Future[universe.v3.model.PackageDefinition] = {
     val packageInfo = packageCollection.getPackageByPackageVersion(
       request.packageName,
-      request.packageVersion.as[Option[universe.v3.model.PackageDefinition.Version]]
+      request.packageVersion.as[Option[universe.v3.model.Version]]
     )
 
     packageInfo.map { case (pkg, _) => pkg }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageInstallHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageInstallHandler.scala
@@ -31,7 +31,7 @@ private[cosmos] final class PackageInstallHandler(
     packageCollection
       .getPackageByPackageVersion(
         request.packageName,
-        request.packageVersion.as[Option[universe.v3.model.PackageDefinition.Version]]
+        request.packageVersion.as[Option[universe.v3.model.Version]]
       )
       .flatMap { case (pkg, sourceUri) =>
         val packageConfig =

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageRenderHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageRenderHandler.scala
@@ -28,7 +28,7 @@ private[cosmos] final class PackageRenderHandler(
     packageCache
       .getPackageByPackageVersion(
         request.packageName,
-        request.packageVersion.as[Option[universe.v3.model.PackageDefinition.Version]]
+        request.packageVersion.as[Option[universe.v3.model.Version]]
       )
       .flatMap { case (pkg, uri) =>
         val packageConfig =

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/internal/model/package.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/internal/model/package.scala
@@ -28,8 +28,8 @@ package object model {
       }
     }
 
-    def packageVersion: Option[universe.v3.model.PackageDefinition.Version] = {
-      app.labels.get(MarathonApp.versionLabel).map(universe.v3.model.PackageDefinition.Version)
+    def packageVersion: Option[universe.v3.model.Version] = {
+      app.labels.get(MarathonApp.versionLabel).map(universe.v3.model.Version)
     }
 
     def packageRepository: Option[PackageOrigin] = for {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/internal/model/package.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/internal/model/package.scala
@@ -20,9 +20,9 @@ package object model {
 
     def packageName: Option[String] = app.labels.get(MarathonApp.nameLabel)
 
-    def packageReleaseVersion: Option[universe.v3.model.PackageDefinition.ReleaseVersion] = {
+    def packageReleaseVersion: Option[universe.v3.model.ReleaseVersion] = {
       app.labels.get(MarathonApp.releaseLabel).flatMap { label =>
-        Injection.invert[universe.v3.model.PackageDefinition.ReleaseVersion, String](
+        Injection.invert[universe.v3.model.ReleaseVersion, String](
           label
         ).toOption
       }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/CosmosRepository.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/CosmosRepository.scala
@@ -43,7 +43,7 @@ final class CosmosRepository (
 
   override def getPackageByPackageVersion(
     packageName: String,
-    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+    packageVersion: Option[universe.v3.model.Version]
   )(
     implicit session: RequestSession
   ): Future[(universe.v3.model.PackageDefinition, Uri)] = {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/CosmosRepository.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/CosmosRepository.scala
@@ -28,7 +28,7 @@ final class CosmosRepository (
 
   def getPackageByReleaseVersion(
     packageName: String,
-    releaseVersion: universe.v3.model.PackageDefinition.ReleaseVersion
+    releaseVersion: universe.v3.model.ReleaseVersion
   )(
     implicit session: RequestSession
   ): Future[universe.v3.model.PackageDefinition] = {
@@ -107,7 +107,7 @@ final class CosmosRepository (
               ))
 
             val releaseVersion = searchResult.versions.get(pkg.version).map { releaseVersion =>
-              import universe.v3.model.PackageDefinition.ReleaseVersion
+              import universe.v3.model.ReleaseVersion
               implicitly[Ordering[ReleaseVersion]].max(releaseVersion, pkg.releaseVersion)
             } getOrElse {
               pkg.releaseVersion

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/LocalPackageCollection.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/LocalPackageCollection.scala
@@ -38,7 +38,7 @@ final class LocalPackageCollection private(
   // They may only specify the name.
   final def getInstalledPackage(
     packageName: String,
-    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+    packageVersion: Option[universe.v3.model.Version]
   ): Future[rpc.v1.model.LocalPackage] = {
     list().map { packages =>
       LocalPackageCollection.installedPackage(packages, packageName, packageVersion)
@@ -50,7 +50,7 @@ final class LocalPackageCollection private(
   // describe any package while we only want to render or uninstall installed packages.
   final def getPackageByPackageVersion(
     packageName: String,
-    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+    packageVersion: Option[universe.v3.model.Version]
   ): Future[rpc.v1.model.LocalPackage] = {
     list().map { packages =>
       LocalPackageCollection.packageByPackageVersion(packages, packageName, packageVersion)
@@ -83,7 +83,7 @@ object LocalPackageCollection {
   def installedPackage(
     packages: List[rpc.v1.model.LocalPackage],
     packageName: String,
-    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+    packageVersion: Option[universe.v3.model.Version]
   ): rpc.v1.model.LocalPackage = {
     val namedPackages = packages
       .filter(pkg => pkg.packageName == packageName)
@@ -95,7 +95,7 @@ object LocalPackageCollection {
   def packageByPackageVersion(
     packages: List[rpc.v1.model.LocalPackage],
     packageName: String,
-    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+    packageVersion: Option[universe.v3.model.Version]
   ): rpc.v1.model.LocalPackage = {
     val namedPackages = packages.filter(pkg => pkg.packageName == packageName)
 
@@ -112,7 +112,7 @@ object LocalPackageCollection {
   private[this] def resolveVersion(
     packages: List[rpc.v1.model.LocalPackage],
     packageName: String,
-    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+    packageVersion: Option[universe.v3.model.Version]
   ): rpc.v1.model.LocalPackage = {
     val optionalPackage = packageVersion match {
       case Some(version) => packages.find(_.packageVersion == version)

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageCollection.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageCollection.scala
@@ -19,7 +19,7 @@ trait PackageCollection {
 
   def getPackageByPackageVersion(
     packageName: String,
-    packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+    packageVersion: Option[universe.v3.model.Version]
   )(implicit session: RequestSession): Future[(universe.v3.model.PackageDefinition, Uri)]
 
   def search(query: Option[String])(implicit session: RequestSession): Future[List[rpc.v1.model.SearchResult]]

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/UniverseClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/UniverseClient.scala
@@ -308,7 +308,7 @@ final class DefaultUniverseClient(
           // unfortunately com.mesosphere.universe.v2.model.PackageDetails#tags is a list string due to the
           // more formal type not being defined. The likely of this failing is remove, especially when the
           // source is universe-server.
-          universe.v3.model.PackageDefinition.Tag(tag).get
+          universe.v3.model.Tag(tag).get
       },
       details.selected.orElse(Some(false)),
       details.scm,

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/UniverseClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/UniverseClient.scala
@@ -296,8 +296,7 @@ final class DefaultUniverseClient(
     universe.v3.model.V2Package(
       universe.v3.model.V2PackagingVersion,
       details.name,
-      universe.v3.model.PackageDefinition
-        .Version(details.version.toString),
+      universe.v3.model.Version(details.version.toString),
       releaseVersion.as[ScalaTry[universe.v3.model.PackageDefinition.ReleaseVersion]].get,
       details.maintainer,
       details.description,

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/UniverseClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/UniverseClient.scala
@@ -297,7 +297,7 @@ final class DefaultUniverseClient(
       universe.v3.model.V2PackagingVersion,
       details.name,
       universe.v3.model.Version(details.version.toString),
-      releaseVersion.as[ScalaTry[universe.v3.model.PackageDefinition.ReleaseVersion]].get,
+      releaseVersion.as[ScalaTry[universe.v3.model.ReleaseVersion]].get,
       details.maintainer,
       details.description,
       universe.v3.model.Marathon(marathon),

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/PackageSearchHandlerSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/PackageSearchHandlerSpec.scala
@@ -40,9 +40,9 @@ object PackageSearchHandlerSpec {
   def searchResult(name: String): SearchResult = {
     SearchResult(
       name = name,
-      currentVersion = universe.v3.model.PackageDefinition.Version("1.2.3"),
+      currentVersion = universe.v3.model.Version("1.2.3"),
       versions = Map(
-        universe.v3.model.PackageDefinition.Version("1.2.3") ->
+        universe.v3.model.Version("1.2.3") ->
           universe.v3.model.PackageDefinition.ReleaseVersion(0).get
       ),
       description = "a package",

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/PackageSearchHandlerSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/PackageSearchHandlerSpec.scala
@@ -43,7 +43,7 @@ object PackageSearchHandlerSpec {
       currentVersion = universe.v3.model.Version("1.2.3"),
       versions = Map(
         universe.v3.model.Version("1.2.3") ->
-          universe.v3.model.PackageDefinition.ReleaseVersion(0).get
+          universe.v3.model.ReleaseVersion(0).get
       ),
       description = "a package",
       tags = Nil,

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/SelectedPackageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/SelectedPackageSpec.scala
@@ -127,9 +127,9 @@ object SelectedPackageSpec {
   def makeSearchResult(selected: Option[Boolean], name: String = "some-package"): SearchResult = {
     SearchResult(
       name = name,
-      currentVersion = universe.v3.model.PackageDefinition.Version("1.2.3"),
+      currentVersion = universe.v3.model.Version("1.2.3"),
       versions = Map(
-        universe.v3.model.PackageDefinition.Version("1.2.3") ->
+        universe.v3.model.Version("1.2.3") ->
           universe.v3.model.PackageDefinition.ReleaseVersion(0).get
       ),
       description = "An arbitrary package",

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/SelectedPackageSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/SelectedPackageSpec.scala
@@ -130,7 +130,7 @@ object SelectedPackageSpec {
       currentVersion = universe.v3.model.Version("1.2.3"),
       versions = Map(
         universe.v3.model.Version("1.2.3") ->
-          universe.v3.model.PackageDefinition.ReleaseVersion(0).get
+          universe.v3.model.ReleaseVersion(0).get
       ),
       description = "An arbitrary package",
       tags = Nil,

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/converter/CommonSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/converter/CommonSpec.scala
@@ -17,7 +17,7 @@ final class CommonSpec extends FreeSpec with PropertyChecks {
     forAll { (name: String, version: String) =>
       val expected = rpc.v1.model.PackageCoordinate(
         name,
-        universe.v3.model.PackageDefinition.Version(version)
+        universe.v3.model.Version(version)
       )
       val intermediate: String = expected.as[String]
       val Success(actual) = intermediate.as[Try[rpc.v1.model.PackageCoordinate]]

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/converter/ResponseSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/converter/ResponseSpec.scala
@@ -15,7 +15,7 @@ import org.scalatest.prop.GeneratorDrivenPropertyChecks.forAll
 final class ResponseSpec extends FreeSpec {
   "Conversion[rpc.v2.model.InstallResponse,Try[rpc.v1.model.InstallResponse]]" - {
     val vstring = "9.87.654.3210"
-    val ver = universe.v3.model.PackageDefinition.Version(vstring)
+    val ver = universe.v3.model.Version(vstring)
     val name = "ResponseSpec"
     val appid = AppId("foobar")
     val clis = List(None, Some("post install notes"))

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/handler/PackageAddHandlerSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/handler/PackageAddHandlerSpec.scala
@@ -57,7 +57,7 @@ final class PackageAddHandlerSpec extends FreeSpec with MockitoSugar with Proper
         def assertErrorOnPendingOperation(
           packageDef: universe.v3.model.V3Package,
           sourceUri: Uri,
-          packageVersion: Option[universe.v3.model.PackageDefinition.Version]
+          packageVersion: Option[universe.v3.model.Version]
         ): Assertion = {
           val coordinate = rpc.v1.model.PackageCoordinate(packageDef.name, packageDef.version)
           val addRequest = rpc.v1.model.UniverseAddRequest(packageDef.name, packageVersion)

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/repository/LocalPackageCollectionSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/repository/LocalPackageCollectionSpec.scala
@@ -21,7 +21,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     packagingVersion=universe.v3.model.V3PackagingVersion,
     name="ceph",
     version=universe.v3.model.Version("1.1"),
-    releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
+    releaseVersion=universe.v3.model.ReleaseVersion(3).get,
     maintainer="jose@mesosphere.com",
     description="Great object store"
   )
@@ -30,7 +30,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     packagingVersion=universe.v3.model.V3PackagingVersion,
     name="lambda",
     version=universe.v3.model.Version("0.5"),
-    releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(2).get,
+    releaseVersion=universe.v3.model.ReleaseVersion(2).get,
     maintainer="jose@mesosphere.com",
     description="Great compute framework"
   )
@@ -41,7 +41,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       name="marathon",
       version=universe.v3.model.Version("0.9"),
       releaseVersion=
-        universe.v3.model.PackageDefinition.ReleaseVersion(4).get, // scalastyle:ignore magic.number
+        universe.v3.model.ReleaseVersion(4).get, // scalastyle:ignore magic.number
       maintainer="jose@mesosphere.com",
       description="paas framework"
     ),
@@ -49,7 +49,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="marathon",
       version=universe.v3.model.Version("0.8.4"),
-      releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
+      releaseVersion=universe.v3.model.ReleaseVersion(3).get,
       maintainer="jose@mesosphere.com",
       description="paas framework"
     ),
@@ -57,7 +57,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="marathon",
       version=universe.v3.model.Version("1.0"),
-      releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(2).get,
+      releaseVersion=universe.v3.model.ReleaseVersion(2).get,
       maintainer="jose@mesosphere.com",
       description="paas framework"
     ),
@@ -65,7 +65,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="marathon",
       version=universe.v3.model.Version("0.10"),
-      releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(1).get,
+      releaseVersion=universe.v3.model.ReleaseVersion(1).get,
       maintainer="jose@mesosphere.com",
       description="paas framework"
     )
@@ -76,7 +76,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="lambda",
       version=universe.v3.model.Version("0.12"),
-      releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
+      releaseVersion=universe.v3.model.ReleaseVersion(3).get,
       maintainer="jose@mesosphere.com",
       description="Great compute framework"
     ),
@@ -86,7 +86,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="ceph",
       version=universe.v3.model.Version("0.8.4"),
-      releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(2).get,
+      releaseVersion=universe.v3.model.ReleaseVersion(2).get,
       maintainer="jose@mesosphere.com",
       description="Great object store"
     ),
@@ -94,7 +94,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="ceph",
       version=universe.v3.model.Version("1.5"),
-      releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(1).get,
+      releaseVersion=universe.v3.model.ReleaseVersion(1).get,
       maintainer="jose@mesosphere.com",
       description="Great object store"
     )
@@ -175,7 +175,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
         packagingVersion=universe.v3.model.V3PackagingVersion,
         name="lambda",
         version=universe.v3.model.Version("0.8"),
-        releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
+        releaseVersion=universe.v3.model.ReleaseVersion(3).get,
         maintainer="jose@mesosphere.com",
         description="Great compute framework"
       )
@@ -185,7 +185,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="lambda",
       version=universe.v3.model.Version("0.10"),
-      releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
+      releaseVersion=universe.v3.model.ReleaseVersion(3).get,
       maintainer="jose@mesosphere.com",
       description="Great compute framework"
     )
@@ -204,7 +204,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
           packagingVersion=universe.v3.model.V3PackagingVersion,
           name="lambda",
           version=universe.v3.model.Version("0.12"),
-          releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
+          releaseVersion=universe.v3.model.ReleaseVersion(3).get,
           maintainer="jose@mesosphere.com",
           description="Great compute framework"
         )
@@ -215,7 +215,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
             packagingVersion=universe.v3.model.V3PackagingVersion,
             name="lambda",
             version=universe.v3.model.Version("0.11"),
-            releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
+            releaseVersion=universe.v3.model.ReleaseVersion(3).get,
             maintainer="jose@mesosphere.com",
             description="Great compute framework"
           )

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/repository/LocalPackageCollectionSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/repository/LocalPackageCollectionSpec.scala
@@ -20,7 +20,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
   val expectedLatestCeph = universe.v3.model.V3Package(
     packagingVersion=universe.v3.model.V3PackagingVersion,
     name="ceph",
-    version=universe.v3.model.PackageDefinition.Version("1.1"),
+    version=universe.v3.model.Version("1.1"),
     releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
     maintainer="jose@mesosphere.com",
     description="Great object store"
@@ -29,7 +29,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
   val expectedLambda05 = universe.v3.model.V3Package(
     packagingVersion=universe.v3.model.V3PackagingVersion,
     name="lambda",
-    version=universe.v3.model.PackageDefinition.Version("0.5"),
+    version=universe.v3.model.Version("0.5"),
     releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(2).get,
     maintainer="jose@mesosphere.com",
     description="Great compute framework"
@@ -39,7 +39,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     universe.v3.model.V3Package(
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="marathon",
-      version=universe.v3.model.PackageDefinition.Version("0.9"),
+      version=universe.v3.model.Version("0.9"),
       releaseVersion=
         universe.v3.model.PackageDefinition.ReleaseVersion(4).get, // scalastyle:ignore magic.number
       maintainer="jose@mesosphere.com",
@@ -48,7 +48,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     universe.v3.model.V3Package(
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="marathon",
-      version=universe.v3.model.PackageDefinition.Version("0.8.4"),
+      version=universe.v3.model.Version("0.8.4"),
       releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
       maintainer="jose@mesosphere.com",
       description="paas framework"
@@ -56,7 +56,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     universe.v3.model.V3Package(
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="marathon",
-      version=universe.v3.model.PackageDefinition.Version("1.0"),
+      version=universe.v3.model.Version("1.0"),
       releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(2).get,
       maintainer="jose@mesosphere.com",
       description="paas framework"
@@ -64,7 +64,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     universe.v3.model.V3Package(
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="marathon",
-      version=universe.v3.model.PackageDefinition.Version("0.10"),
+      version=universe.v3.model.Version("0.10"),
       releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(1).get,
       maintainer="jose@mesosphere.com",
       description="paas framework"
@@ -75,7 +75,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     universe.v3.model.V3Package(
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="lambda",
-      version=universe.v3.model.PackageDefinition.Version("0.12"),
+      version=universe.v3.model.Version("0.12"),
       releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
       maintainer="jose@mesosphere.com",
       description="Great compute framework"
@@ -85,7 +85,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     universe.v3.model.V3Package(
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="ceph",
-      version=universe.v3.model.PackageDefinition.Version("0.8.4"),
+      version=universe.v3.model.Version("0.8.4"),
       releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(2).get,
       maintainer="jose@mesosphere.com",
       description="Great object store"
@@ -93,7 +93,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     universe.v3.model.V3Package(
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="ceph",
-      version=universe.v3.model.PackageDefinition.Version("1.5"),
+      version=universe.v3.model.Version("1.5"),
       releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(1).get,
       maintainer="jose@mesosphere.com",
       description="Great object store"
@@ -124,7 +124,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     val actualLambda05 = Await.result(
       packageCollection.getPackageByPackageVersion(
         "lambda",
-        Option(universe.v3.model.PackageDefinition.Version("0.5"))
+        Option(universe.v3.model.Version("0.5"))
       )
     )
     actualLambda05 shouldBe rpc.v1.model.Installed(expectedLambda05)
@@ -134,12 +134,12 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       Await.result(
         packageCollection.getPackageByPackageVersion(
           "ceph",
-          Option(universe.v3.model.PackageDefinition.Version("1.55"))
+          Option(universe.v3.model.Version("1.55"))
         )
       )
     )
     missingPackageVersion shouldBe Failure(
-      VersionNotFound("ceph", universe.v3.model.PackageDefinition.Version("1.55"))
+      VersionNotFound("ceph", universe.v3.model.Version("1.55"))
     )
 
 
@@ -148,7 +148,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       Await.result(
         packageCollection.getPackageByPackageVersion(
           "queue",
-          Option(universe.v3.model.PackageDefinition.Version("1.5"))
+          Option(universe.v3.model.Version("1.5"))
         )
       )
     )
@@ -174,7 +174,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
       universe.v3.model.V3Package(
         packagingVersion=universe.v3.model.V3PackagingVersion,
         name="lambda",
-        version=universe.v3.model.PackageDefinition.Version("0.8"),
+        version=universe.v3.model.Version("0.8"),
         releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
         maintainer="jose@mesosphere.com",
         description="Great compute framework"
@@ -184,7 +184,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     val package010 = universe.v3.model.V3Package(
       packagingVersion=universe.v3.model.V3PackagingVersion,
       name="lambda",
-      version=universe.v3.model.PackageDefinition.Version("0.10"),
+      version=universe.v3.model.Version("0.10"),
       releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
       maintainer="jose@mesosphere.com",
       description="Great compute framework"
@@ -203,7 +203,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
         universe.v3.model.V3Package(
           packagingVersion=universe.v3.model.V3PackagingVersion,
           name="lambda",
-          version=universe.v3.model.PackageDefinition.Version("0.12"),
+          version=universe.v3.model.Version("0.12"),
           releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
           maintainer="jose@mesosphere.com",
           description="Great compute framework"
@@ -214,7 +214,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
           universe.v3.model.V3Package(
             packagingVersion=universe.v3.model.V3PackagingVersion,
             name="lambda",
-            version=universe.v3.model.PackageDefinition.Version("0.11"),
+            version=universe.v3.model.Version("0.11"),
             releaseVersion=universe.v3.model.PackageDefinition.ReleaseVersion(3).get,
             maintainer="jose@mesosphere.com",
             description="Great compute framework"
@@ -226,7 +226,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
         rpc.v1.model.ErrorResponse("type", "message", None),
         rpc.v1.model.PackageCoordinate(
           "lambda",
-          universe.v3.model.PackageDefinition.Version("0.9")
+          universe.v3.model.Version("0.9")
         )
       ),
       expectedInstalled
@@ -237,7 +237,7 @@ final class LocalPackageCollectionSpec extends FreeSpec with Matchers {
     LocalPackageCollection.packageByPackageVersion(
       input,
       "lambda",
-      Some(universe.v3.model.PackageDefinition.Version("0.10"))
+      Some(universe.v3.model.Version("0.10"))
     ) shouldBe expected010
     LocalPackageCollection.packageByPackageName(input, "lambda") shouldBe input
 

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/repository/MultiRepositorySpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/repository/MultiRepositorySpec.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos
 
 import com.mesosphere.cosmos.repository.PackageSourcesStorage
 import com.mesosphere.cosmos.repository.UniverseClient
-import com.mesosphere.universe.v3.model.PackageDefinition.Version
+import com.mesosphere.universe.v3.model.Version
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
 import org.scalatest.FreeSpec
 import com.mesosphere.cosmos.http.RequestSession

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/repository/OperationProcessorSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/repository/OperationProcessorSpec.scala
@@ -196,7 +196,7 @@ final class OperationProcessorSpec extends FreeSpec with Matchers {
 object OperationProcessorSpec {
   val (packageCoordinate, pkg) = {
     val name = "test"
-    val version = universe.v3.model.PackageDefinition.Version("1.2.3")
+    val version = universe.v3.model.Version("1.2.3")
 
     val packageCoordinate = rpc.v1.model.PackageCoordinate(name, version)
 

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/repository/OperationProcessorSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/repository/OperationProcessorSpec.scala
@@ -204,7 +204,7 @@ object OperationProcessorSpec {
       universe.v3.model.V3PackagingVersion,
       name,
       version,
-      universe.v3.model.PackageDefinition.ReleaseVersion(0).get,
+      universe.v3.model.ReleaseVersion(0).get,
       "does@not.matter",
       "doesn't matter"
     )

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/installqueue/InstallQueueSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/storage/installqueue/InstallQueueSpec.scala
@@ -15,8 +15,8 @@ import com.mesosphere.cosmos.storage.v1.model.PendingOperation
 import com.mesosphere.cosmos.storage.v1.model.PendingStatus
 import com.mesosphere.cosmos.storage.v1.model.UniverseInstall
 import com.mesosphere.cosmos.zookeeper.Clients
+import com.mesosphere.universe
 import com.mesosphere.universe.test.TestingPackages
-import com.mesosphere.universe.v3.model.PackageDefinition
 import com.twitter.util.Await
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.test.TestingCluster
@@ -661,15 +661,15 @@ final class InstallQueueSpec extends fixture.FreeSpec with BeforeAndAfterAll {
 
 object InstallQueueSpec {
   private val coordinate1 =
-    PackageCoordinate("coordinate", PackageDefinition.Version("1"))
+    PackageCoordinate("coordinate", universe.v3.model.Version("1"))
   private val coordinate2 =
-    PackageCoordinate("coordinate", PackageDefinition.Version("2"))
+    PackageCoordinate("coordinate", universe.v3.model.Version("2"))
   private val coordinate3 =
-    PackageCoordinate("coordinate", PackageDefinition.Version("3"))
+    PackageCoordinate("coordinate", universe.v3.model.Version("3"))
   private val coordinate4 =
-    PackageCoordinate("coordinate", PackageDefinition.Version("4"))
+    PackageCoordinate("coordinate", universe.v3.model.Version("4"))
   private val coordinate5 =
-    PackageCoordinate("coordinate", PackageDefinition.Version("5"))
+    PackageCoordinate("coordinate", universe.v3.model.Version("5"))
   private val errorResponse1 =
     ErrorResponse("foo", "bar")
   private val errorResponse2 =

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/test/TestUtil.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/test/TestUtil.scala
@@ -7,7 +7,7 @@ import com.mesosphere.cosmos.storage.ObjectStorage
 import com.mesosphere.cosmos.storage.installqueue.ReaderView
 import com.mesosphere.universe
 import com.mesosphere.universe.test.TestingPackages
-import com.mesosphere.universe.v3.model.PackageDefinition.ReleaseVersion
+import com.mesosphere.universe.v3.model.ReleaseVersion
 import com.mesosphere.universe.v3.model._
 import com.twitter.util.Future
 import java.io.IOException

--- a/cosmos-server/src/test/scala/com/mesosphere/universe/TestUtil.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/universe/TestUtil.scala
@@ -9,7 +9,7 @@ object TestUtil {
 
   def buildPackage(v3Package: v3.model.V3Package): Array[Byte] = {
     val (packageData, _) =
-      v3Package.as[(v3.model.Metadata, v3.model.PackageDefinition.ReleaseVersion)]
+      v3Package.as[(v3.model.Metadata, v3.model.ReleaseVersion)]
 
     val bytesOut = new ByteArrayOutputStream()
     PackageUtil.buildPackage(bytesOut, packageData)


### PR DESCRIPTION
In order to add a v4 Package, we need to clean up the PackageDefinition hierarchy. One part of this clean up is to get all the inner objects out of PackageDefinition companion object. This is important so that these objects can be used in other packages, and most importantly versioned independently.