### PR TITLE
Store only the user provided options

### DIFF
--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/PackageRenderHandlerSpec.scala
@@ -52,7 +52,7 @@ class PackageRenderHandlerSpec extends FreeSpec {
              "c3BoZXJlL2Rjb3MtaGVsbG93b3JsZCIsImZyYW1ld29yayI6ZmFsc2UsInByZUluc3RhbGxOb3RlcyI6Ik" +
              "Egc2FtcGxlIHByZS1pbnN0YWxsYXRpb24gbWVzc2FnZSIsInBvc3RJbnN0YWxsTm90ZXMiOiJBIHNhbXBs" +
              "ZSBwb3N0LWluc3RhbGxhdGlvbiBtZXNzYWdlIn0=").asJson,
-          "DCOS_PACKAGE_OPTIONS" -> "eyJwb3J0Ijo4MDgwfQ==".asJson,
+          "DCOS_PACKAGE_OPTIONS" -> "e30=".asJson,
           "DCOS_PACKAGE_REGISTRY_VERSION" -> "2.0".asJson,
           "DCOS_PACKAGE_VERSION" -> "0.1.0".asJson,
           "DCOS_PACKAGE_NAME" -> "helloworld".asJson,

--- a/cosmos-render/src/main/scala/com/mesosphere/cosmos/render/MarathonLabels.scala
+++ b/cosmos-render/src/main/scala/com/mesosphere/cosmos/render/MarathonLabels.scala
@@ -53,6 +53,7 @@ final class MarathonLabels(
       Some(MarathonApp.optionsLabel -> MarathonLabels.encodeForLabel(options))
     ).flatten.toMap
   }
+
   private[this] def metadataLabel: String = {
     MarathonLabels.encodeForLabel(packageMetadata.asJson)
   }

