### PR TITLE
Refactor tests so that it's easy to add v4 packages

### DIFF
--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/PackagingVersionConverterSpec.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/PackagingVersionConverterSpec.scala
@@ -2,13 +2,18 @@ package com.mesosphere.universe.bijection
 
 import com.mesosphere.universe
 import com.mesosphere.universe.bijection.UniverseConversions._
+import com.mesosphere.universe.test.TestingPackages
+import com.twitter.bijection.Bijection
 import com.twitter.bijection.Conversion.asMethod
-import com.twitter.bijection.{Bijection, Injection}
+import com.twitter.bijection.Injection
 import org.scalatest.FreeSpec
+import org.scalatest.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
-import scala.util.{Failure, Success, Try}
-
-final class PackagingVersionConverterSpec extends FreeSpec {
+final class PackagingVersionConverterSpec extends FreeSpec with Matchers with TableDrivenPropertyChecks {
 
   "v2PackagingVersionToString should" - {
 
@@ -99,34 +104,18 @@ final class PackagingVersionConverterSpec extends FreeSpec {
     aToString: Bijection[A, String]
   ): Unit = {
 
-    "succeed in the forward direction" - {
-
-      "V2PackagingVersion" in {
-        val version: universe.v3.model.PackagingVersion = universe.v3.model.V2PackagingVersion
-        assertResult("2.0")(version.as[A].as[String])
+    "succeed in the forward direction" in {
+      forAll(TestingPackages.validPackagingVersions) { (version, string) =>
+        version.as[A].as[String] should be (string)
       }
-
-      "V3PackagingVersion" in {
-        val version: universe.v3.model.PackagingVersion = universe.v3.model.V3PackagingVersion
-        assertResult("3.0")(version.as[A].as[String])
-      }
-
     }
 
     "succeed in the reverse direction" - {
-
-      "if the version is 2.0" in {
-        assertResult(Success(universe.v3.model.V2PackagingVersion)) {
-          "2.0".as[A].as[Try[universe.v3.model.PackagingVersion]]
+      "when the version is valid" in {
+        forAll(TestingPackages.validPackagingVersions) { (version, string) =>
+          string.as[A].as[Try[universe.v3.model.PackagingVersion]] should be (Success(version))
         }
       }
-
-      "if the version is 3.0" in {
-        assertResult(Success(universe.v3.model.V3PackagingVersion)) {
-          "3.0".as[A].as[Try[universe.v3.model.PackagingVersion]]
-        }
-      }
-
     }
 
     "fail in the reverse direction if the version is not 2.0 or 3.0" in {

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/PackagingVersionConverterSpec.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/PackagingVersionConverterSpec.scala
@@ -2,7 +2,6 @@ package com.mesosphere.universe.bijection
 
 import com.mesosphere.universe
 import com.mesosphere.universe.bijection.UniverseConversions._
-import com.mesosphere.universe.test.TestingPackages
 import com.twitter.bijection.Bijection
 import com.twitter.bijection.Conversion.asMethod
 import com.twitter.bijection.Injection
@@ -105,22 +104,23 @@ final class PackagingVersionConverterSpec extends FreeSpec with Matchers with Ta
   ): Unit = {
 
     "succeed in the forward direction" in {
-      forAll(TestingPackages.validPackagingVersions) { (version, string) =>
+      forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
         version.as[A].as[String] should be (string)
       }
     }
 
     "succeed in the reverse direction" - {
       "when the version is valid" in {
-        forAll(TestingPackages.validPackagingVersions) { (version, string) =>
+        forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
           string.as[A].as[Try[universe.v3.model.PackagingVersion]] should be (Success(version))
         }
       }
     }
 
     "fail in the reverse direction if the version is not 2.0 or 3.0" in {
-      val Failure(iae) = "2.5".as[A].as[Try[universe.v3.model.PackagingVersion]]
-      val message = "Expected one of [2.0, 3.0] for packaging version, but found [2.5]"
+      val invalidVersion = "2.5"
+      val Failure(iae) = invalidVersion.as[A].as[Try[universe.v3.model.PackagingVersion]]
+      val message = universe.v3.model.PackagingVersionTestOps.renderInvalidVersionMessage(invalidVersion)
       assertResult(message)(iae.getMessage)
     }
 

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/PackagingVersionConverterSpec.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/PackagingVersionConverterSpec.scala
@@ -104,14 +104,14 @@ final class PackagingVersionConverterSpec extends FreeSpec with Matchers with Ta
   ): Unit = {
 
     "succeed in the forward direction" in {
-      forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
+      forAll(universe.v3.model.PackagingVersionTestCompanion.validPackagingVersions) { (version, string) =>
         version.as[A].as[String] should be (string)
       }
     }
 
     "succeed in the reverse direction" - {
       "when the version is valid" in {
-        forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
+        forAll(universe.v3.model.PackagingVersionTestCompanion.validPackagingVersions) { (version, string) =>
           string.as[A].as[Try[universe.v3.model.PackagingVersion]] should be (Success(version))
         }
       }
@@ -120,7 +120,7 @@ final class PackagingVersionConverterSpec extends FreeSpec with Matchers with Ta
     "fail in the reverse direction if the version is not 2.0 or 3.0" in {
       val invalidVersion = "2.5"
       val Failure(iae) = invalidVersion.as[A].as[Try[universe.v3.model.PackagingVersion]]
-      val message = universe.v3.model.PackagingVersionTestOps.renderInvalidVersionMessage(invalidVersion)
+      val message = universe.v3.model.PackagingVersionTestCompanion.renderInvalidVersionMessage(invalidVersion)
       assertResult(message)(iae.getMessage)
     }
 

--- a/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/UniverseConversionsSpec.scala
+++ b/cosmos-bijection/src/test/scala/com/mesosphere/universe/bijection/UniverseConversionsSpec.scala
@@ -40,7 +40,7 @@ final class UniverseConversionsSpec extends FreeSpec with Matchers with TableDri
 
   "(Metadata, ReleaseVersion) => SupportedPackageDefinition => (Metadata, ReleaseVersion) is the identity fn" in {
     forAll(metadataAndReleaseVersion) { metadataAndReleaseVersion =>
-      id(metadataAndReleaseVersion) should be(metadataAndReleaseVersion)
+      metadataConversionRoundTrip(metadataAndReleaseVersion) should be(metadataAndReleaseVersion)
     }
   }
 
@@ -54,7 +54,7 @@ final class UniverseConversionsSpec extends FreeSpec with Matchers with TableDri
   "SupportedPackageDefinition => (Metadata, ReleaseVersion) => SupportedPackageDefinition" - {
     "is almost the identity function" in {
       forAll(supportedPackageDefinition) { original =>
-        val roundtrip = almostId(original) match {
+        val roundtrip = metadataConversionAlmostRoundTrip(original) match {
           case v3: universe.v3.model.V3Package =>
             v3.copy(selected = original.selected, command = original.command)
         }
@@ -63,7 +63,7 @@ final class UniverseConversionsSpec extends FreeSpec with Matchers with TableDri
     }
     "should produce empty command and selected parameters" in {
       forAll(supportedPackageDefinition) { original =>
-        val roundtrip = almostId(original)
+        val roundtrip = metadataConversionAlmostRoundTrip(original)
         roundtrip.command should be(None)
         roundtrip.selected should be(None)
       }
@@ -142,7 +142,7 @@ final class UniverseConversionsSpec extends FreeSpec with Matchers with TableDri
     assertResult(v3)(v2FromV3.as[universe.v3.model.Version])
   }
 
-  def id(
+  def metadataConversionRoundTrip(
     metadataAndReleaseVersion: (universe.v3.model.Metadata, universe.v3.model.ReleaseVersion)
   ): (universe.v3.model.Metadata, universe.v3.model.ReleaseVersion) = {
     metadataAndReleaseVersion
@@ -150,7 +150,7 @@ final class UniverseConversionsSpec extends FreeSpec with Matchers with TableDri
       .as[(universe.v3.model.Metadata, universe.v3.model.ReleaseVersion)]
   }
 
-  def almostId(
+  def metadataConversionAlmostRoundTrip(
     supportedPackage: universe.v3.model.SupportedPackageDefinition
   ): universe.v3.model.SupportedPackageDefinition = {
     supportedPackage

--- a/cosmos-common/src/test/scala/com/mesosphere/util/PackageUtilSpec.scala
+++ b/cosmos-common/src/test/scala/com/mesosphere/util/PackageUtilSpec.scala
@@ -55,8 +55,8 @@ final class PackageUtilSpec extends FreeSpec with PropertyChecks {
       val contentsWithMetadata = zipContents + (MetadataJson -> metadataBytes)
       val bytesIn = encodeZip(contentsWithMetadata)
 
-      val Right(extractedMetadata) = PackageUtil.extractMetadata(bytesIn)
-      assertResult(goodMetadata)(extractedMetadata)
+      val extractedMetadata = PackageUtil.extractMetadata(bytesIn)
+      assertResult(Right(goodMetadata))(extractedMetadata)
       assert(bytesIn.isClosed)
     }
   }

--- a/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/PackagingVersionEncoderDecoderSpec.scala
+++ b/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/PackagingVersionEncoderDecoderSpec.scala
@@ -1,7 +1,6 @@
 package com.mesosphere.universe.v3.circe
 
 import com.mesosphere.universe
-import com.mesosphere.universe.test.TestingPackages
 import io.circe.Decoder
 import io.circe.Json
 import io.circe.syntax._
@@ -15,13 +14,13 @@ final class PackagingVersionEncoderDecoderSpec extends FreeSpec with Matchers wi
 
   "Encoders.encodePackagingVersion" - {
     "as PackagingVersion type" in {
-      forAll(TestingPackages.validPackagingVersions) { (version, string) =>
+      forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
         version.asJson should be(Json.fromString(string))
       }
     }
 
     "as subclass type" in {
-      forAll(TestingPackages.validPackagingVersions) { (version, string) =>
+      forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
         toJsonAsPackagingVersionSubclass(version) should be(Json.fromString(string))
       }
     }
@@ -29,7 +28,7 @@ final class PackagingVersionEncoderDecoderSpec extends FreeSpec with Matchers wi
 
   "Decoders.decodeV3PackagingVersion should" - {
     "successfully decode packaging versions" in {
-      forAll(TestingPackages.validPackagingVersions) { (version, string) =>
+      forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
         val decodedVersion =
           Decoder[universe.v3.model.PackagingVersion].decodeJson(Json.fromString(string))
         decodedVersion should be (Right(version))
@@ -37,8 +36,12 @@ final class PackagingVersionEncoderDecoderSpec extends FreeSpec with Matchers wi
     }
 
     "fail to decode any other string value" in {
-      val Left(failure) = Decoder[universe.v3.model.PackagingVersion].decodeJson(Json.fromString("3.1"))
-      assertResult("Expected one of [2.0, 3.0] for packaging version, but found [3.1]") {
+      val invalidVersion = "3.1"
+      val Left(failure) =
+        Decoder[universe.v3.model.PackagingVersion].decodeJson(Json.fromString(invalidVersion))
+      val expectedMessage =
+        universe.v3.model.PackagingVersionTestOps.renderInvalidVersionMessage(invalidVersion)
+      assertResult(expectedMessage) {
         failure.message
       }
     }

--- a/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/PackagingVersionEncoderDecoderSpec.scala
+++ b/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/PackagingVersionEncoderDecoderSpec.scala
@@ -14,13 +14,13 @@ final class PackagingVersionEncoderDecoderSpec extends FreeSpec with Matchers wi
 
   "Encoders.encodePackagingVersion" - {
     "as PackagingVersion type" in {
-      forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
+      forAll(universe.v3.model.PackagingVersionTestCompanion.validPackagingVersions) { (version, string) =>
         version.asJson should be(Json.fromString(string))
       }
     }
 
     "as subclass type" in {
-      forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
+      forAll(universe.v3.model.PackagingVersionTestCompanion.validPackagingVersions) { (version, string) =>
         toJsonAsPackagingVersionSubclass(version) should be(Json.fromString(string))
       }
     }
@@ -28,7 +28,7 @@ final class PackagingVersionEncoderDecoderSpec extends FreeSpec with Matchers wi
 
   "Decoders.decodeV3PackagingVersion should" - {
     "successfully decode packaging versions" in {
-      forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
+      forAll(universe.v3.model.PackagingVersionTestCompanion.validPackagingVersions) { (version, string) =>
         val decodedVersion =
           Decoder[universe.v3.model.PackagingVersion].decodeJson(Json.fromString(string))
         decodedVersion should be (Right(version))
@@ -40,7 +40,7 @@ final class PackagingVersionEncoderDecoderSpec extends FreeSpec with Matchers wi
       val Left(failure) =
         Decoder[universe.v3.model.PackagingVersion].decodeJson(Json.fromString(invalidVersion))
       val expectedMessage =
-        universe.v3.model.PackagingVersionTestOps.renderInvalidVersionMessage(invalidVersion)
+        universe.v3.model.PackagingVersionTestCompanion.renderInvalidVersionMessage(invalidVersion)
       assertResult(expectedMessage) {
         failure.message
       }

--- a/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/PackagingVersionEncoderDecoderSpec.scala
+++ b/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/PackagingVersionEncoderDecoderSpec.scala
@@ -41,9 +41,7 @@ final class PackagingVersionEncoderDecoderSpec extends FreeSpec with Matchers wi
         Decoder[universe.v3.model.PackagingVersion].decodeJson(Json.fromString(invalidVersion))
       val expectedMessage =
         universe.v3.model.PackagingVersionTestCompanion.renderInvalidVersionMessage(invalidVersion)
-      assertResult(expectedMessage) {
-        failure.message
-      }
+      assertResult(expectedMessage)(failure.message)
     }
 
     behave like failedDecodeOnNonString[universe.v3.model.PackagingVersion]

--- a/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/RepositoryEncoderDecoderSpec.scala
+++ b/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/RepositoryEncoderDecoderSpec.scala
@@ -93,7 +93,7 @@ class RepositoryEncoderDecoderSpec extends FreeSpec {
         )
       )
 
-      val expectedErrorMessage = s"Expected one of ${PackagingVersionTestOps.versionStringList}" +
+      val expectedErrorMessage = s"Expected one of ${PackagingVersionTestCompanion.versionStringList}" +
         " for packaging version, but found " +
         "[3.1]: El(DownField(packagingVersion),true,false),El(DownArray,true,false)," +
         "El(DownField(packages),true,false)"

--- a/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/RepositoryEncoderDecoderSpec.scala
+++ b/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/RepositoryEncoderDecoderSpec.scala
@@ -101,7 +101,8 @@ class RepositoryEncoderDecoderSpec extends FreeSpec {
         )
       )
 
-      val expectedErrorMessage = "Expected one of [2.0, 3.0] for packaging version, but found " +
+      val expectedErrorMessage = s"Expected one of ${PackagingVersionTestOps.versionStringList}" +
+        " for packaging version, but found " +
         "[3.1]: El(DownField(packagingVersion),true,false),El(DownArray,true,false)," +
         "El(DownField(packages),true,false)"
 

--- a/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/RepositoryEncoderDecoderSpec.scala
+++ b/cosmos-json/src/test/scala/com/mesosphere/universe/v3/circe/RepositoryEncoderDecoderSpec.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.universe.v3.circe
 
 import com.mesosphere.universe.v3.model._
+import com.mesosphere.universe.v3.syntax.PackageDefinitionOps._
 import io.circe.Json
 import io.circe.jawn.parse
 import io.circe.syntax._
@@ -61,18 +62,9 @@ class RepositoryEncoderDecoderSpec extends FreeSpec {
       assertResult(expected)(repo.packages.size)
 
       val cassandraVersions = repo.packages
-        .filter {
-          case v2: V2Package => v2.name == "cassandra"
-          case v3: V3Package => v3.name == "cassandra"
-        }
-        .sortBy {
-          case v2: V2Package => v2.releaseVersion.value
-          case v3: V3Package => v3.releaseVersion.value
-        }
-        .map {
-          case v2: V2Package => v2.version
-          case v3: V3Package => v3.version
-        }
+        .filter(_.name == "cassandra")
+        .sortBy(_.releaseVersion.value)
+        .map(_.version)
 
       val expectedCassandraVersions = List(
         Version("0.2.0-1"),

--- a/cosmos-model/src/test/scala/com/mesosphere/universe/test/TestingPackages.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/universe/test/TestingPackages.scala
@@ -7,12 +7,15 @@ import io.circe.syntax._
 import io.circe.JsonObject
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
+import org.scalatest.prop.TableFor2
 
 object TestingPackages {
   val PackagingVersion = universe.v3.model.V3PackagingVersion
   val Name = "MAXIMAL"
   val Version = universe.v3.model.Version("9.87.654.3210")
   val Maintainer = "max@mesosphere.io"
+  val MaxReleaseVersion = universe.v3.model.ReleaseVersion(Long.MaxValue).get
+  val MinReleaseVersion = universe.v3.model.ReleaseVersion(0L).get
   val Description = "A complete package definition"
   val MarathonTemplate = Some(universe.v3.model.Marathon(
     v2AppMustacheTemplate = ByteBuffer.wrap("marathon template".getBytes(StandardCharsets.UTF_8))
@@ -89,7 +92,7 @@ object TestingPackages {
     PackagingVersion,
     Name,
     Version,
-    releaseVersion = universe.v3.model.ReleaseVersion(Long.MaxValue).get,
+    MaxReleaseVersion,
     Maintainer,
     Description,
     Tags,
@@ -114,7 +117,7 @@ object TestingPackages {
     packagingVersion = universe.v3.model.V3PackagingVersion,
     name = "minimal",
     version = universe.v3.model.Version("1.2.3"),
-    releaseVersion = universe.v3.model.ReleaseVersion(0).get,
+    releaseVersion = MinReleaseVersion,
     maintainer = "minimal@mesosphere.io",
     description = "A minimal package definition"
   )
@@ -276,7 +279,7 @@ object TestingPackages {
   val HelloWorldV3Package: universe.v3.model.V3Package = universe.v3.model.V3Package(
     name = "helloworld",
     version = universe.v3.model.Version("0.1.0"),
-    releaseVersion = universe.v3.model.ReleaseVersion(0L).get(),
+    releaseVersion = MinReleaseVersion,
     website = Some("https://github.com/mesosphere/dcos-helloworld"),
     maintainer = "support@mesosphere.io",
     description = "Example DCOS application package",
@@ -296,5 +299,12 @@ object TestingPackages {
       )
     )))
   )
+
+  val validPackagingVersions: TableFor2[universe.v3.model.PackagingVersion, String] =
+    new TableFor2(
+      "PackagingVersion" -> "String",
+      universe.v3.model.V2PackagingVersion -> "2.0",
+      universe.v3.model.V3PackagingVersion -> "3.0"
+    )
 
 }

--- a/cosmos-model/src/test/scala/com/mesosphere/universe/test/TestingPackages.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/universe/test/TestingPackages.scala
@@ -300,11 +300,4 @@ object TestingPackages {
     )))
   )
 
-  val validPackagingVersions: TableFor2[universe.v3.model.PackagingVersion, String] =
-    new TableFor2(
-      "PackagingVersion" -> "String",
-      universe.v3.model.V2PackagingVersion -> "2.0",
-      universe.v3.model.V3PackagingVersion -> "3.0"
-    )
-
 }

--- a/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackagingVersionSpec.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackagingVersionSpec.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.universe.v3.model
 
-import com.mesosphere.universe.test.TestingPackages
+import com.mesosphere.universe
 import org.scalatest.FreeSpec
 import org.scalatest.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks
@@ -8,7 +8,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 final class PackagingVersionSpec extends FreeSpec with Matchers with TableDrivenPropertyChecks {
 
   "PackagingVersion.show" - {
-    forAll(TestingPackages.validPackagingVersions) { (version, string) =>
+    forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
         s"PackagingVersion $string" in {
           version.show should be(string)
         }
@@ -16,7 +16,8 @@ final class PackagingVersionSpec extends FreeSpec with Matchers with TableDriven
   }
 
   "PackagingVersions.allVersions" in {
-    TestingPackages.validPackagingVersions.map(_._1) should be(PackagingVersion.allVersions)
+    val allVersions = universe.v3.model.PackagingVersionTestOps.validPackagingVersions.map(_._1)
+    allVersions should be(PackagingVersion.allVersions)
   }
 
 }

--- a/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackagingVersionSpec.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackagingVersionSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 final class PackagingVersionSpec extends FreeSpec with Matchers with TableDrivenPropertyChecks {
 
   "PackagingVersion.show" - {
-    forAll(universe.v3.model.PackagingVersionTestOps.validPackagingVersions) { (version, string) =>
+    forAll(universe.v3.model.PackagingVersionTestCompanion.validPackagingVersions) { (version, string) =>
         s"PackagingVersion $string" in {
           version.show should be(string)
         }
@@ -16,7 +16,7 @@ final class PackagingVersionSpec extends FreeSpec with Matchers with TableDriven
   }
 
   "PackagingVersions.allVersions" in {
-    val allVersions = universe.v3.model.PackagingVersionTestOps.validPackagingVersions.map(_._1)
+    val allVersions = universe.v3.model.PackagingVersionTestCompanion.validPackagingVersions.map(_._1)
     allVersions should be(PackagingVersion.allVersions)
   }
 

--- a/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackagingVersionSpec.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackagingVersionSpec.scala
@@ -1,25 +1,22 @@
 package com.mesosphere.universe.v3.model
 
+import com.mesosphere.universe.test.TestingPackages
 import org.scalatest.FreeSpec
+import org.scalatest.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
 
-final class PackagingVersionSpec extends FreeSpec {
+final class PackagingVersionSpec extends FreeSpec with Matchers with TableDrivenPropertyChecks {
 
   "PackagingVersion.show" - {
-
-    "V2PackagingVersion" in {
-      assertResult("2.0")(V2PackagingVersion.show)
+    forAll(TestingPackages.validPackagingVersions) { (version, string) =>
+        s"PackagingVersion $string" in {
+          version.show should be(string)
+        }
     }
-
-    "V3PackagingVersion" in {
-      assertResult("3.0")(V3PackagingVersion.show)
-    }
-
   }
 
-  "PackagingVersion$.allVersions" in {
-    assertResult(Seq(V2PackagingVersion, V3PackagingVersion)) {
-      PackagingVersion.allVersions
-    }
+  "PackagingVersions.allVersions" in {
+    TestingPackages.validPackagingVersions.map(_._1) should be(PackagingVersion.allVersions)
   }
 
 }

--- a/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackagingVersionTestCompanion.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackagingVersionTestCompanion.scala
@@ -3,7 +3,7 @@ package com.mesosphere.universe.v3.model
 import com.mesosphere.universe
 import org.scalatest.prop.TableFor2
 
-object PackagingVersionTestOps {
+object PackagingVersionTestCompanion {
 
   val validPackagingVersions: TableFor2[universe.v3.model.PackagingVersion, String] = {
     new TableFor2(

--- a/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackagingVersionTestOps.scala
+++ b/cosmos-model/src/test/scala/com/mesosphere/universe/v3/model/PackagingVersionTestOps.scala
@@ -1,0 +1,22 @@
+package com.mesosphere.universe.v3.model
+
+import com.mesosphere.universe
+import org.scalatest.prop.TableFor2
+
+object PackagingVersionTestOps {
+
+  val validPackagingVersions: TableFor2[universe.v3.model.PackagingVersion, String] = {
+    new TableFor2(
+      "PackagingVersion" -> "String",
+      universe.v3.model.V2PackagingVersion -> "2.0",
+      universe.v3.model.V3PackagingVersion -> "3.0"
+    )
+  }
+
+  val versionStringList =  validPackagingVersions.map(_._2).mkString("[", ", ", "]")
+
+  def renderInvalidVersionMessage(invalidVersion: String): String = {
+    s"Expected one of $versionStringList for packaging version, but found [$invalidVersion]"
+  }
+
+}

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
@@ -130,7 +130,7 @@ class EncodersDecodersSpec extends FreeSpec with PropertyChecks with Matchers {
 
         val invalidVersion = "1.0"
         val invalidPackagingVersionErrorString =
-          universe.v3.model.PackagingVersionTestOps.renderInvalidVersionMessage(invalidVersion)
+          universe.v3.model.PackagingVersionTestCompanion.renderInvalidVersionMessage(invalidVersion)
 
         assertResult("json_error")(typ)
         assertResult("decode")(dataType)

--- a/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
+++ b/cosmos-server/src/test/scala/com/mesosphere/cosmos/circe/EncodersDecodersSpec.scala
@@ -19,6 +19,7 @@ import com.mesosphere.cosmos.rpc.v1.model.LocalPackage
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
 import com.mesosphere.cosmos.storage
 import com.mesosphere.cosmos.storage.v1.circe.Decoders._
+import com.mesosphere.universe
 import com.mesosphere.universe.test.TestingPackages
 import com.mesosphere.universe.v3.model.Repository
 import com.netaporter.uri.Uri
@@ -126,9 +127,14 @@ class EncodersDecodersSpec extends FreeSpec with PropertyChecks with Matchers {
         val Right(dataType) = c.downField("data").downField("type").as[String]
         val Right(reason) = c.downField("data").downField("reason").as[String]
         val Right(path) = c.downField("data").downField("path").as[String]
+
+        val invalidVersion = "1.0"
+        val invalidPackagingVersionErrorString =
+          universe.v3.model.PackagingVersionTestOps.renderInvalidVersionMessage(invalidVersion)
+
         assertResult("json_error")(typ)
         assertResult("decode")(dataType)
-        assertResult("Expected one of [2.0, 3.0] for packaging version, but found [1.0]")(reason)
+        assertResult(invalidPackagingVersionErrorString)(reason)
         assertResult(".packages[0].packagingVersion")(path)
       }
 


### PR DESCRIPTION
Refactor tests to use Table testing style. With this style we'll be able add new examples (v4 examples) to the tables instead of copying and pasting the tests.

Also moves TestingPackages to cosmos-model, so that all tests in all modules are able to use the example packages.