### PR TITLE
Translate host suffixes in no_proxy to JVM syntax

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
@@ -124,10 +124,9 @@ private[cosmos] object HttpProxySupport {
       noProxy.map(np => (HttpProxyNoHosts, translateNoProxy(np)))
   }
 
-  private[cosmos] def parseHostPortProperties(
-    hostProperty: String,
-    portProperty: String
-  )(proxyUri: Uri): List[(String, String)] = {
+  def parseHostPortProperties(hostProperty: String, portProperty: String)(
+    proxyUri: Uri
+  ): List[(String, String)] = {
     Uris.extractHostAndPort(proxyUri)
       .toOption
       .toList
@@ -140,7 +139,7 @@ private[cosmos] object HttpProxySupport {
    * Normalizes the input into the format required by the `http.nonProxyHosts` system property.
    * @see https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html#Proxies
    */
-  private[cosmos] def translateNoProxy(noProxy: String): String = {
+  def translateNoProxy(noProxy: String): String = {
     noProxy
       .split(Array(',', '|'))
       .map(suffix => if (suffix.startsWith(".")) "*" + suffix else suffix)

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
@@ -137,7 +137,10 @@ private[cosmos] object HttpProxySupport {
   }
 
   private[cosmos] def translateNoProxy(noProxy: String): String = {
-    noProxy.replaceAllLiterally(",", "|")
+    noProxy
+      .split(',')
+      .map(suffix => if (suffix.startsWith(".")) "*" + suffix else suffix)
+      .mkString("|")
   }
 
   private[this] def setPropertyIfUnset(key: String, value: String): Unit = {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
@@ -136,9 +136,13 @@ private[cosmos] object HttpProxySupport {
       }
   }
 
+  /**
+   * Normalizes the input into the format required by the `http.nonProxyHosts` system property.
+   * @see https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html#Proxies
+   */
   private[cosmos] def translateNoProxy(noProxy: String): String = {
     noProxy
-      .split(',')
+      .split(Array(',', '|'))
       .map(suffix => if (suffix.startsWith(".")) "*" + suffix else suffix)
       .mkString("|")
   }

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/HttpProxySupportSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/HttpProxySupportSpec.scala
@@ -141,6 +141,12 @@ final class HttpProxySupportSpec extends FreeSpec with BeforeAndAfter {
             }
           }
 
+          "should add wildcard in front of '.'-delimited domain suffixes" in {
+            assertResult("*.mesos|*.example.com") {
+              HttpProxySupport.translateNoProxy(".mesos,.example.com")
+            }
+          }
+
         }
 
         "respects http.nonProxyHosts" in {

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/HttpProxySupportSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/HttpProxySupportSpec.scala
@@ -1,13 +1,23 @@
 package com.mesosphere.cosmos
 
-import java.net.{Authenticator, URI, URL}
-import java.net.Authenticator.RequestorType
-
-import com.mesosphere.cosmos.HttpProxySupport.{CosmosHttpProxyPasswordAuthenticator, ProxyEnvVariables}
-import org.scalatest.FreeSpec
+import com.mesosphere.cosmos.HttpProxySupport.CosmosHttpProxyPasswordAuthenticator
+import com.mesosphere.cosmos.HttpProxySupport.ProxyEnvVariables
 import com.netaporter.uri.dsl._
+import java.net.Authenticator
+import java.net.Authenticator.RequestorType
+import java.net.URI
+import java.net.URL
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FreeSpec
 
-class HttpProxySupportSpec extends FreeSpec {
+final class HttpProxySupportSpec extends FreeSpec with BeforeAndAfter {
+
+  import HttpProxySupportSpec._
+
+  after {
+    List(HttpHost, HttpPort, HttpsHost, HttpsPort, NonHosts).foreach(System.clearProperty)
+    Authenticator.setDefault(null)  // scalastyle:ignore null
+  }
 
   "HttpProxySupport should" - {
 
@@ -16,21 +26,19 @@ class HttpProxySupportSpec extends FreeSpec {
       "HTTP" - {
 
         "respects http.proxyHost and http.proxyPort" in {
-          System.setProperty("http.proxyHost", "host")
-          System.setProperty("http.proxyPort", "port")
-          HttpProxySupport.initHttpProxyProperties(Some("http://localhost:3128"), "http.proxyHost", "http.proxyPort")
-          assertResult("host")(System.getProperty("http.proxyHost"))
-          assertResult("port")(System.getProperty("http.proxyPort"))
-          clearSystemProperty("http.proxyHost")
-          clearSystemProperty("http.proxyPort")
+          val proxyUri = "http://localhost:3128"
+          System.setProperty(HttpHost, "host")
+          System.setProperty(HttpPort, "port")
+          HttpProxySupport.initHttpProxyProperties(Some(proxyUri), HttpHost, HttpPort)
+          assertResult("host")(System.getProperty(HttpHost))
+          assertResult("port")(System.getProperty(HttpPort))
         }
 
         "http.proxyHost and http.proxyPort will be set if not previously set" in {
-          HttpProxySupport.initHttpProxyProperties(Some("http://localhost:3128"), "http.proxyHost", "http.proxyPort")
-          assertResult("localhost")(System.getProperty("http.proxyHost"))
-          assertResult("3128")(System.getProperty("http.proxyPort"))
-          clearSystemProperty("http.proxyHost")
-          clearSystemProperty("http.proxyPort")
+          val proxyUri = "http://localhost:3128"
+          HttpProxySupport.initHttpProxyProperties(Some(proxyUri), HttpHost, HttpPort)
+          assertResult("localhost")(System.getProperty(HttpHost))
+          assertResult("3128")(System.getProperty(HttpPort))
         }
 
         "will use http_proxy before HTTP_PROXY" in {
@@ -55,21 +63,19 @@ class HttpProxySupportSpec extends FreeSpec {
       "HTTPS" - {
 
         "respects https.proxyHost and https.proxyPort" in {
-          System.setProperty("https.proxyHost", "host")
-          System.setProperty("https.proxyPort", "port")
-          HttpProxySupport.initHttpProxyProperties(Some("https://localhost:3128"), "https.proxyHost", "https.proxyPort")
-          assertResult("host")(System.getProperty("https.proxyHost"))
-          assertResult("port")(System.getProperty("https.proxyPort"))
-          clearSystemProperty("https.proxyHost")
-          clearSystemProperty("https.proxyPort")
+          val proxyUri = "https://localhost:3128"
+          System.setProperty(HttpsHost, "host")
+          System.setProperty(HttpsPort, "port")
+          HttpProxySupport.initHttpProxyProperties(Some(proxyUri), HttpsHost, HttpsPort)
+          assertResult("host")(System.getProperty(HttpsHost))
+          assertResult("port")(System.getProperty(HttpsPort))
         }
 
         "https.proxyHost and https.proxyPort will be set if not previously set" in {
-          HttpProxySupport.initHttpProxyProperties(Some("https://localhost:3128"), "https.proxyHost", "https.proxyPort")
-          assertResult("localhost")(System.getProperty("https.proxyHost"))
-          assertResult("3128")(System.getProperty("https.proxyPort"))
-          clearSystemProperty("https.proxyHost")
-          clearSystemProperty("https.proxyPort")
+          val proxyUri = "https://localhost:3128"
+          HttpProxySupport.initHttpProxyProperties(Some(proxyUri), HttpsHost, HttpsPort)
+          assertResult("localhost")(System.getProperty(HttpsHost))
+          assertResult("3128")(System.getProperty(HttpsPort))
         }
 
         "will use https_proxy before HTTPS_PROXY" in {
@@ -94,16 +100,14 @@ class HttpProxySupportSpec extends FreeSpec {
       "No Proxy" - {
 
         "respects http.nonProxyHosts" in {
-          System.setProperty("http.nonProxyHosts", "*.google.com")
+          System.setProperty(NonHosts, "*.google.com")
           HttpProxySupport.initNoProxyProperties(Some("something"))
-          assertResult("*.google.com")(System.getProperty("http.nonProxyHosts"))
-          clearSystemProperty("http.nonProxyHosts")
+          assertResult("*.google.com")(System.getProperty(NonHosts))
         }
 
         "sets http.nonProxyHosts from env variable" in {
           HttpProxySupport.initNoProxyProperties(Some("something"))
-          assertResult("something")(System.getProperty("http.nonProxyHosts"))
-          clearSystemProperty("http.nonProxyHosts")
+          assertResult("something")(System.getProperty(NonHosts))
         }
 
         "will use no_proxy before NO_PROXY" in {
@@ -125,22 +129,29 @@ class HttpProxySupportSpec extends FreeSpec {
 
         "should allow excluded hosts to be separated by ','" in {
           HttpProxySupport.initNoProxyProperties(Some("127.0.0.1,localhost"))
-          assertResult("127.0.0.1|localhost")(System.getProperty("http.nonProxyHosts"))
-          clearSystemProperty("http.nonProxyHosts")
+          assertResult("127.0.0.1|localhost")(System.getProperty(NonHosts))
         }
 
         "should allow excluded hosts to be separated by '|'" in {
           HttpProxySupport.initNoProxyProperties(Some("127.0.0.1|localhost"))
-          assertResult("127.0.0.1|localhost")(System.getProperty("http.nonProxyHosts"))
-          clearSystemProperty("http.nonProxyHosts")
+          assertResult("127.0.0.1|localhost")(System.getProperty(NonHosts))
         }
 
       }
 
       "Proxy Credentials" - {
 
-        val vars = ProxyEnvVariables(Some("http://localhost:3128"), Some("http://hostlocal:8213"), Some("no_proxy_vals"))
-        val authVars = ProxyEnvVariables(Some("http://test:testtest@localhost:3128"), Some("http://foo:bar@hostlocal:8213"), Some("no_proxy_vals"))
+        val vars = ProxyEnvVariables(
+          httpProxyUri = Some("http://localhost:3128"),
+          httpsProxyUri = Some("http://hostlocal:8213"),
+          noProxy = Some("no_proxy_vals")
+        )
+
+        val authVars = ProxyEnvVariables(
+          httpProxyUri = Some("http://test:testtest@localhost:3128"),
+          httpsProxyUri = Some("http://foo:bar@hostlocal:8213"),
+          noProxy = Some("no_proxy_vals")
+        )
 
         "can be set from http_proxy, https_proxy and no_proxy" in {
           var authenticatorSet = false
@@ -148,19 +159,12 @@ class HttpProxySupportSpec extends FreeSpec {
 
           HttpProxySupport.initProxyConfig(vars, setAuthenticator)
 
-          assertResult("localhost")(System.getProperty("http.proxyHost"))
-          assertResult("3128")(System.getProperty("http.proxyPort"))
-          assertResult("hostlocal")(System.getProperty("https.proxyHost"))
-          assertResult("8213")(System.getProperty("https.proxyPort"))
-          assertResult("no_proxy_vals")(System.getProperty("http.nonProxyHosts"))
+          assertResult("localhost")(System.getProperty(HttpHost))
+          assertResult("3128")(System.getProperty(HttpPort))
+          assertResult("hostlocal")(System.getProperty(HttpsHost))
+          assertResult("8213")(System.getProperty(HttpsPort))
+          assertResult("no_proxy_vals")(System.getProperty(NonHosts))
           assert(authenticatorSet)
-
-          clearSystemProperty("http.proxyHost")
-          clearSystemProperty("http.proxyPort")
-          clearSystemProperty("http.nonProxyHosts")
-          clearSystemProperty("https.proxyHost")
-          clearSystemProperty("https.proxyPort")
-          Authenticator.setDefault(null)  // scalastyle:ignore null
         }
 
         "are used in Authenticator (http)" in {
@@ -173,7 +177,6 @@ class HttpProxySupportSpec extends FreeSpec {
 
           assertResult("test")(authentication.getUserName)
           assertResult("testtest".toCharArray)(authentication.getPassword)
-
         }
 
         "are used in Authenticator (https)" in {
@@ -218,7 +221,12 @@ class HttpProxySupportSpec extends FreeSpec {
         }
 
         "are not provided when no password in url" in {
-          val vars = ProxyEnvVariables(Some("http://bill@localhost:3128"), Some("http://alice@hostlocal:8213"), Some("no_proxy_vals"))
+          val vars = ProxyEnvVariables(
+            httpProxyUri = Some("http://bill@localhost:3128"),
+            httpsProxyUri = Some("http://alice@hostlocal:8213"),
+            noProxy = Some("no_proxy_vals")
+          )
+
           val auth = new CosmosHttpProxyPasswordAuthenticator(vars) {
             override def getRequestorType: RequestorType = RequestorType.PROXY
             override def getRequestingURL: URL = URI.create("https://someplace:123").toURL
@@ -234,8 +242,14 @@ class HttpProxySupportSpec extends FreeSpec {
 
   }
 
-  private[this] def clearSystemProperty(name: String): Unit = {
-    val _ = System.clearProperty(name)
-  }
+}
+
+object HttpProxySupportSpec {
+
+  val HttpHost: String = "http.proxyHost"
+  val HttpPort: String = "http.proxyPort"
+  val HttpsHost: String = "https.proxyHost"
+  val HttpsPort: String = "https.proxyPort"
+  val NonHosts: String = "http.nonProxyHosts"
 
 }

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/HttpProxySupportSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/HttpProxySupportSpec.scala
@@ -125,20 +125,47 @@ final class HttpProxySupportSpec extends FreeSpec with BeforeAndAfter with Prope
 
         "translates env var into a property value" - {
 
-          "should allow excluded hosts to be separated by ','" in {
-            forAll (Gen.listOf(genNoProxyHost)) { hosts =>
-              assertResult(renderProperty(hosts)) {
-                HttpProxySupport.translateNoProxy(renderEnvVar(hosts, ','))
+          "single cases" - {
+
+            "single host" in {
+              assertResult("something") {
+                HttpProxySupport.translateNoProxy("something")
               }
             }
+
+            "traditional no_proxy value" in {
+              assertResult("127.0.0.1|*.example.com|localhost") {
+                HttpProxySupport.translateNoProxy("127.0.0.1,.example.com,localhost")
+              }
+            }
+
+            "JVM http.nonProxyHosts value" in {
+              val unchangedValue = "127.0.0.1|*.example.com|localhost"
+              assertResult(unchangedValue) {
+                HttpProxySupport.translateNoProxy(unchangedValue)
+              }
+            }
+
           }
 
-          "should allow excluded hosts to be separated by '|'" in {
-            forAll (Gen.listOf(genNoProxyHost)) { hosts =>
-              assertResult(renderProperty(hosts)) {
-                HttpProxySupport.translateNoProxy(renderEnvVar(hosts, '|'))
+          "exhaustive checks" - {
+
+            "should allow excluded hosts to be separated by ','" in {
+              forAll (Gen.listOf(genNoProxyHost)) { hosts =>
+                assertResult(renderProperty(hosts)) {
+                  HttpProxySupport.translateNoProxy(renderEnvVar(hosts, ','))
+                }
               }
             }
+
+            "should allow excluded hosts to be separated by '|'" in {
+              forAll (Gen.listOf(genNoProxyHost)) { hosts =>
+                assertResult(renderProperty(hosts)) {
+                  HttpProxySupport.translateNoProxy(renderEnvVar(hosts, '|'))
+                }
+              }
+            }
+
           }
 
         }
@@ -309,7 +336,7 @@ object HttpProxySupportSpec {
           case ImplicitWildcard => "."
         }
 
-        prefix + host.elements.mkString(".")
+        host.elements.mkString(prefix, ".", "")
       }
       .mkString(delimiter.toString)
   }
@@ -322,7 +349,7 @@ object HttpProxySupportSpec {
           case _ => "*."
         }
 
-        prefix + host.elements.mkString(".")
+        host.elements.mkString(prefix, ".", "")
       }
       .mkString("|")
   }


### PR DESCRIPTION
This ended up being a bigger change than intended. I decided to write property tests for the `no_proxy` parsing to make sure all the edge cases got covered. But to make it easier to write the tests, I first separated the initialization code in `HttpProxySupport` into two parts:

1. parse the values of the system properties (without side effects)
2. set the values in the global system properties