--- a/cosmos-render/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
+++ b/cosmos-render/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
@@ -56,7 +56,11 @@ object PackageDefinitionRenderer {
           renderTemplate(m.v2AppMustacheTemplate, mergedOptions).flatMap { mJson =>
             extractLabels(Json.fromJsonObject(mJson))
               .map { existingLabels =>
-                val labels = MarathonLabels(pkgDef, sourceUri, defaultOptionsAndUserOptions)
+                val labels = MarathonLabels(
+                  pkgDef,
+                  sourceUri,
+                  options.getOrElse(JsonObject.empty)
+                )
 
                 (marathonAppId.map(appIdDoc) ::
                   generateLabelsPartialObjects(labels, existingLabels).map(Some(_))

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageInstallHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageInstallHandler.scala
@@ -8,7 +8,14 @@ import com.mesosphere.cosmos.PackageRunner
 import com.mesosphere.cosmos.ServiceAlreadyStarted
 import com.mesosphere.cosmos.finch.EndpointHandler
 import com.mesosphere.cosmos.http.RequestSession
-import com.mesosphere.cosmos.render._
+import com.mesosphere.cosmos.render.InvalidLabelSchema
+import com.mesosphere.cosmos.render.MissingMarathonV2AppTemplate
+import com.mesosphere.cosmos.render.OptionsNotAllowed
+import com.mesosphere.cosmos.render.OptionsValidationFailure
+import com.mesosphere.cosmos.render.PackageDefinitionRenderError
+import com.mesosphere.cosmos.render.PackageDefinitionRenderer
+import com.mesosphere.cosmos.render.RenderedTemplateNotJson
+import com.mesosphere.cosmos.render.RenderedTemplateNotJsonObject
 import com.mesosphere.cosmos.repository.PackageCollection
 import com.mesosphere.cosmos.rpc
 import com.mesosphere.universe
@@ -16,17 +23,18 @@ import com.mesosphere.universe.bijection.UniverseConversions._
 import com.mesosphere.universe.v3.syntax.PackageDefinitionOps._
 import com.twitter.bijection.Conversion.asMethod
 import com.twitter.util.Future
+import io.circe.Json
 import io.circe.syntax._
-import scala.util.Left
-import scala.util.Right
 
 private[cosmos] final class PackageInstallHandler(
   packageCollection: PackageCollection,
   packageRunner: PackageRunner
 ) extends EndpointHandler[rpc.v1.model.InstallRequest, rpc.v2.model.InstallResponse] {
 
-  override def apply(request: rpc.v1.model.InstallRequest)(implicit
-    session: RequestSession
+  override def apply(
+    request: rpc.v1.model.InstallRequest
+  )(
+    implicit session: RequestSession
   ): Future[rpc.v2.model.InstallResponse] = {
     packageCollection
       .getPackageByPackageVersion(
@@ -41,43 +49,58 @@ private[cosmos] final class PackageInstallHandler(
           request.appId
         )
 
-        packageConfig match {
-          case Right(renderedMarathonJson) =>
-            packageRunner.launch(renderedMarathonJson)
-              .map { runnerResponse =>
-                rpc.v2.model.InstallResponse(
-                  packageName = pkg.name,
-                  packageVersion = pkg.version,
-                  appId = Some(runnerResponse.id),
-                  postInstallNotes = pkg.postInstallNotes,
-                  cli = pkg.cli
-                )
-              }.handle {
-              case ServiceAlreadyStarted() =>
-                throw PackageAlreadyInstalled()
-            }
-          case Left(OptionsValidationFailure(validationErrors)) =>
-            Future.exception(JsonSchemaMismatch(validationErrors))
-          case Left(InvalidLabelSchema(cause)) =>
-            Future.exception(CirceError(cause))
-          case Left(RenderedTemplateNotJson(cause)) =>
-            Future.exception(CirceError(cause))
-          case Left(RenderedTemplateNotJsonObject) =>
-            Future.exception(MarathonTemplateMustBeJsonObject)
-          case Left(OptionsNotAllowed) =>
-            val error = Map("message" -> "No schema available to validate the provided options").asJson
-            Future.exception(JsonSchemaMismatch(List(error)))
-          case Left(MissingMarathonV2AppTemplate) =>
-            Future {
-              rpc.v2.model.InstallResponse(
-                packageName = pkg.name,
-                packageVersion = pkg.version,
-                appId = None,
-                postInstallNotes = pkg.postInstallNotes,
-                cli = pkg.cli
-              )
-            }
+        handlePackageConfig(pkg, packageConfig)
+      }
+  }
+
+  private[this] def handlePackageConfig(
+    pkg: universe.v3.model.PackageDefinition,
+    packageConfig: Either[PackageDefinitionRenderError, Json]
+  )(
+    implicit session: RequestSession
+  ): Future[rpc.v2.model.InstallResponse] = packageConfig match {
+    case Right(renderedMarathonJson) =>
+      packageRunner.launch(renderedMarathonJson)
+        .map { runnerResponse =>
+          rpc.v2.model.InstallResponse(
+            packageName = pkg.name,
+            packageVersion = pkg.version,
+            appId = Some(runnerResponse.id),
+            postInstallNotes = pkg.postInstallNotes,
+            cli = pkg.cli
+          )
         }
+        .handle {
+          case ServiceAlreadyStarted() =>
+            throw PackageAlreadyInstalled()
+        }
+    case Left(OptionsValidationFailure(validationErrors)) =>
+      Future.exception(JsonSchemaMismatch(validationErrors))
+    case Left(InvalidLabelSchema(cause)) =>
+      Future.exception(CirceError(cause))
+    case Left(RenderedTemplateNotJson(cause)) =>
+      Future.exception(CirceError(cause))
+    case Left(RenderedTemplateNotJsonObject) =>
+      Future.exception(MarathonTemplateMustBeJsonObject)
+    case Left(OptionsNotAllowed) =>
+      Future.exception(
+        JsonSchemaMismatch(
+          List(
+            Map(
+              "message" -> "No schema available to validate the provided options"
+            ).asJson
+          )
+        )
+      )
+    case Left(MissingMarathonV2AppTemplate) =>
+      Future {
+        rpc.v2.model.InstallResponse(
+          packageName = pkg.name,
+          packageVersion = pkg.version,
+          appId = None,
+          postInstallNotes = pkg.postInstallNotes,
+          cli = pkg.cli
+        )
       }
   }
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageInstallHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageInstallHandler.scala
@@ -34,8 +34,12 @@ private[cosmos] final class PackageInstallHandler(
         request.packageVersion.as[Option[universe.v3.model.Version]]
       )
       .flatMap { case (pkg, sourceUri) =>
-        val packageConfig =
-          PackageDefinitionRenderer.renderMarathonV2App(sourceUri, pkg, request.options, request.appId)
+        val packageConfig = PackageDefinitionRenderer.renderMarathonV2App(
+          sourceUri,
+          pkg,
+          request.options,
+          request.appId
+        )
 
         packageConfig match {
           case Right(renderedMarathonJson) =>


### PR DESCRIPTION
Change the options JSON object that we store in Marathon so that we only
store the user provided options. If the user doesn't provide any option
that is equivalent to the empty JSON objct. E.g. "{}".

The possible values for the DCOS_PACKAGE_OPTIONS are:
1. Missing - the application was deployed with an old
Cosmos so we don't have the user provided options.
2. Empty JSON object - the user didn't provide any options
3. JSON object - contains the user provided options