### PR TITLE
Fix some incorrect tests

### DIFF
--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -28,6 +28,7 @@ import com.twitter.util.Future
 import java.nio.charset.StandardCharsets
 import java.util.Base64
 import java.util.UUID
+import org.scalatest.AppendedClues._
 import org.scalatest.Assertion
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.FreeSpec
@@ -243,10 +244,15 @@ final class PackageInstallIntegrationSpec extends FreeSpec with BeforeAndAfterAl
       case Anything => // Don't care
     }
 
+    val attempts: Int = 60
+    ItUtil.waitForDeployment(CosmosIntegrationTestClient.adminRouter)(attempts)
+
     val request = CosmosRequests.packageInstallV1(installRequest)
     val response = CosmosClient.submit(request)
 
-    assertResult(expectedResult.status)(response.status)
+
+    assertResult(expectedResult.status)(response.status).withClue(
+      response.contentString)
     expectedResult match {
       case InstallSuccess(expectedBody) =>
         val Right(actualBody) = decode[InstallResponse](response.contentString)

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
@@ -98,13 +98,13 @@ class ServiceDescribeSpec
 
         install.appId shouldBe appId
 
-        When("the user makes a request to the service/describe endpoint")
-        val response = serviceDescribe(appId.toString)
-        response.status shouldBe Status.Ok withClue response.contentString
-        response.contentType shouldBe Some(accept)
-        val Right(content) = parse(response.contentString)
-
         try {
+          When("the user makes a request to the service/describe endpoint")
+          val response = serviceDescribe(appId.toString)
+          response.status shouldBe Status.Ok withClue response.contentString
+          response.contentType shouldBe Some(accept)
+          val Right(content) = parse(response.contentString)
+
           // the actual test
           testCode(
             content,


### PR DESCRIPTION
This tests are misbehaving here and in enterprise. The change to ServiceDescribeSpec makes it so that the package is cleaned up if service/describe fails. The change to PackageInstallIntegrationSpec, makes it so that the failure gives a better error message. The test also waits for any deployments to finish before installing. This failing in Enterprise consistently because of a Conflict.