### PR TITLE
Make PackagingVersion and PackageDefinition sealed traits

### DIFF
--- a/cosmos-model/src/main/scala/com/mesosphere/universe/PackageDefinition.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/PackageDefinition.scala
@@ -14,7 +14,7 @@ import io.circe.syntax.EncoderOps
 
 package v3.model {
 
-  sealed abstract class PackageDefinition
+  sealed trait PackageDefinition
 
   object PackageDefinition {
 

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/PackagingVersion.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/PackagingVersion.scala
@@ -58,6 +58,20 @@ package v3.model {
         }
       }
     }
+
+    def decodePackagingVersionSubclass[V <: PackagingVersion](expected: V): Decoder[V] = {
+      Decoder.instance { c: HCursor =>
+        c.as[String].flatMap {
+          case expected.show => Right(expected)
+          case s => Left(
+            DecodingFailure(
+              s"Expected value [${expected.show}] for packaging version, but found [$s]",
+              c.history
+            )
+          )
+        }
+      }
+    }
   }
 
   case object V2PackagingVersion extends PackagingVersion {
@@ -65,17 +79,7 @@ package v3.model {
     val show: String = "2.0"
 
     implicit val decodeV2PackagingVersion: Decoder[V2PackagingVersion.type] = {
-      Decoder.instance { c: HCursor =>
-        c.as[String].flatMap {
-          case this.show => Right(this)
-          case s => Left(
-            DecodingFailure(
-              s"Expected value [$show] for packaging version, but found [$s]",
-              c.history
-            )
-          )
-        }
-      }
+      PackagingVersion.decodePackagingVersionSubclass(this)
     }
 
     implicit val encodeV2PackagingVersion: Encoder[V2PackagingVersion.type] = {
@@ -90,17 +94,7 @@ package v3.model {
     val show: String = "3.0"
 
     implicit val decodeV3PackagingVersion: Decoder[V3PackagingVersion.type] = {
-      Decoder.instance { c: HCursor =>
-        c.as[String].flatMap {
-          case this.show => Right(this)
-          case s => Left(
-            DecodingFailure(
-              s"Expected value [$show] for packaging version, but found [$s]",
-              c.history
-            )
-          )
-        }
-      }
+      PackagingVersion.decodePackagingVersionSubclass(this)
     }
 
     implicit val encodeV3PackagingVersion: Encoder[V3PackagingVersion.type] = {

--- a/cosmos-model/src/main/scala/com/mesosphere/universe/PackagingVersion.scala
+++ b/cosmos-model/src/main/scala/com/mesosphere/universe/PackagingVersion.scala
@@ -9,15 +9,24 @@ import io.circe.Decoder
 import io.circe.DecodingFailure
 import io.circe.Encoder
 import io.circe.HCursor
+import io.circe.syntax.EncoderOps
 
 package v3.model {
 
-  sealed abstract class PackagingVersion private[model](val show: String)
+  sealed trait PackagingVersion {
+    val show: String
+  }
 
   object PackagingVersion {
-    val allVersions = Seq(V2PackagingVersion, V3PackagingVersion)
 
-    private[this] val allVersionsString = allVersions.map(_.show).mkString(", ")
+    val allVersions: Seq[PackagingVersion] =
+      Seq(
+        V2PackagingVersion,
+        V3PackagingVersion
+      )
+
+    private[this] val allVersionsString: String =
+      allVersions.map(_.show).mkString(", ")
 
     private[this] val allVersionsIndex: Map[String, PackagingVersion] = {
       allVersions.map(v => v.show -> v).toMap
@@ -32,11 +41,7 @@ package v3.model {
       }
     }
 
-    implicit def encodePackagingVersion[A <: PackagingVersion]: Encoder[A] = {
-      Encoder[String].contramap(version => version.show)
-    }
-
-    implicit val decodeV3PackagingVersion: Decoder[PackagingVersion] = {
+    implicit val decodePackagingVersion: Decoder[PackagingVersion] = {
       Decoder.instance[PackagingVersion] { (c: HCursor) =>
         c.as[String].map(PackagingVersion(_)).flatMap {
           case Return(v) => Right(v)
@@ -45,37 +50,63 @@ package v3.model {
       }
     }
 
-    def packagingVersionSubclassToString[V <: PackagingVersion](
-      expected: V
-    ): Decoder[V] = {
-      Decoder.instance { (c: HCursor) =>
+    implicit val encodePackagingVersion: Encoder[PackagingVersion] = {
+      Encoder.instance { packagingVersion: PackagingVersion =>
+        packagingVersion match {
+          case V2PackagingVersion => V2PackagingVersion.asJson
+          case V3PackagingVersion => V3PackagingVersion.asJson
+        }
+      }
+    }
+  }
+
+  case object V2PackagingVersion extends PackagingVersion {
+
+    val show: String = "2.0"
+
+    implicit val decodeV2PackagingVersion: Decoder[V2PackagingVersion.type] = {
+      Decoder.instance { c: HCursor =>
         c.as[String].flatMap {
-          case expected.show => Right(expected)
-          case x => Left(DecodingFailure(
-            s"Expected value [${expected.show}] for packaging version, but found [$x]",
-            c.history
-          ))
+          case this.show => Right(this)
+          case s => Left(
+            DecodingFailure(
+              s"Expected value [$show] for packaging version, but found [$s]",
+              c.history
+            )
+          )
         }
       }
     }
 
-  }
-
-  case object V2PackagingVersion extends PackagingVersion("2.0") {
-    implicit val encodeV3V2PackagingVersion: Encoder[V2PackagingVersion.type] = {
-      PackagingVersion.encodePackagingVersion
-    }
-    implicit val decodeV3V2PackagingVersion: Decoder[V2PackagingVersion.type] = {
-      PackagingVersion.packagingVersionSubclassToString(V2PackagingVersion)
+    implicit val encodeV2PackagingVersion: Encoder[V2PackagingVersion.type] = {
+      Encoder.instance { _: V2PackagingVersion.type =>
+        show.asJson
+      }
     }
   }
 
-  case object V3PackagingVersion extends PackagingVersion("3.0") {
-    implicit val encodeV3V3PackagingVersion: Encoder[V3PackagingVersion.type] = {
-      PackagingVersion.encodePackagingVersion
+  case object V3PackagingVersion extends PackagingVersion {
+
+    val show: String = "3.0"
+
+    implicit val decodeV3PackagingVersion: Decoder[V3PackagingVersion.type] = {
+      Decoder.instance { c: HCursor =>
+        c.as[String].flatMap {
+          case this.show => Right(this)
+          case s => Left(
+            DecodingFailure(
+              s"Expected value [$show] for packaging version, but found [$s]",
+              c.history
+            )
+          )
+        }
+      }
     }
-    implicit val decodeV3V3PackagingVersion: Decoder[V3PackagingVersion.type] = {
-      PackagingVersion.packagingVersionSubclassToString(V3PackagingVersion)
+
+    implicit val encodeV3PackagingVersion: Encoder[V3PackagingVersion.type] = {
+      Encoder.instance { _: V3PackagingVersion.type =>
+        show.asJson
+      }
     }
   }
 


### PR DESCRIPTION
DescribeResponse depends on v3 PackageVersion, which means we may need to keep it around. Making it a sealed trait makes this much easier.