### PR TITLE
Publish unit and integration test JARs

### DIFF
--- a/cosmos-server/src/it/scala/com/mesosphere/cosmos/finagle/FinagleStreamingSpec.scala
+++ b/cosmos-server/src/it/scala/com/mesosphere/cosmos/finagle/FinagleStreamingSpec.scala
@@ -34,7 +34,7 @@ final class FinagleStreamingSpec extends FreeSpec {
 
     try {
       val reqBodySize = 10 * Runtime.getRuntime.maxMemory()
-      val readSize: Long = 200 * 1000 * 1000
+      val readSize: Long = 200L * 1000L * 1000L
 
       val values = Iterator.iterate(0L)(_ + 1).takeWhile(_ < reqBodySize)
       val bytes = iteratorToInputStream(values.map(v => (v & 0xFF).toByte))


### PR DESCRIPTION
Mostly straightforward, except that I had to customize how the integration test artifacts are generated by SBT. The defaults in SBT handle artifacts for unit tests, but not integration tests.