### PR TITLE
Add RoundTrip abstraction

### DIFF
--- a/cosmos-common/src/main/scala/com/mesosphere/util/RoundTrip.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/util/RoundTrip.scala
@@ -1,0 +1,62 @@
+package com.mesosphere.util
+
+class RoundTrip[A](
+  private val withResource: (A => Unit) => Unit
+) {
+
+  def map[B](transform: A => B): RoundTrip[B] = {
+    def withResourceB(bInner: B => Unit): Unit = {
+      withResource { a: A =>
+        bInner(transform(a))
+      }
+    }
+    new RoundTrip[B](withResourceB)
+  }
+
+  def flatMap[B](transform: A => RoundTrip[B]): RoundTrip[B] = {
+    def withResourceB(bInner: B => Unit): Unit = {
+      withResource{ a: A =>
+        transform(a).withResource { b: B =>
+          bInner(b)
+        }
+      }
+    }
+    new RoundTrip[B](withResourceB)
+  }
+
+  def get(): A = {
+    var innerA: Option[A] = None
+    withResource { a: A =>
+      innerA = Some(a)
+    }
+    innerA.get
+  }
+
+  def apply[B](transform: A => B): B = {
+    map(transform).get()
+  }
+
+}
+
+object RoundTrip {
+
+  def apply[A](
+    forward: => A)(
+    backwards: A => Unit
+  ): RoundTrip[A] = {
+    def withResource(aInner: A => Unit): Unit = {
+      val a = forward
+      try {
+        aInner(a)
+      } finally {
+        backwards(a)
+      }
+    }
+    new RoundTrip[A](withResource)
+  }
+
+  def value[A](a: A): RoundTrip[A] = {
+    RoundTrip(a)((_: A) => ())
+  }
+
+}

--- a/cosmos-integration-tests/src/it/scala/com/mesosphere/cosmos/NonSharedServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/it/scala/com/mesosphere/cosmos/NonSharedServiceDescribeSpec.scala
@@ -7,12 +7,12 @@ import org.scalatest.Matchers
 final class NonSharedServiceDescribeSpec extends FeatureSpec with Matchers {
   feature("The service/describe endpoint") {
     scenario("The user cannot retrieve the options used to run a service") {
-      RoundTrips.withInstallV1("helloworld", Some("0.1.0")) { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0")).runWith { ir =>
         Requests.describeService(ir.appId).resolvedOptions.shouldBe(None)
       }
     }
     scenario("The user cannot retrieve the options they provided to run a service") {
-      RoundTrips.withInstallV1("helloworld", Some("0.1.0")) { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0")).runWith { ir =>
         Requests.describeService(ir.appId).userProvidedOptions.shouldBe(None)
       }
     }

--- a/cosmos-integration-tests/src/it/scala/com/mesosphere/cosmos/NonSharedServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/it/scala/com/mesosphere/cosmos/NonSharedServiceDescribeSpec.scala
@@ -1,30 +1,20 @@
 package com.mesosphere.cosmos
 
-import _root_.io.circe.Json
+import com.mesosphere.cosmos.ItOps._
 import org.scalatest.FeatureSpec
-import org.scalatest.GivenWhenThen
 import org.scalatest.Matchers
-import org.scalatest.prop.TableDrivenPropertyChecks
 
-final class NonSharedServiceDescribeSpec
-  extends FeatureSpec
-    with GivenWhenThen
-    with Matchers
-    with TableDrivenPropertyChecks {
-
-  scenario("The user cannot retrieve the options used to run a service") {
-    ServiceDescribeSpec.serviceDescribeTest { (content, _, _, _) =>
-      Then("the user should not be able to observe the options used to run that service")
-      val actualResolvedOptions = content.hcursor.get[Json]("resolvedOptions")
-      assert(actualResolvedOptions.isLeft)
+final class NonSharedServiceDescribeSpec extends FeatureSpec with Matchers {
+  feature("The service/describe endpoint") {
+    scenario("The user cannot retrieve the options used to run a service") {
+      RoundTrips.withInstall("helloworld", Some("0.1.0")) { ir =>
+        Requests.describeService(ir.appId).resolvedOptions.shouldBe(None)
+      }
+    }
+    scenario("The user cannot retrieve the options they provided to run a service") {
+      RoundTrips.withInstall("helloworld", Some("0.1.0")) { ir =>
+        Requests.describeService(ir.appId).userProvidedOptions.shouldBe(None)
+      }
     }
   }
-  scenario("The user cannot retrieve the options they provided to run a service") {
-    ServiceDescribeSpec.serviceDescribeTest { (content, _, _, _) =>
-      Then("the user should not be able to observe the options they provided to run a service")
-      val actualUserProvidedOptions = content.hcursor.get[Json]("userProvidedOptions")
-      assert(actualUserProvidedOptions.isLeft)
-    }
-  }
-
 }

--- a/cosmos-integration-tests/src/it/scala/com/mesosphere/cosmos/NonSharedServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/it/scala/com/mesosphere/cosmos/NonSharedServiceDescribeSpec.scala
@@ -7,12 +7,12 @@ import org.scalatest.Matchers
 final class NonSharedServiceDescribeSpec extends FeatureSpec with Matchers {
   feature("The service/describe endpoint") {
     scenario("The user cannot retrieve the options used to run a service") {
-      RoundTrips.withInstall("helloworld", Some("0.1.0")) { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0")) { ir =>
         Requests.describeService(ir.appId).resolvedOptions.shouldBe(None)
       }
     }
     scenario("The user cannot retrieve the options they provided to run a service") {
-      RoundTrips.withInstall("helloworld", Some("0.1.0")) { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0")) { ir =>
         Requests.describeService(ir.appId).userProvidedOptions.shouldBe(None)
       }
     }

--- a/cosmos-integration-tests/src/it/scala/com/mesosphere/cosmos/NonSharedServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/it/scala/com/mesosphere/cosmos/NonSharedServiceDescribeSpec.scala
@@ -7,12 +7,12 @@ import org.scalatest.Matchers
 final class NonSharedServiceDescribeSpec extends FeatureSpec with Matchers {
   feature("The service/describe endpoint") {
     scenario("The user cannot retrieve the options used to run a service") {
-      RoundTrips.withInstallV1("helloworld", Some("0.1.0")).runWith { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0".detailsVersion)).runWith { ir =>
         Requests.describeService(ir.appId).resolvedOptions.shouldBe(None)
       }
     }
     scenario("The user cannot retrieve the options they provided to run a service") {
-      RoundTrips.withInstallV1("helloworld", Some("0.1.0")).runWith { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0".detailsVersion)).runWith { ir =>
         Requests.describeService(ir.appId).userProvidedOptions.shouldBe(None)
       }
     }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/HttpErrorResponse.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/HttpErrorResponse.scala
@@ -8,10 +8,8 @@ final case class HttpErrorResponse(
   status: Status,
   errorResponse: ErrorResponse
 ) extends TestFailedException(
-  _ => Some(
-    s"Status: $status, ErrorResponse: $errorResponse"
-  ),
-  None,
-  _ => 0,
-  None
+  messageFun = _ => Some(s"Status: $status, ErrorResponse: $errorResponse"),
+  cause = None,
+  failedCodeStackDepthFun = _ => 0,
+  payload = None
 )

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/HttpErrorResponse.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/HttpErrorResponse.scala
@@ -4,12 +4,12 @@ import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.twitter.finagle.http.Status
 import org.scalatest.exceptions.TestFailedException
 
-case class HttpErrorResponse(
+final case class HttpErrorResponse(
   status: Status,
   errorResponse: ErrorResponse
 ) extends TestFailedException(
   _ => Some(
-    s"${errorResponse.`type`} $status: ${errorResponse.message}"
+    s"Status: $status, ErrorResponse: $errorResponse"
   ),
   None,
   _ => 0,

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/HttpErrorResponse.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/HttpErrorResponse.scala
@@ -1,0 +1,17 @@
+package com.mesosphere.cosmos
+
+import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
+import com.twitter.finagle.http.Status
+import org.scalatest.exceptions.TestFailedException
+
+case class HttpErrorResponse(
+  status: Status,
+  errorResponse: ErrorResponse
+) extends TestFailedException(
+  _ => Some(
+    s"${errorResponse.`type`} $status: ${errorResponse.message}"
+  ),
+  None,
+  _ => 0,
+  None
+)

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
@@ -5,6 +5,8 @@ import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.universe
 import com.twitter.bijection.Conversion
+import io.circe.Json
+import io.circe.jawn.parse
 import java.util.UUID
 
 object ItOps {
@@ -22,8 +24,14 @@ object ItOps {
   implicit final class ItStringOps(val string: String) extends AnyVal {
     def version: universe.v3.model.Version =
       universe.v3.model.Version(string)
+
     def detailsVersion: universe.v2.model.PackageDetailsVersion =
       universe.v2.model.PackageDetailsVersion(string)
+
+    def json: Json = {
+      val Right(result) = parse(string)
+      result
+    }
   }
 
 }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
@@ -8,20 +8,11 @@ import com.twitter.bijection.Conversion
 import io.circe.Json
 import io.circe.jawn.parse
 import java.util.UUID
-import scala.language.implicitConversions
 
 object ItOps {
 
   implicit def cosmosErrorToErrorResponse[E <: CosmosError]: Conversion[E, ErrorResponse] = {
     Conversion.fromFunction(_.exception.errorResponse)
-  }
-
-  implicit def stringToVersion(s: String): universe.v3.model.Version = {
-    universe.v3.model.Version(s)
-  }
-
-  implicit def stringToDetailsVersion(s: String): universe.v2.model.PackageDetailsVersion = {
-    universe.v2.model.PackageDetailsVersion(s)
   }
 
   implicit val uuidToAppId: Conversion[UUID, AppId] = {
@@ -30,9 +21,15 @@ object ItOps {
     }
   }
 
-  implicit def stringToJson(s: String): Json = {
-    val Right(res) = parse(s)
-    res
+  implicit final class ItStringOps(val string: String) extends AnyVal {
+    def version: universe.v3.model.Version =
+      universe.v3.model.Version(string)
+    def detailsVersion: universe.v2.model.PackageDetailsVersion =
+      universe.v2.model.PackageDetailsVersion(string)
+    def json: Json = {
+      val Right(res) = parse(string)
+      res
+    }
   }
 
 }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
@@ -4,6 +4,8 @@ import com.mesosphere.cosmos.error.CosmosError
 import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.universe
+import io.circe.Json
+import io.circe.jawn.parse
 import java.util.UUID
 import scala.language.implicitConversions
 
@@ -29,6 +31,11 @@ object ItOps {
     uuid: UUID
   ): AppId = {
     AppId(uuid.toString)
+  }
+
+  implicit def stringToJson(s: String): Json = {
+    val Right(res) = parse(s)
+    res
   }
 
 }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
@@ -5,8 +5,6 @@ import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.universe
 import com.twitter.bijection.Conversion
-import io.circe.Json
-import io.circe.jawn.parse
 import java.util.UUID
 
 object ItOps {
@@ -26,10 +24,6 @@ object ItOps {
       universe.v3.model.Version(string)
     def detailsVersion: universe.v2.model.PackageDetailsVersion =
       universe.v2.model.PackageDetailsVersion(string)
-    def json: Json = {
-      val Right(res) = parse(string)
-      res
-    }
   }
 
 }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
@@ -4,6 +4,7 @@ import com.mesosphere.cosmos.error.CosmosError
 import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.universe
+import com.twitter.bijection.Conversion
 import io.circe.Json
 import io.circe.jawn.parse
 import java.util.UUID
@@ -11,12 +12,8 @@ import scala.language.implicitConversions
 
 object ItOps {
 
-  implicit def cosmosErrorToErrorResponse[E <: CosmosError](cosmosError: E): ErrorResponse = {
-    cosmosError.exception.errorResponse
-  }
-
-  implicit def toOption[A](a: A): Option[A] = {
-    Option(a)
+  implicit def cosmosErrorToErrorResponse[E <: CosmosError]: Conversion[E, ErrorResponse] = {
+    Conversion.fromFunction(_.exception.errorResponse)
   }
 
   implicit def stringToVersion(s: String): universe.v3.model.Version = {
@@ -27,10 +24,10 @@ object ItOps {
     universe.v2.model.PackageDetailsVersion(s)
   }
 
-  implicit def uuidToAppId(
-    uuid: UUID
-  ): AppId = {
-    AppId(uuid.toString)
+  implicit val uuidToAppId: Conversion[UUID, AppId] = {
+    Conversion.fromFunction { id =>
+      AppId(id.toString)
+    }
   }
 
   implicit def stringToJson(s: String): Json = {

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItOps.scala
@@ -1,0 +1,34 @@
+package com.mesosphere.cosmos
+
+import com.mesosphere.cosmos.error.CosmosError
+import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
+import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
+import com.mesosphere.universe
+import java.util.UUID
+import scala.language.implicitConversions
+
+object ItOps {
+
+  implicit def cosmosErrorToErrorResponse[E <: CosmosError](cosmosError: E): ErrorResponse = {
+    cosmosError.exception.errorResponse
+  }
+
+  implicit def toOption[A](a: A): Option[A] = {
+    Option(a)
+  }
+
+  implicit def stringToVersion(s: String): universe.v3.model.Version = {
+    universe.v3.model.Version(s)
+  }
+
+  implicit def stringToDetailsVersion(s: String): universe.v2.model.PackageDetailsVersion = {
+    universe.v2.model.PackageDetailsVersion(s)
+  }
+
+  implicit def uuidToAppId(
+    uuid: UUID
+  ): AppId = {
+    AppId(uuid.toString)
+  }
+
+}

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItUtil.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItUtil.scala
@@ -1,81 +1,11 @@
 package com.mesosphere.cosmos
 
-import _root_.io.circe.JsonObject
-import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.repository.DefaultRepositories
-import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
-import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
-import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
-import com.mesosphere.universe
-import com.netaporter.uri.Uri
-import com.twitter.finagle.http.Status
 import com.twitter.util.Await
 import scala.concurrent.duration._
 
 object ItUtil {
-
-  def listRepositories(): Seq[rpc.v1.model.PackageRepository] = {
-    val request = CosmosRequests.packageRepositoryList
-    val Right(response) = CosmosClient.callEndpoint[rpc.v1.model.PackageRepositoryListResponse](
-      request
-    )
-    response.repositories
-  }
-
-  def deleteRepositoryEither(
-    name: Option[String] = None,
-    uri: Option[Uri] = None
-  ): (Status, Either[rpc.v1.model.ErrorResponse, rpc.v1.model.PackageRepositoryDeleteResponse]) = {
-    val repoDeleteRequest = rpc.v1.model.PackageRepositoryDeleteRequest(name, uri)
-    val request = CosmosRequests.packageRepositoryDelete(repoDeleteRequest)
-    CosmosClient.call[rpc.v1.model.PackageRepositoryDeleteResponse](
-      request
-    )
-  }
-
-  def deleteRepository(
-    name: Option[String] = None,
-    uri: Option[Uri] = None
-  ): rpc.v1.model.PackageRepositoryDeleteResponse = {
-    val repoDeleteRequest = rpc.v1.model.PackageRepositoryDeleteRequest(name, uri)
-    val request = CosmosRequests.packageRepositoryDelete(repoDeleteRequest)
-    val Right(response) = CosmosClient.callEndpoint[rpc.v1.model.PackageRepositoryDeleteResponse](
-      request
-    )
-    response
-  }
-
-  def addRepositoryEither(
-    source: rpc.v1.model.PackageRepository,
-    index: Option[Int] = None
-  ): (Status, Either[rpc.v1.model.ErrorResponse, rpc.v1.model.PackageRepositoryAddResponse]) = {
-    val repoAddRequest = rpc.v1.model.PackageRepositoryAddRequest(source.name, source.uri, index)
-    val request = CosmosRequests.packageRepositoryAdd(repoAddRequest)
-    CosmosClient.call[rpc.v1.model.PackageRepositoryAddResponse](
-      request
-    )
-  }
-
-  def addRepository(
-    source: rpc.v1.model.PackageRepository
-  ): rpc.v1.model.PackageRepositoryAddResponse = {
-    val repoAddRequest = rpc.v1.model.PackageRepositoryAddRequest(source.name, source.uri)
-    val request = CosmosRequests.packageRepositoryAdd(repoAddRequest)
-    val Right(response) = CosmosClient.callEndpoint[rpc.v1.model.PackageRepositoryAddResponse](
-      request
-    )
-    response
-  }
-
-  def replaceRepositoriesWith(repositories: Seq[rpc.v1.model.PackageRepository]): Unit = {
-    listRepositories().foreach { repo =>
-      deleteRepository(Some(repo.name))
-    }
-    repositories.foreach { repo =>
-      addRepository(repo)
-    }
-  }
 
   def getRepoByName(name: String): String = {
     DefaultRepositories()
@@ -83,36 +13,6 @@ object ItUtil {
       .find(_.name == name)
       .map(_.uri.toString)
       .get
-  }
-
-  def packageInstall(
-    name: String,
-    version: Option[String],
-    options: Option[JsonObject] = None,
-    appId: Option[AppId] = None
-  ): Either[rpc.v1.model.ErrorResponse, rpc.v1.model.InstallResponse] = {
-    val detailsVersion = version.map(universe.v2.model.PackageDetailsVersion)
-    CosmosClient.callEndpoint[rpc.v1.model.InstallResponse](
-      CosmosRequests.packageInstallV2(
-        rpc.v1.model.InstallRequest(name, detailsVersion, options, appId)
-      )
-    )
-  }
-
-  def packageUninstall(
-    name: String,
-    appId: AppId,
-    all: Boolean
-  ): Either[rpc.v1.model.ErrorResponse, rpc.v1.model.UninstallResponse] = {
-    CosmosClient.callEndpoint[rpc.v1.model.UninstallResponse](
-      CosmosRequests.packageUninstall(
-        rpc.v1.model.UninstallRequest(
-          packageName = name,
-          appId = Some(appId),
-          all = Some(all)
-        )
-      )
-    )
   }
 
   def waitForDeployment(adminRouter: AdminRouter)(attempts: Int): Boolean = {

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageDescribeSpec.scala
@@ -10,7 +10,6 @@ import com.mesosphere.universe
 import com.mesosphere.universe.v3.syntax.PackageDefinitionOps._
 import com.twitter.finagle.http.Response
 import com.twitter.finagle.http.Status
-import java.util.Base64
 import org.scalatest.AppendedClues._
 import org.scalatest.Assertion
 import org.scalatest.FreeSpec

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -56,7 +56,7 @@ final class PackageInstallIntegrationSpec
       val version = "0.1.0"
       val options: Json = """{ "port": 9999 } """
       val repoName = "V4TestUniverse"
-      RoundTrips.withInstallV1(name, Some(version), options.asObject) { ir =>
+      RoundTrips.withInstallV1(name, Some(version), options.asObject).runWith { ir =>
         val repo = Requests.getRepository(repoName)
         val pkg = Requests.describePackage(name, ir.packageVersion).`package`
         val app = Requests.getMarathonApp(ir.appId)
@@ -71,7 +71,7 @@ final class PackageInstallIntegrationSpec
     }
     "The user should be able to install a package by specifying only the name" in {
       val name = "helloworld"
-      RoundTrips.withInstallV1(name) { ir =>
+      RoundTrips.withInstallV1(name).runWith { ir =>
         val Some((expectedVersion, _)) = Requests.getHighestReleaseVersion(
           ir.packageName,
           includePackageVersions = true
@@ -84,7 +84,7 @@ final class PackageInstallIntegrationSpec
     "The user should be able to install a package with a specific version" in {
       val name = "helloworld"
       val version = universe.v2.model.PackageDetailsVersion("0.1.0")
-      RoundTrips.withInstallV1(name, Some(version)) { ir =>
+      RoundTrips.withInstallV1(name, Some(version)).runWith { ir =>
         ir.packageName shouldBe name
         ir.packageVersion shouldBe version
         assert(Requests.isMarathonAppInstalled(ir.appId))
@@ -94,7 +94,7 @@ final class PackageInstallIntegrationSpec
       val name = "helloworld"
       val version = "0.1.0"
       val options: Json = """{ "port": 9999 }"""
-      RoundTrips.withInstallV1(name, Some(version), options = options.asObject) { ir =>
+      RoundTrips.withInstallV1(name, Some(version), options = options.asObject).runWith { ir =>
         val marathonApp = Requests.getMarathonApp(ir.appId)
         marathonApp.serviceOptions shouldBe options.asObject
       }
@@ -103,7 +103,7 @@ final class PackageInstallIntegrationSpec
       val name = "helloworld"
       val version = "0.1.0"
       val appId = AppId("utnhaoesntuahs")
-      RoundTrips.withInstallV1(name, Some(version), appId = Some(appId)) { ir =>
+      RoundTrips.withInstallV1(name, Some(version), appId = Some(appId)).runWith { ir =>
         ir.appId shouldBe appId
         assert(Requests.isMarathonAppInstalled(appId))
       }
@@ -111,7 +111,7 @@ final class PackageInstallIntegrationSpec
     "The user should receive an error if trying to install an already installed package" in {
       val name = "helloworld"
       val version = "0.1.0"
-      RoundTrips.withInstallV1(name, Some(version)) { _ =>
+      RoundTrips.withInstallV1(name, Some(version)).runWith { _ =>
         val expectedError: ErrorResponse = PackageAlreadyInstalled()
         val error = intercept[HttpErrorResponse] {
           RoundTrips.withInstallV1(name, Some(version)).run()

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -64,7 +64,7 @@ final class PackageInstallIntegrationSpec
         app.packageDefinition shouldBe Some(pkg)
         app.packageMetadata shouldBe Some(pkg.as[label.v1.model.PackageMetadata])
         app.packageName shouldBe Some(name)
-        app.packageVersion.toString shouldBe version
+        app.packageVersion.get.toString shouldBe version
         app.packageRepository.map(_.uri) shouldBe repo.map(_.uri)
         app.serviceOptions shouldBe options.asObject
       }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -14,13 +14,15 @@ import com.twitter.bijection.Conversion.asMethod
 import com.twitter.finagle.http._
 import org.scalatest.FeatureSpec
 import org.scalatest.Matchers
+import io.circe.syntax.EncoderOps
+
 
 final class PackageInstallIntegrationSpec extends FeatureSpec with Matchers {
   feature("The package/install endpoint") {
     scenario("should store the correct labels") {
       val name = "helloworld"
       val version = "0.1.0"
-      val options = """{ "port": 9999 } """.json
+      val options = """{ "port": 9999 } """.asJson
       val repoName = "V4TestUniverse"
       RoundTrips.withInstallV1(name, Some(version.detailsVersion), options.asObject).runWith { ir =>
         val repo = Requests.getRepository(repoName)
@@ -59,7 +61,7 @@ final class PackageInstallIntegrationSpec extends FeatureSpec with Matchers {
     scenario("The user should be able to specify the configuration during install") {
       val name = "helloworld"
       val version = "0.1.0"
-      val options = """{ "port": 9999 }""".json
+      val options = """{ "port": 9999 }""".asJson
       RoundTrips.withInstallV1(name, Some(version.detailsVersion), options = options.asObject).runWith { ir =>
         val marathonApp = Requests.getMarathonApp(ir.appId)
         marathonApp.serviceOptions shouldBe options.asObject
@@ -109,7 +111,7 @@ final class PackageInstallIntegrationSpec extends FeatureSpec with Matchers {
       val name = "helloworld"
       // port must be int
       val options =
-        """{ "port": "9999" }""".json
+        """{ "port": "9999" }""".asJson
       val error = intercept[HttpErrorResponse] {
         RoundTrips.withInstallV1(name, options = options.asObject).run()
       }
@@ -119,8 +121,8 @@ final class PackageInstallIntegrationSpec extends FeatureSpec with Matchers {
     scenario("The user should receive an error when attempting to install" +
       " a service with no marathon template and requesting a v1 response") {
       val name = "enterprise-security-cli"
-      val version = "0.8.0"
-      val expectedError = ServiceMarathonTemplateNotFound(name, version.version).as[ErrorResponse]
+      val version = "0.8.0".version
+      val expectedError = ServiceMarathonTemplateNotFound(name, version).as[ErrorResponse]
       val error = intercept[HttpErrorResponse] {
         RoundTrips.withInstallV1(name).run()
       }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -1,57 +1,24 @@
 package com.mesosphere.cosmos
 
 import _root_.io.circe.Json
-import _root_.io.circe.JsonObject
-import _root_.io.circe.jawn._
-import _root_.io.circe.syntax._
-import com.mesosphere.cosmos.circe.Decoders.parse64
+import com.mesosphere.cosmos.ItOps._
+import com.mesosphere.cosmos.bijection.CosmosConversions._
 import com.mesosphere.cosmos.error.PackageAlreadyInstalled
 import com.mesosphere.cosmos.error.PackageNotFound
-import com.mesosphere.cosmos.http.CosmosRequests
-import com.mesosphere.cosmos.http.RequestSession
-import com.mesosphere.cosmos.repository.DefaultRepositories
-import com.mesosphere.cosmos.rpc.MediaTypes
-import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
-import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
-import com.mesosphere.cosmos.rpc.v1.model.InstallRequest
-import com.mesosphere.cosmos.rpc.v1.model.InstallResponse
-import com.mesosphere.cosmos.rpc.v2.circe.Decoders._
-import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
-import com.mesosphere.cosmos.thirdparty.marathon.model._
-import com.mesosphere.universe
-import com.mesosphere.universe.v2.model.PackageDetails
-import com.mesosphere.universe.v2.model.PackageDetailsVersion
-import com.mesosphere.universe.v2.model.PackageFiles
-import com.mesosphere.universe.v2.model.PackagingVersion
-import com.netaporter.uri.Uri
-import com.twitter.finagle.http._
-import com.twitter.util.Await
-import com.twitter.util.Future
-import java.util.UUID
-import org.scalatest.AppendedClues._
-import org.scalatest.Assertion
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.FreeSpec
-import org.scalatest.Matchers
-import org.scalatest.Succeeded
-import org.scalatest.prop.TableDrivenPropertyChecks
-import com.mesosphere.cosmos.ItOps._
 import com.mesosphere.cosmos.error.ServiceMarathonTemplateNotFound
 import com.mesosphere.cosmos.error.VersionNotFound
+import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
+import com.mesosphere.cosmos.thirdparty.marathon.model._
+import com.mesosphere.universe
+import com.mesosphere.universe.v3.syntax.PackageDefinitionOps._
 import com.twitter.bijection.Conversion.asMethod
-import com.mesosphere.cosmos.bijection.CosmosConversions._
+import com.twitter.finagle.http._
+import org.scalatest.FeatureSpec
+import org.scalatest.Matchers
 
-final class PackageInstallIntegrationSpec
-  extends FreeSpec
-    with BeforeAndAfterAll
-    with Matchers {
-
-  import CosmosIntegrationTestClient._
-  import PackageInstallIntegrationSpec._
-
-
-  "The package/install endpoint" - {
-    "should store the correct labels" in {
+final class PackageInstallIntegrationSpec extends FeatureSpec with Matchers {
+  feature("The package/install endpoint") {
+    scenario("should store the correct labels") {
       val name = "helloworld"
       val version = "0.1.0"
       val options: Json = """{ "port": 9999 } """
@@ -69,7 +36,7 @@ final class PackageInstallIntegrationSpec
         app.serviceOptions shouldBe options.asObject
       }
     }
-    "The user should be able to install a package by specifying only the name" in {
+    scenario("The user should be able to install a package by specifying only the name") {
       val name = "helloworld"
       RoundTrips.withInstallV1(name).runWith { ir =>
         val Some((expectedVersion, _)) = Requests.getHighestReleaseVersion(
@@ -81,7 +48,7 @@ final class PackageInstallIntegrationSpec
         assert(Requests.isMarathonAppInstalled(ir.appId))
       }
     }
-    "The user should be able to install a package with a specific version" in {
+    scenario("The user should be able to install a package with a specific version") {
       val name = "helloworld"
       val version = universe.v2.model.PackageDetailsVersion("0.1.0")
       RoundTrips.withInstallV1(name, Some(version)).runWith { ir =>
@@ -90,7 +57,7 @@ final class PackageInstallIntegrationSpec
         assert(Requests.isMarathonAppInstalled(ir.appId))
       }
     }
-    "The user should be able to specify the configuration during install" in {
+    scenario("The user should be able to specify the configuration during install") {
       val name = "helloworld"
       val version = "0.1.0"
       val options: Json = """{ "port": 9999 }"""
@@ -99,7 +66,7 @@ final class PackageInstallIntegrationSpec
         marathonApp.serviceOptions shouldBe options.asObject
       }
     }
-    "The user should be able to specify the app ID during an install" in {
+    scenario("The user should be able to specify the app ID during an install") {
       val name = "helloworld"
       val version = "0.1.0"
       val appId = AppId("utnhaoesntuahs")
@@ -108,7 +75,7 @@ final class PackageInstallIntegrationSpec
         assert(Requests.isMarathonAppInstalled(appId))
       }
     }
-    "The user should receive an error if trying to install an already installed package" in {
+    scenario("The user should receive an error if trying to install an already installed package") {
       val name = "helloworld"
       val version = "0.1.0"
       RoundTrips.withInstallV1(name, Some(version)).runWith { _ =>
@@ -120,7 +87,7 @@ final class PackageInstallIntegrationSpec
         error.errorResponse shouldBe expectedError
       }
     }
-    "The user should recieve an error if trying to install a version that does not exist" in {
+    scenario("The user should recieve an error if trying to install a version that does not exist") {
       val name = "helloworld"
       val version = "0.1.0-does-not-exist"
       val expectedError = VersionNotFound(name, version).as[ErrorResponse]
@@ -130,7 +97,7 @@ final class PackageInstallIntegrationSpec
       error.status shouldBe Status.BadRequest
       error.errorResponse shouldBe expectedError
     }
-    "The user should receive an error when trying to install a package that does not exist" in {
+    scenario("The user should receive an error when trying to install a package that does not exist") {
       val name = "does-not-exist"
       val expectedError = PackageNotFound(name).as[ErrorResponse]
       val error = intercept[HttpErrorResponse] {
@@ -139,17 +106,19 @@ final class PackageInstallIntegrationSpec
       error.status shouldBe Status.BadRequest
       error.errorResponse shouldBe expectedError
     }
-    "The user should receive an error when trying to install a package with incorrect options" in {
+    scenario("The user should receive an error when trying to install a package with incorrect options") {
       val name = "helloworld"
-      val options: Json = """{ "port": "9999" }""" // port must be int
+      // port must be int
+      val options: Json =
+        """{ "port": "9999" }"""
       val error = intercept[HttpErrorResponse] {
         RoundTrips.withInstallV1(name, options = options.asObject).run()
       }
       error.status shouldBe Status.BadRequest
       error.errorResponse.`type` shouldBe "JsonSchemaMismatch"
     }
-    "The user should receive an error when attempting to install" +
-      " a service with no marathon template and requesting a v1 response" in {
+    scenario("The user should receive an error when attempting to install" +
+      " a service with no marathon template and requesting a v1 response") {
       val name = "enterprise-security-cli"
       val version = "0.8.0"
       val expectedError = ServiceMarathonTemplateNotFound(name, version).as[ErrorResponse]
@@ -159,409 +128,17 @@ final class PackageInstallIntegrationSpec
       error.status shouldBe Status.BadRequest
       error.errorResponse shouldBe expectedError
     }
-    "The user should be able to install a package with no marathon" +
-      " template when requesting a v2 response" in {
+    scenario("The user should be able to install a package with no marathon" +
+      " template when requesting a v2 response") {
       val name = "enterprise-security-cli"
       val version = "0.8.0"
+      // No state change
       val response = Requests.installV2(name, Some(version))
+      val pkg = Requests.describePackage(name, Some(version))
       response.packageName shouldBe name
       response.packageVersion.toString shouldBe version
       response.appId shouldBe None
+      response.cli shouldBe pkg.`package`.cli
     }
-  }
-
-  "The package install endpoint" - {
-
-    "reports an error if the requested package is not in the cache" in {
-      forAll (PackageTable) { (packageName, _) =>
-        val errorResponse = ErrorResponse(
-          `type` = "PackageNotFound",
-          message = s"Package [$packageName] not found",
-          data = Some(JsonObject.singleton("packageName", packageName.asJson))
-        )
-
-        installPackageAndAssert(
-          InstallRequest(packageName),
-          expectedResult = InstallFailure(Status.BadRequest, errorResponse),
-          preInstallState = Anything,
-          postInstallState = Unchanged
-        )
-      }
-    }
-
-    "don't install if specified version is not found" in {
-      forAll (PackageDummyVersionsTable) { (packageName, packageVersion) =>
-        val errorMessage = s"Version [$packageVersion] of package [$packageName] not found"
-        val errorResponse = ErrorResponse(
-          `type` = "VersionNotFound",
-          message = errorMessage,
-          data = Some(JsonObject.fromMap(Map(
-            "packageName" -> packageName.asJson,
-            "packageVersion" -> packageVersion.toString.asJson
-          )))
-        )
-
-        // TODO This currently relies on test execution order to be correct
-        // Update it to explicitly install a package twice
-        installPackageAndAssert(
-          InstallRequest(packageName, packageVersion = Some(packageVersion)),
-          expectedResult = InstallFailure(Status.BadRequest, errorResponse),
-          preInstallState = NotInstalled,
-          postInstallState = Unchanged
-        )
-      }
-    }
-
-    "can successfully install packages from Universe" in {
-      forAll (UniversePackagesTable) { (expectedResponse, forceVersion, labelsOpt) =>
-        val versionOption = if (forceVersion) Some(expectedResponse.packageVersion) else None
-
-        installPackageAndAssert(
-          InstallRequest(expectedResponse.packageName, packageVersion = versionOption),
-          expectedResult = InstallSuccess(expectedResponse),
-          preInstallState = NotInstalled,
-          postInstallState = Installed
-        )
-        // TODO Confirm that the correct config was sent to Marathon - see issue #38
-        val packageInfo = Await.result(getMarathonApp(expectedResponse.appId))
-        labelsOpt.foreach(labels => assertResult(labels)(StandardLabels(packageInfo.labels)))
-
-        // Assert that installing twice gives us a package already installed error
-        installPackageAndAssert(
-          InstallRequest(expectedResponse.packageName, packageVersion = versionOption),
-          expectedResult = InstallFailure(
-            Status.Conflict,
-            ErrorResponse(
-              "PackageAlreadyInstalled",
-              "Package is already installed",
-              None
-            ),
-            Some(expectedResponse.appId)
-          ),
-          preInstallState = AlreadyInstalled,
-          postInstallState = Unchanged
-        )
-      }
-    }
-
-    "supports custom app IDs" in {
-      val expectedResponse = InstallResponse("cassandra", PackageDetailsVersion("0.2.0-2"), AppId("custom-app-id"))
-
-      installPackageAndAssert(
-        InstallRequest(
-          packageName = expectedResponse.packageName,
-          packageVersion = Some(PackageDetailsVersion("0.2.0-2")),
-          appId = Some(expectedResponse.appId)
-        ),
-        expectedResult = InstallSuccess(expectedResponse),
-        preInstallState = NotInstalled,
-        postInstallState = Installed
-      )
-    }
-
-    "validates merged config template options JSON schema" in {
-      val Some(badOptions) = Map("chronos" -> Map("zk-hosts" -> false)).asJson.asObject
-
-      val schemaError = JsonObject.fromIterable {
-        Vector(
-          "level" -> "error".asJson,
-          "schema" -> Map(
-            "loadingURI" -> "#",
-            "pointer" -> "/properties/chronos/properties/zk-hosts"
-          ).asJson,
-          "instance" -> Map("pointer" -> "/chronos/zk-hosts").asJson,
-          "domain" -> "validation".asJson,
-          "keyword" -> "type".asJson,
-          "message" -> "instance type (boolean) does not match any allowed primitive type (allowed: [\"string\"])".asJson,
-          "found" -> "boolean".asJson,
-          "expected" -> List("string").asJson
-        )
-      }.asJson
-
-      val errorData = JsonObject.singleton("errors", List(schemaError).asJson)
-      val errorResponse =
-        ErrorResponse("JsonSchemaMismatch", "Options JSON failed validation", Some(errorData))
-
-      val appId = AppId("chronos-bad-json")
-
-      installPackageAndAssert(
-        InstallRequest("chronos", options = Some(badOptions), appId = Some(appId)),
-        expectedResult = InstallFailure(Status.BadRequest, errorResponse),
-        preInstallState = Anything,
-        postInstallState = Unchanged
-      )
-    }
-
-    "will error if attempting to install a service for a v1 response with no marathon template" in {
-      val errorResponse = ErrorResponse(
-        "ServiceMarathonTemplateNotFound",
-        s"Package: [enterprise-security-cli] version: [0.8.0] does not have a " +
-          "Marathon template defined and can not be rendered",
-        Some(JsonObject.fromMap(Map(
-          "packageName" -> "enterprise-security-cli".asJson,
-          "packageVersion" -> "0.8.0".asJson
-        )))
-      )
-
-      installPackageAndAssert(
-        InstallRequest("enterprise-security-cli"),
-        expectedResult = InstallFailure(Status.BadRequest, errorResponse),
-        preInstallState = Anything,
-        postInstallState = Unchanged
-      )
-    }
-
-    "will succeed if attempting to install a service for a v2 response with no marathon template" in {
-      import com.mesosphere.universe.v3.model._
-      val expectedBody = rpc.v2.model.InstallResponse(
-        "enterprise-security-cli",
-        universe.v3.model.Version("0.8.0"),
-        cli = Some(Cli(Some(Platforms(
-          None,
-          Some(Architectures(Binary(
-            "zip",
-            "https://downloads.dcos.io/cli/binaries/linux/x86-64/0.8.0/dcos-security",
-            List(HashInfo("sha256","6e745248badc4741048a52a9d0ee6eabd4ddda239dfe345f7ba8397535ce3f3d"))
-          ))),
-          Some(Architectures(Binary(
-            "zip",
-            "https://downloads.dcos.io/cli/binaries/darwin/x86-64/0.8.0/dcos-security",
-            List(HashInfo("sha256","8f486a771e4db8c72725742102f384274cc028fee9d58fe92268e38f1c1adbeb"))
-          )))
-        ))))
-      )
-
-      val installRequest = InstallRequest("enterprise-security-cli")
-      val request = CosmosRequests.packageInstallV2(installRequest)
-      val response = CosmosClient.submit(request)
-
-      assertResult(Status.Ok)(response.status)
-      assertResult(MediaTypes.V2InstallResponse.show)(response.contentType.get)
-      val Right(actualBody) = decode[rpc.v2.model.InstallResponse](response.contentString)
-      assertResult(expectedBody)(actualBody)
-    }
-
-  }
-
-  override protected def beforeAll(): Unit = { /*no-op*/ }
-
-  override protected def afterAll(): Unit = {
-    // TODO: This should actually happen between each test, but for now tests depend on eachother :(
-    val deletes: Future[Seq[Assertion]] = Future.collect(Seq(
-      adminRouter.deleteApp(AppId("/helloworld"), force = true) map { resp => assert(resp.statusCode === 200) },
-      adminRouter.deleteApp(AppId("/cassandra/dcos"), force = true) map { resp => assert(resp.statusCode === 200) },
-      adminRouter.deleteApp(AppId("/custom-app-id"), force = true) map { resp => assert(resp.statusCode === 200) },
-
-      // Make sure this is cleaned up if its test failed
-      adminRouter.deleteApp(AppId("/chronos-bad-json"), force = true) map { _ => Succeeded }
-    ))
-    Await.result(deletes.flatMap { x => Future.Unit })
-    val attempts: Int = 60
-    ItUtil.waitForDeployment(CosmosIntegrationTestClient.adminRouter)(attempts)
-    ()
-  }
-
-  private[cosmos] def installPackageAndAssert(
-    installRequest: InstallRequest,
-    expectedResult: ExpectedResult,
-    preInstallState: PreInstallState,
-    postInstallState: PostInstallState
-  ): Assertion = {
-    val appId = expectedResult.appId.getOrElse(AppId(installRequest.packageName))
-
-    val packageWasInstalled = isAppInstalled(appId)
-    preInstallState match {
-      case AlreadyInstalled => assertResult(true)(packageWasInstalled)
-      case NotInstalled => assertResult(false)(packageWasInstalled)
-      case Anything => // Don't care
-    }
-
-    val attempts: Int = 60
-    ItUtil.waitForDeployment(CosmosIntegrationTestClient.adminRouter)(attempts)
-
-    val request = CosmosRequests.packageInstallV1(installRequest)
-    val response = CosmosClient.submit(request)
-
-
-    assertResult(expectedResult.status)(response.status).withClue(
-      response.contentString)
-    expectedResult match {
-      case InstallSuccess(expectedBody) =>
-        val Right(actualBody) = decode[InstallResponse](response.contentString)
-        assertResult(expectedBody)(actualBody)
-      case InstallFailure(_, expectedBody, _) =>
-        val Right(actualBody) = decode[ErrorResponse](response.contentString)
-        assertResult(expectedBody)(actualBody)
-    }
-
-    val expectedInstalled = postInstallState match {
-      case Installed => true
-      case Unchanged => packageWasInstalled
-    }
-    val actuallyInstalled = isAppInstalled(appId)
-    assertResult(expectedInstalled)(actuallyInstalled)
-  }
-
-  private[this] def isAppInstalled(appId: AppId): Boolean = {
-    Await.result {
-      adminRouter.getAppOption(appId)
-        .map(_.isDefined)
-    }
-  }
-
-}
-
-private object PackageInstallIntegrationSpec extends Matchers with TableDrivenPropertyChecks {
-
-  private val PackageTableRows: Seq[(String, PackageFiles)] = Seq(
-    packageTableRow("helloworld2", 1, 512.0, 2),
-    packageTableRow("helloworld3", 0.75, 256.0, 3)
-  )
-
-  private lazy val PackageTable = Table(
-    ("package name", "package files"),
-    PackageTableRows: _*
-  )
-
-  private val PackageDummyVersionsTable = Table(
-    ("package name", "version"),
-    ("helloworld", PackageDetailsVersion("a.b.c")),
-    ("cassandra", PackageDetailsVersion("foobar"))
-  )
-
-  private val HelloWorldLabels = StandardLabels(
-    packageMetadata = Map(
-      "website" -> "https://github.com/mesosphere/dcos-helloworld".asJson,
-      "name" -> "helloworld".asJson,
-      "postInstallNotes" -> "A sample post-installation message".asJson,
-      "description" -> "Example DCOS application package".asJson,
-      "packagingVersion" -> "4.0".asJson,
-      "tags" -> List("mesosphere".asJson, "example".asJson, "subcommand".asJson).asJson,
-      "selected" -> false.asJson,
-      "framework" -> false.asJson,
-      "maintainer" -> "support@mesosphere.io".asJson,
-      "version" -> "0.4.2".asJson,
-      "preInstallNotes" -> "A sample pre-installation message".asJson
-    ).asJson,
-    packageName = "helloworld",
-    packageVersion = "0.4.2",
-    packageSource = DefaultRepositories().getOrThrow(0).uri.toString,
-    userOptions = JsonObject.empty.asJson
-  )
-
-  private val UniversePackagesTable = Table(
-    ("expected response", "force version", "Labels"),
-    (
-      InstallResponse("helloworld", PackageDetailsVersion("0.4.2"), AppId("helloworld")),
-      false,
-      Some(HelloWorldLabels)
-    ),
-    (
-      InstallResponse("cassandra", PackageDetailsVersion("0.2.0-1"), AppId("cassandra/dcos")),
-      true,
-      None
-    )
-  )
-
-  private def getMarathonApp(
-    appId: AppId
-  )(
-    implicit session: RequestSession
-  ): Future[MarathonApp] = {
-    CosmosIntegrationTestClient.adminRouter.getApp(appId)
-      .map(_.app)
-  }
-
-  private def packageTableRow(
-    name: String, cpus: Double, mem: Double, pythonVersion: Int
-  ): (String, PackageFiles) = {
-    val cmd =
-      if (pythonVersion <= 2) "python2 -m SimpleHTTPServer 8082" else "python3 -m http.server 8083"
-
-    val packageDefinition = PackageDetails(
-      packagingVersion = PackagingVersion("2.0"),
-      name = name,
-      version = PackageDetailsVersion("0.1.0"),
-      maintainer = "Mesosphere",
-      description = "Test framework",
-      tags = Nil,
-      scm = None,
-      website = None,
-      framework = None,
-      preInstallNotes = None,
-      postInstallNotes = None,
-      postUninstallNotes = None,
-      licenses = None
-    )
-
-    val marathonMustacheTemplate = s"""
-    |{
-    |  "id": "$name",
-    |  "cpus": $cpus,
-    |  "mem": $mem,
-    |  "instances": 1,
-    |  "cmd": $cmd,
-    |  "container": {
-    |    "type": "DOCKER",
-    |    "docker: {
-    |      "image": "python:$pythonVersion",
-    |      "network": "HOST"
-    |    }
-    |  },
-    |  "labels": {
-    |    "test-id": "${UUID.randomUUID().toString}",
-    |  },
-    |  "uris": []
-    |}""".stripMargin
-
-    val packageFiles = PackageFiles(
-      revision = "0",
-      sourceUri = Uri.parse("in/memory/source"),
-      packageJson = packageDefinition,
-      marathonJsonMustache = marathonMustacheTemplate
-    )
-
-    (name, packageFiles)
-  }
-}
-
-private sealed abstract class ExpectedResult(val status: Status, val appId: Option[AppId])
-
-private case class InstallSuccess(body: InstallResponse)
-  extends ExpectedResult(Status.Ok, Some(body.appId))
-
-private case class InstallFailure(
-  override val status: Status,
-  body: ErrorResponse,
-  override val appId: Option[AppId] = None
-) extends ExpectedResult(status, appId)
-
-private sealed trait PreInstallState
-private case object AlreadyInstalled extends PreInstallState
-private case object NotInstalled extends PreInstallState
-private case object Anything extends PreInstallState
-
-private sealed trait PostInstallState
-private case object Installed extends PostInstallState
-private case object Unchanged extends PostInstallState
-
-case class StandardLabels(
-  packageMetadata: Json,
-  packageName: String,
-  packageVersion: String,
-  packageSource: String,
-  userOptions: Json
-)
-
-object StandardLabels {
-
-  def apply(labels: Map[String, String]): StandardLabels = {
-    StandardLabels(
-      packageMetadata = parse64(labels("DCOS_PACKAGE_METADATA")),
-      packageName = labels("DCOS_PACKAGE_NAME"),
-      packageVersion = labels("DCOS_PACKAGE_VERSION"),
-      packageSource = labels("DCOS_PACKAGE_SOURCE"),
-      userOptions = parse64(labels("DCOS_PACKAGE_OPTIONS"))
-    )
   }
 }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -14,15 +14,13 @@ import com.twitter.bijection.Conversion.asMethod
 import com.twitter.finagle.http._
 import org.scalatest.FeatureSpec
 import org.scalatest.Matchers
-import io.circe.syntax.EncoderOps
-
 
 final class PackageInstallIntegrationSpec extends FeatureSpec with Matchers {
   feature("The package/install endpoint") {
     scenario("should store the correct labels") {
       val name = "helloworld"
       val version = "0.1.0"
-      val options = """{ "port": 9999 } """.asJson
+      val options = """{ "port": 9999 } """.json
       val repoName = "V4TestUniverse"
       RoundTrips.withInstallV1(name, Some(version.detailsVersion), options.asObject).runWith { ir =>
         val repo = Requests.getRepository(repoName)
@@ -61,7 +59,7 @@ final class PackageInstallIntegrationSpec extends FeatureSpec with Matchers {
     scenario("The user should be able to specify the configuration during install") {
       val name = "helloworld"
       val version = "0.1.0"
-      val options = """{ "port": 9999 }""".asJson
+      val options = """{ "port": 9999 }""".json
       RoundTrips.withInstallV1(name, Some(version.detailsVersion), options = options.asObject).runWith { ir =>
         val marathonApp = Requests.getMarathonApp(ir.appId)
         marathonApp.serviceOptions shouldBe options.asObject
@@ -111,7 +109,7 @@ final class PackageInstallIntegrationSpec extends FeatureSpec with Matchers {
       val name = "helloworld"
       // port must be int
       val options =
-        """{ "port": "9999" }""".asJson
+        """{ "port": "9999" }""".json
       val error = intercept[HttpErrorResponse] {
         RoundTrips.withInstallV1(name, options = options.asObject).run()
       }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageInstallIntegrationSpec.scala
@@ -356,6 +356,8 @@ final class PackageInstallIntegrationSpec
       adminRouter.deleteApp(AppId("/chronos-bad-json"), force = true) map { _ => Succeeded }
     ))
     Await.result(deletes.flatMap { x => Future.Unit })
+    val attempts: Int = 60
+    ItUtil.waitForDeployment(CosmosIntegrationTestClient.adminRouter)(attempts)
   }
 
   private[cosmos] def installPackageAndAssert(

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.Matchers
 final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
   feature("The package/list endpoint") {
     scenario("should list installed packages") {
-      RoundTrips.withInstall("helloworld", appId = Some(UUID.randomUUID())) { ir =>
+      RoundTrips.withInstall("helloworld") { ir =>
         val pkg = Requests.describePackage(ir.packageName, ir.packageVersion).`package`
         val pkgs = Requests.listPackages()
         pkgs.map(_.appId) should contain(ir.appId)
@@ -22,7 +22,7 @@ final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
     }
     scenario("Issue #251: should include packages whose repositories have been removed") {
       // TODO: Change this to remove helloworld's repo when describe returns repo information
-      RoundTrips.withInstall("helloworld", appId = Some(UUID.randomUUID())) { ir =>
+      RoundTrips.withInstall("helloworld") { ir =>
         val pkg = Requests.describePackage(ir.packageName, ir.packageVersion).`package`
         RoundTrips.withDeletedRepository(Some("V4TestUniverse")) { _ =>
           val pkgs = Requests.listPackages()

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.Matchers
 final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
   feature("The package/list endpoint") {
     scenario("should list installed packages") {
-      RoundTrips.withInstall("helloworld") { ir =>
+      RoundTrips.withInstallV1("helloworld") { ir =>
         val pkg = Requests.describePackage(ir.packageName, ir.packageVersion).`package`
         val pkgs = Requests.listPackages()
         pkgs.map(_.appId) should contain(ir.appId)
@@ -22,7 +22,7 @@ final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
     }
     scenario("Issue #251: should include packages whose repositories have been removed") {
       // TODO: Change this to remove helloworld's repo when describe returns repo information
-      RoundTrips.withInstall("helloworld") { ir =>
+      RoundTrips.withInstallV1("helloworld") { ir =>
         val pkg = Requests.describePackage(ir.packageName, ir.packageVersion).`package`
         RoundTrips.withDeletedRepository(Some("V4TestUniverse")) { _ =>
           val pkgs = Requests.listPackages()
@@ -36,7 +36,7 @@ final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
     scenario("Issue #124: should respond with packages sorted by name and app id") {
       val names = List("linkerd", "linkerd", "zeppelin", "jenkins", "cassandra")
       val withInstalls = RoundTrip.sequence(names.map { name =>
-        RoundTrips.withInstall(name, appId = Some(UUID.randomUUID()))
+        RoundTrips.withInstallV1(name, appId = Some(UUID.randomUUID()))
       })
       withInstalls { installs =>
         val expectedPkgs = installs.map(i => (i.packageName, i.appId))

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.Matchers
 final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
   feature("The package/list endpoint") {
     scenario("should list installed packages") {
-      RoundTrips.withInstallV1("helloworld") { ir =>
+      RoundTrips.withInstallV1("helloworld").runWith { ir =>
         val pkg = Requests.describePackage(ir.packageName, ir.packageVersion).`package`
         val pkgs = Requests.listPackages()
         pkgs.map(_.appId) should contain(ir.appId)
@@ -22,9 +22,9 @@ final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
     }
     scenario("Issue #251: should include packages whose repositories have been removed") {
       // TODO: Change this to remove helloworld's repo when describe returns repo information
-      RoundTrips.withInstallV1("helloworld") { ir =>
+      RoundTrips.withInstallV1("helloworld").runWith { ir =>
         val pkg = Requests.describePackage(ir.packageName, ir.packageVersion).`package`
-        RoundTrips.withDeletedRepository(Some("V4TestUniverse")) { _ =>
+        RoundTrips.withDeletedRepository(Some("V4TestUniverse")).runWith { _ =>
           val pkgs = Requests.listPackages()
           pkgs.map(_.appId) should contain(ir.appId)
           pkgs.find(_.appId == ir.appId).get.packageInformation.shouldBe(
@@ -38,7 +38,7 @@ final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
       val withInstalls = RoundTrip.sequence(names.map { name =>
         RoundTrips.withInstallV1(name, appId = Some(UUID.randomUUID()))
       })
-      withInstalls { installs =>
+      withInstalls.runWith { installs =>
         val expectedPkgs = installs.map(i => (i.packageName, i.appId))
         val pkgs = Requests.listPackages().map { i =>
           (i.packageInformation.packageDefinition.name, i.appId)

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageListIntegrationSpec.scala
@@ -2,6 +2,7 @@ package com.mesosphere.cosmos
 
 import com.mesosphere.cosmos.ItOps._
 import com.mesosphere.cosmos.converter.Response._
+import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.cosmos.util.RoundTrip
 import com.twitter.bijection.Conversion.asMethod
 import java.util.UUID
@@ -12,7 +13,7 @@ final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
   feature("The package/list endpoint") {
     scenario("should list installed packages") {
       RoundTrips.withInstallV1("helloworld").runWith { ir =>
-        val pkg = Requests.describePackage(ir.packageName, ir.packageVersion).`package`
+        val pkg = Requests.describePackage(ir.packageName, Some(ir.packageVersion)).`package`
         val pkgs = Requests.listPackages()
         pkgs.map(_.appId) should contain(ir.appId)
         pkgs.find(_.appId == ir.appId).get.packageInformation.shouldBe(
@@ -23,7 +24,7 @@ final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
     scenario("Issue #251: should include packages whose repositories have been removed") {
       // TODO: Change this to remove helloworld's repo when describe returns repo information
       RoundTrips.withInstallV1("helloworld").runWith { ir =>
-        val pkg = Requests.describePackage(ir.packageName, ir.packageVersion).`package`
+        val pkg = Requests.describePackage(ir.packageName, Some(ir.packageVersion)).`package`
         RoundTrips.withDeletedRepository(Some("V4TestUniverse")).runWith { _ =>
           val pkgs = Requests.listPackages()
           pkgs.map(_.appId) should contain(ir.appId)
@@ -36,7 +37,7 @@ final class PackageListIntegrationSpec extends FeatureSpec with Matchers {
     scenario("Issue #124: should respond with packages sorted by name and app id") {
       val names = List("linkerd", "linkerd", "zeppelin", "jenkins", "cassandra")
       val withInstalls = RoundTrip.sequence(names.map { name =>
-        RoundTrips.withInstallV1(name, appId = Some(UUID.randomUUID()))
+        RoundTrips.withInstallV1(name, appId = Some(UUID.randomUUID().as[AppId]))
       })
       withInstalls.runWith { installs =>
         val expectedPkgs = installs.map(i => (i.packageName, i.appId))

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageRepositorySpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/PackageRepositorySpec.scala
@@ -29,7 +29,7 @@ class PackageRepositorySpec extends FeatureSpec with Matchers {
     scenario("The user should be able to list added repositories") {
       val name = "cli-test-4"
       val uri: Uri = "https://github.com/mesosphere/universe/archive/cli-test-4.zip"
-      RoundTrips.withRepository(name, uri) { _ =>
+      RoundTrips.withRepository(name, uri).runWith { _ =>
         Requests.listRepositories() should contain(
           rpc.v1.model.PackageRepository(name, uri)
         )
@@ -39,7 +39,7 @@ class PackageRepositorySpec extends FeatureSpec with Matchers {
       val name = "cli-test-4"
       val uri: Uri = "https://github.com/mesosphere/universe/archive/cli-test-4.zip"
       (RoundTrips.withRepository(name, uri) &:
-        RoundTrips.withDeletedRepository(Some(name), Some(uri))) { _ =>
+        RoundTrips.withDeletedRepository(Some(name), Some(uri))).runWith { _ =>
         Requests.listRepositories() should not contain
           rpc.v1.model.PackageRepository(name, uri)
       }
@@ -50,7 +50,7 @@ class PackageRepositorySpec extends FeatureSpec with Matchers {
     scenario("the user would like to add a repository at the default priority (lowest priority)") {
       val name = "cli-test-4"
       val uri: Uri = "https://github.com/mesosphere/universe/archive/cli-test-4.zip"
-      RoundTrips.withRepository(name, uri) { response =>
+      RoundTrips.withRepository(name, uri).runWith { response =>
         val last = response.repositories.last
         last.name shouldBe name
         last.uri shouldBe uri
@@ -60,7 +60,7 @@ class PackageRepositorySpec extends FeatureSpec with Matchers {
       val name = "cli-test-4"
       val uri: Uri = "https://github.com/mesosphere/universe/archive/cli-test-4.zip"
       val index = 0
-      RoundTrips.withRepository(name, uri, Some(index)) { response =>
+      RoundTrips.withRepository(name, uri, Some(index)).runWith { response =>
         val actual = response.repositories(index)
         actual.name shouldBe name
         actual.uri shouldBe uri
@@ -70,7 +70,7 @@ class PackageRepositorySpec extends FeatureSpec with Matchers {
       val name = "bounds"
       val uri: Uri = "https://github.com/mesosphere/universe/archive/cli-test-4.zip"
       val index = Requests.listRepositories().size
-      RoundTrips.withRepository(name, uri, Some(index)) { response =>
+      RoundTrips.withRepository(name, uri, Some(index)).runWith { response =>
         val last = response.repositories.last
         last.name shouldBe name
         last.uri shouldBe uri
@@ -80,7 +80,7 @@ class PackageRepositorySpec extends FeatureSpec with Matchers {
       val name = "cli-test-4"
       val uri: Uri = "https://github.com/mesosphere/universe/archive/cli-test-4.zip"
       val expectedError: ErrorResponse = RepositoryAlreadyPresent(Ior.Both(name, uri))
-      RoundTrips.withRepository(name, uri) { _ =>
+      RoundTrips.withRepository(name, uri).runWith { _ =>
         val error = intercept[HttpErrorResponse] {
           RoundTrips.withRepository(name, uri).run()
         }
@@ -183,14 +183,14 @@ class PackageRepositorySpec extends FeatureSpec with Matchers {
   feature("The package/repository/delete endpoint") {
     scenario("the user would like to delete a repository by name") {
       val deleted = Requests.listRepositories().head
-      RoundTrips.withDeletedRepository(deleted.name) { dr =>
+      RoundTrips.withDeletedRepository(deleted.name).runWith { dr =>
         dr.repositories should not contain deleted
         Requests.listRepositories() should not contain deleted
       }
     }
     scenario("the user would like to delete a repository by uri") {
       val deleted = Requests.listRepositories().head
-      RoundTrips.withDeletedRepository(uri = deleted.uri) { dr =>
+      RoundTrips.withDeletedRepository(uri = deleted.uri).runWith { dr =>
         dr.repositories should not contain deleted
         Requests.listRepositories() should not contain deleted
       }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/Requests.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/Requests.scala
@@ -36,8 +36,6 @@ object Requests {
   ): Res = {
     val (status, response) = CosmosClient.call[Res](request)
     response match {
-      case Left(errorResponse) if errorResponse.`type` == "ServiceUnavailable" =>
-        throw ServiceUnavailable(errorResponse.data.toString).exception
       case Left(errorResponse) =>
         throw HttpErrorResponse(status, errorResponse)
       case Right(res) =>

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/Requests.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/Requests.scala
@@ -1,26 +1,35 @@
 package com.mesosphere.cosmos
 
-import com.mesosphere.cosmos.error.ServiceUnavailable
 import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.rpc.v1.model.ListVersionsResponse
+import com.mesosphere.cosmos.rpc.v2.circe.Decoders._
+import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
+import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.Session
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
+import com.mesosphere.cosmos.thirdparty.marathon.model.Deployment
+import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonApp
 import com.mesosphere.universe
 import com.netaporter.uri.Uri
+import com.twitter.util.Await
 import io.circe.Decoder
 import io.circe.JsonObject
+import org.scalatest.Matchers._
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.time.SpanSugar._
 
 object Requests {
 
-  def install(
+  def installV1(
     name: String,
     version: Option[universe.v2.model.PackageDetailsVersion] = None,
     options: Option[JsonObject] = None,
     appId: Option[AppId] = None
   ): rpc.v1.model.InstallResponse = {
     callEndpoint[rpc.v1.model.InstallResponse](
-      CosmosRequests.packageInstallV2(
+      CosmosRequests.packageInstallV1(
         rpc.v1.model.InstallRequest(
           name,
           version,
@@ -31,16 +40,22 @@ object Requests {
     )
   }
 
-  def callEndpoint[Res](request: HttpRequest)(implicit
-    decoder: Decoder[Res]
-  ): Res = {
-    val (status, response) = CosmosClient.call[Res](request)
-    response match {
-      case Left(errorResponse) =>
-        throw HttpErrorResponse(status, errorResponse)
-      case Right(res) =>
-        res
-    }
+  def installV2(
+    name: String,
+    version: Option[universe.v2.model.PackageDetailsVersion] = None,
+    options: Option[JsonObject] = None,
+    appId: Option[AppId] = None
+  ): rpc.v2.model.InstallResponse = {
+    callEndpoint[rpc.v2.model.InstallResponse](
+      CosmosRequests.packageInstallV2(
+        rpc.v1.model.InstallRequest(
+          name,
+          version,
+          options,
+          appId
+        )
+      )
+    )
   }
 
   def uninstall(
@@ -80,6 +95,27 @@ object Requests {
     ).packages.toList
   }
 
+  def getHighestReleaseVersion(
+    name: String,
+    includePackageVersions: Boolean
+  ): Option[(universe.v2.model.PackageDetailsVersion, universe.v2.model.ReleaseVersion)] = {
+    listPackageVersions(name, includePackageVersions)
+      .results.toList.sortBy(_._2.toString.toInt).reverse.headOption
+  }
+
+  def listPackageVersions(
+    name: String,
+    includePackageVersions: Boolean
+  ): rpc.v1.model.ListVersionsResponse = {
+    callEndpoint[ListVersionsResponse](
+      CosmosRequests.packageListVersions(
+        rpc.v1.model.ListVersionsRequest(
+          name, includePackageVersions
+        )
+      )
+    )
+  }
+
   def deleteRepository(
     name: Option[String] = None,
     uri: Option[Uri] = None
@@ -92,6 +128,18 @@ object Requests {
         )
       )
     )
+  }
+
+  def callEndpoint[Res](request: HttpRequest)(implicit
+    decoder: Decoder[Res]
+  ): Res = {
+    val (status, response) = CosmosClient.call[Res](request)
+    response match {
+      case Left(errorResponse) =>
+        throw HttpErrorResponse(status, errorResponse)
+      case Right(res) =>
+        res
+    }
   }
 
   def addRepository(
@@ -134,6 +182,40 @@ object Requests {
         )
       )
     )
+  }
+
+  def getRepository(
+    name: String
+  ): Option[rpc.v1.model.PackageRepository] = {
+    listRepositories().find(_.name == name)
+  }
+
+  def getMarathonApp(
+    appId: AppId
+  ): MarathonApp = {
+    Await.result {
+      CosmosIntegrationTestClient.adminRouter.getApp(appId)
+    }.app
+  }
+
+  def isMarathonAppInstalled(appId: AppId): Boolean = {
+    Await.result {
+      CosmosIntegrationTestClient.adminRouter.getAppOption(appId)
+        .map(_.isDefined)
+    }
+  }
+
+  def waitForDeployments(): Unit = {
+    eventually(timeout(5.minutes), interval(5.seconds)) {
+      listDeployments() shouldBe empty
+    }
+    ()
+  }
+
+  def listDeployments(): List[Deployment] = {
+    Await.result {
+      CosmosIntegrationTestClient.adminRouter.listDeployments()
+    }
   }
 
 }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/Requests.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/Requests.scala
@@ -1,0 +1,141 @@
+package com.mesosphere.cosmos
+
+import com.mesosphere.cosmos.error.ServiceUnavailable
+import com.mesosphere.cosmos.http.CosmosRequests
+import com.mesosphere.cosmos.http.HttpRequest
+import com.mesosphere.cosmos.rpc.v1.circe.Decoders._
+import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
+import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
+import com.mesosphere.universe
+import com.netaporter.uri.Uri
+import io.circe.Decoder
+import io.circe.JsonObject
+
+object Requests {
+
+  def install(
+    name: String,
+    version: Option[universe.v2.model.PackageDetailsVersion] = None,
+    options: Option[JsonObject] = None,
+    appId: Option[AppId] = None
+  ): rpc.v1.model.InstallResponse = {
+    callEndpoint[rpc.v1.model.InstallResponse](
+      CosmosRequests.packageInstallV2(
+        rpc.v1.model.InstallRequest(
+          name,
+          version,
+          options,
+          appId
+        )
+      )
+    )
+  }
+
+  def callEndpoint[Res](request: HttpRequest)(implicit
+    decoder: Decoder[Res]
+  ): Res = {
+    val (status, response) = CosmosClient.call[Res](request)
+    response match {
+      case Left(errorResponse) if errorResponse.`type` == "ServiceUnavailable" =>
+        throw ServiceUnavailable(errorResponse.data.toString).exception
+      case Left(errorResponse) =>
+        throw HttpErrorResponse(status, errorResponse)
+      case Right(res) =>
+        res
+    }
+  }
+
+  def uninstall(
+    name: String,
+    appId: Option[AppId] = None,
+    all: Option[Boolean] = None
+  ): rpc.v1.model.UninstallResponse = {
+    callEndpoint[rpc.v1.model.UninstallResponse](
+      CosmosRequests.packageUninstall(
+        rpc.v1.model.UninstallRequest(
+          packageName = name,
+          appId = appId,
+          all = all
+        )
+      )
+    )
+  }
+
+  def listRepositories(
+  ): List[rpc.v1.model.PackageRepository] = {
+    callEndpoint[rpc.v1.model.PackageRepositoryListResponse](
+      CosmosRequests.packageRepositoryList
+    ).repositories.toList
+  }
+
+  def listPackages(
+    name: Option[String] = None,
+    appId: Option[AppId] = None
+  ): List[rpc.v1.model.Installation] = {
+    callEndpoint[rpc.v1.model.ListResponse](
+      CosmosRequests.packageList(
+        rpc.v1.model.ListRequest(
+          name,
+          appId
+        )
+      )
+    ).packages.toList
+  }
+
+  def deleteRepository(
+    name: Option[String] = None,
+    uri: Option[Uri] = None
+  ): rpc.v1.model.PackageRepositoryDeleteResponse = {
+    callEndpoint[rpc.v1.model.PackageRepositoryDeleteResponse](
+      CosmosRequests.packageRepositoryDelete(
+        rpc.v1.model.PackageRepositoryDeleteRequest(
+          name,
+          uri
+        )
+      )
+    )
+  }
+
+  def addRepository(
+    name: String,
+    uri: Uri,
+    index: Option[Int] = None
+  ): rpc.v1.model.PackageRepositoryAddResponse = {
+    callEndpoint[rpc.v1.model.PackageRepositoryAddResponse](
+      CosmosRequests.packageRepositoryAdd(
+        rpc.v1.model.PackageRepositoryAddRequest(
+          name,
+          uri,
+          index
+        )
+      )
+    )
+  }
+
+  def describeService(
+    appId: AppId
+  ): rpc.v1.model.ServiceDescribeResponse = {
+    callEndpoint[rpc.v1.model.ServiceDescribeResponse](
+      CosmosRequests.serviceDescribe(
+        rpc.v1.model.ServiceDescribeRequest(
+          appId
+        )
+      )
+    )
+  }
+
+  def describePackage(
+    name: String,
+    version: Option[universe.v2.model.PackageDetailsVersion]
+  ): rpc.v3.model.DescribeResponse = {
+    callEndpoint[rpc.v3.model.DescribeResponse](
+      CosmosRequests.packageDescribeV3(
+        rpc.v1.model.DescribeRequest(
+          name,
+          version
+        )
+      )
+    )
+  }
+
+}

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
@@ -5,23 +5,20 @@ import com.mesosphere.cosmos.util.RoundTrip
 import com.mesosphere.universe
 import com.netaporter.uri.Uri
 import io.circe.JsonObject
-import org.scalatest.concurrent.Eventually._
-import org.scalatest.time.SpanSugar._
 
 object RoundTrips {
 
-  def withInstall(
+  def withInstallV1(
     name: String,
     version: Option[universe.v2.model.PackageDetailsVersion] = None,
     options: Option[JsonObject] = None,
     appId: Option[AppId] = None
   ): RoundTrip[rpc.v1.model.InstallResponse] = {
     RoundTrip(
-      eventually(timeout(2.minutes), interval(5.seconds)) {
-        Requests.install(name, version, options, appId)
-      }
+      Requests.installV1(name, version, options, appId)
     ) { ir =>
       Requests.uninstall(ir.packageName, Some(ir.appId))
+      Requests.waitForDeployments()
     }
   }
 
@@ -37,28 +34,6 @@ object RoundTrips {
       (repo, repo.map(repos.indexOf(_)))
     }.flatMap { case (repo, index) =>
       withDeletedRepository(name, uri, repo, index)
-    }
-  }
-
-  def withRepositoriesReplaced(
-    newRepositories: List[rpc.v1.model.PackageRepository]
-  ): RoundTrip[List[rpc.v1.model.PackageRepositoryAddResponse]] = {
-    RoundTrip.value(Requests.listRepositories()).flatMap { old =>
-      val withDeletes = RoundTrip.sequence(
-        old.map { repo =>
-          /* we always delete the front, so we also put
-           * it back at the front.
-           * tricky but saves us N listRepositories,
-           * which is N requests to the server,
-           * which is N log lines.
-           */
-          withDeletedRepository(Some(repo.name), Some(repo.uri), Some(repo), Some(0))
-        }
-      )
-      val withAdds = RoundTrip.sequence(
-        newRepositories.map(repo => withRepository(repo.name, repo.uri))
-      )
-      withDeletes.flatMap(_ => withAdds)
     }
   }
 

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
@@ -5,7 +5,6 @@ import com.mesosphere.cosmos.util.RoundTrip
 import com.mesosphere.universe
 import com.netaporter.uri.Uri
 import io.circe.JsonObject
-import org.scalatest.Matchers._
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.time.SpanSugar._
 
@@ -18,14 +17,11 @@ object RoundTrips {
     appId: Option[AppId] = None
   ): RoundTrip[rpc.v1.model.InstallResponse] = {
     RoundTrip(
-      Requests.install(name, version, options, appId)
+      eventually(timeout(2.minutes), interval(5.seconds)) {
+        Requests.install(name, version, options, appId)
+      }
     ) { ir =>
       Requests.uninstall(ir.packageName, Some(ir.appId))
-      eventually(timeout(5.minutes), interval(5.seconds)) {
-        Requests.listPackages(Some(ir.packageName), Some(ir.appId)).map(_.appId).should(
-          not contain ir.appId
-        )
-      }
     }
   }
 

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
@@ -15,10 +15,9 @@ object RoundTrips {
     appId: Option[AppId] = None
   ): RoundTrip[rpc.v1.model.InstallResponse] = {
     RoundTrip(
-      Requests.install(name, version, options, appId)) { ir =>
+      Requests.install(name, version, options, appId))(ir =>
       Requests.uninstall(ir.packageName, Some(ir.appId))
-      ()
-    }
+    )
   }
 
   def withDeletedRepository(
@@ -66,10 +65,9 @@ object RoundTrips {
     index: Option[Int] = None
   ): RoundTrip[rpc.v1.model.PackageRepositoryAddResponse] = {
     RoundTrip(
-      Requests.addRepository(name, uri, index)) { _ =>
+      Requests.addRepository(name, uri, index))(_ =>
       Requests.deleteRepository(Some(name))
-      ()
-    }
+    )
   }
 
   def withDeletedRepository(
@@ -78,10 +76,9 @@ object RoundTrips {
     oldIndex: Int
   ): RoundTrip[rpc.v1.model.PackageRepositoryDeleteResponse] = {
     RoundTrip(
-      Requests.deleteRepository(Some(name), Some(uri))) { _ =>
+      Requests.deleteRepository(Some(name), Some(uri)))(_ =>
       Requests.addRepository(name, uri, Some(oldIndex))
-      ()
-    }
+    )
   }
 
 }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
@@ -1,0 +1,87 @@
+package com.mesosphere.cosmos
+
+import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
+import com.mesosphere.cosmos.util.RoundTrip
+import com.mesosphere.universe
+import com.netaporter.uri.Uri
+import io.circe.JsonObject
+
+object RoundTrips {
+
+  def withInstall(
+    name: String,
+    version: Option[universe.v2.model.PackageDetailsVersion] = None,
+    options: Option[JsonObject] = None,
+    appId: Option[AppId] = None
+  ): RoundTrip[rpc.v1.model.InstallResponse] = {
+    RoundTrip(
+      Requests.install(name, version, options, appId)) { ir =>
+      Requests.uninstall(ir.packageName, Some(ir.appId))
+      ()
+    }
+  }
+
+  def withDeletedRepository(
+    name: Option[String] = None,
+    uri: Option[Uri] = None
+  ): RoundTrip[rpc.v1.model.PackageRepositoryDeleteResponse] = {
+    RoundTrip.value {
+      val repos = Requests.listRepositories()
+      val repo = repos.find { repo =>
+        name.contains(repo.name) || uri.contains(repo.uri)
+      }.getOrElse(
+        throw new RuntimeException("Attempting to delete a non existent repository")
+      )
+      (repo, repos.indexOf(repo))
+    }.flatMap { case (repo, index) =>
+      withDeletedRepository(repo.name, repo.uri, index)
+    }
+  }
+
+  def withRepositoriesReplaced(
+    newRepositories: List[rpc.v1.model.PackageRepository]
+  ): RoundTrip[List[rpc.v1.model.PackageRepositoryAddResponse]] = {
+    RoundTrip.value(Requests.listRepositories()).flatMap { old =>
+      val withDeletes = RoundTrip.sequence(
+        old.map { repo =>
+          /* we always delete the front, so we also put
+           * it back at the front.
+           * tricky but saves us N listRepositories,
+           * which is N requests to the server,
+           * which is N log lines.
+           */
+          withDeletedRepository(repo.name, repo.uri, 0)
+        }
+      )
+      val withAdds = RoundTrip.sequence(
+        newRepositories.map(repo => withRepository(repo.name, repo.uri))
+      )
+      withDeletes.flatMap(_ => withAdds)
+    }
+  }
+
+  def withRepository(
+    name: String,
+    uri: Uri,
+    index: Option[Int] = None
+  ): RoundTrip[rpc.v1.model.PackageRepositoryAddResponse] = {
+    RoundTrip(
+      Requests.addRepository(name, uri, index)) { _ =>
+      Requests.deleteRepository(Some(name))
+      ()
+    }
+  }
+
+  def withDeletedRepository(
+    name: String,
+    uri: Uri,
+    oldIndex: Int
+  ): RoundTrip[rpc.v1.model.PackageRepositoryDeleteResponse] = {
+    RoundTrip(
+      Requests.deleteRepository(Some(name), Some(uri))) { _ =>
+      Requests.addRepository(name, uri, Some(oldIndex))
+      ()
+    }
+  }
+
+}

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
@@ -5,6 +5,9 @@ import com.mesosphere.cosmos.util.RoundTrip
 import com.mesosphere.universe
 import com.netaporter.uri.Uri
 import io.circe.JsonObject
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.time.SpanSugar._
+import org.scalatest.Matchers._
 
 object RoundTrips {
 
@@ -15,9 +18,15 @@ object RoundTrips {
     appId: Option[AppId] = None
   ): RoundTrip[rpc.v1.model.InstallResponse] = {
     RoundTrip(
-      Requests.install(name, version, options, appId))(ir =>
+      Requests.install(name, version, options, appId)
+    ){ ir =>
       Requests.uninstall(ir.packageName, Some(ir.appId))
-    )
+      eventually(timeout(5.minutes), interval(5.seconds)) {
+        Requests.listPackages(Some(ir.packageName), Some(ir.appId)).map(_.appId).should(
+          not contain ir.appId
+        )
+      }
+    }
   }
 
   def withDeletedRepository(

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
@@ -5,9 +5,9 @@ import com.mesosphere.cosmos.util.RoundTrip
 import com.mesosphere.universe
 import com.netaporter.uri.Uri
 import io.circe.JsonObject
+import org.scalatest.Matchers._
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.time.SpanSugar._
-import org.scalatest.Matchers._
 
 object RoundTrips {
 
@@ -19,7 +19,7 @@ object RoundTrips {
   ): RoundTrip[rpc.v1.model.InstallResponse] = {
     RoundTrip(
       Requests.install(name, version, options, appId)
-    ){ ir =>
+    ) { ir =>
       Requests.uninstall(ir.packageName, Some(ir.appId))
       eventually(timeout(5.minutes), interval(5.seconds)) {
         Requests.listPackages(Some(ir.packageName), Some(ir.appId)).map(_.appId).should(

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
@@ -26,7 +26,7 @@ object RoundTrips {
     name: Option[String] = None,
     uri: Option[Uri] = None
   ): RoundTrip[rpc.v1.model.PackageRepositoryDeleteResponse] = {
-    RoundTrip.value {
+    RoundTrip.lift {
       val repos = Requests.listRepositories()
       val repo = repos.find { repo =>
         name.contains(repo.name) || uri.contains(repo.uri)

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
@@ -1,137 +1,39 @@
 package com.mesosphere.cosmos
 
-import _root_.io.circe.Json
-import _root_.io.circe.JsonObject
-import _root_.io.circe.jawn._
-import _root_.io.circe.syntax._
-import cats.syntax.either._
-import com.mesosphere.cosmos.http.HttpRequest
-import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
-import com.mesosphere.cosmos.thirdparty.marathon.circe.Encoders._
+import com.mesosphere.cosmos.ItOps._
+import com.mesosphere.cosmos.error.MarathonAppNotFound
+import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.universe
-import com.mesosphere.universe.v3.syntax.PackageDefinitionOps._
-import com.twitter.finagle.http.Response
 import com.twitter.finagle.http.Status
-import java.util.UUID
-import org.scalatest.AppendedClues._
-import org.scalatest.Assertion
 import org.scalatest.FeatureSpec
-import org.scalatest.GivenWhenThen
 import org.scalatest.Matchers
-import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.prop.TableFor3
 
-class ServiceDescribeSpec
-  extends FeatureSpec
-    with GivenWhenThen
-    with Matchers
-    with TableDrivenPropertyChecks {
-
-  import ServiceDescribeSpec._
-
+class ServiceDescribeSpec extends FeatureSpec with Matchers {
   feature("The service/describe endpoint") {
     scenario("The user would like to know the upgrades available to a service") {
-      serviceDescribeTest { (content, _, expectedUpgrades, _) =>
-        Then("the user should be able to observe the upgrades available to that service")
-        val actualUpgrades = content.hcursor.get[Json]("upgradesTo")
-        actualUpgrades shouldBe Right(expectedUpgrades.asJson)
+      RoundTrips.withInstall("helloworld", Some("0.1.0")) { ir =>
+        Requests.describeService(ir.appId).upgradesTo.shouldBe(
+          List("0.4.2"): List[universe.v3.model.Version])
       }
     }
     scenario("The user would like to know the downgrades available to a service") {
-      serviceDescribeTest { (content, _, _, expectedDowngrades) =>
-        Then("the user should be able to observe the downgrades available to that service")
-        val actualDowngrades = content.hcursor.get[Json]("downgradesTo")
-        actualDowngrades shouldBe Right(expectedDowngrades.asJson)
+      RoundTrips.withInstall("helloworld", Some("0.4.2")) { ir =>
+        Requests.describeService(ir.appId).downgradesTo.shouldBe(
+          List("0.4.2", "0.4.1", "0.4.0", "0.1.0"): List[universe.v3.model.Version])
       }
     }
     scenario("The user would like to know the package definition used to run a service") {
-      serviceDescribeTest { (content, packageDefinition, _, _) =>
-        Then("the user should be able to observe the package definition used to run that service")
-        val expectedDefinition = ItObjects.dropNullKeys(packageDefinition.asJson)
-        val actualDefinition = content.hcursor.get[Json]("package").map(ItObjects.dropNullKeys)
-        actualDefinition shouldBe Right(expectedDefinition)
+      RoundTrips.withInstall("helloworld", Some("0.1.0")) { ir =>
+        Requests.describeService(ir.appId).`package`.shouldBe(
+          Requests.describePackage(ir.packageName, Some(ir.packageVersion)).`package`)
       }
     }
-  }
-
-}
-
-object ServiceDescribeSpec
-  extends FeatureSpec with GivenWhenThen with Matchers with TableDrivenPropertyChecks {
-
-  private val path: String = "service/describe"
-  private val contentType: String =
-    "application/vnd.dcos.service.describe-request+json;charset=utf-8;version=v1"
-  private val accept: String =
-    "application/vnd.dcos.service.describe-response+json;charset=utf-8;version=v1"
-
-  private val helloWorldPackageDefinitions:
-    TableFor3[universe.v4.model.PackageDefinition, List[String], List[String]] = {
-    Table(
-      ("Package Definition", "Upgrades To", "Downgrades To"),
-      (ItObjects.helloWorldPackage0, List("0.4.2"), List()),
-      (ItObjects.helloWorldPackage3, List("0.4.2", "0.4.1"), List()),
-      (ItObjects.helloWorldPackage4, List("0.4.2"), List("0.4.0"))
-    )
-  }
-
-  private def serviceDescribe(appId: String): Response = {
-    val body = Json.obj(
-      "appId" -> appId.asJson
-    )
-    CosmosClient.submit(
-      HttpRequest.post(
-        path = path,
-        body = body.noSpaces,
-        contentType = Some(contentType),
-        accept = Some(accept)
-      )
-    )
-  }
-
-  def serviceDescribeTest(
-    testCode: (Json, universe.v4.model.PackageDefinition, List[String], List[String]) => Assertion
-  ): Unit = {
-    forAll(helloWorldPackageDefinitions) {
-      (
-        packageDefinition,
-        expectedUpgrades,
-        expectedDowngrades
-      ) =>
-        Given("a running service and its appId")
-        val appId = AppId(UUID.randomUUID().toString)
-        val name = packageDefinition.name
-        val version = packageDefinition.version.toString
-        val Right(install) = ItUtil.packageInstall(
-          name,
-          Some(version),
-          options = Some(JsonObject.singleton("name", appId.asJson))
-        )
-
-        install.appId shouldBe appId
-
-        try {
-          When("the user makes a request to the service/describe endpoint")
-          val response = serviceDescribe(appId.toString)
-          response.status shouldBe Status.Ok withClue response.contentString
-          response.contentType shouldBe Some(accept)
-          val Right(content) = parse(response.contentString)
-
-          // the actual test
-          testCode(
-            content,
-            packageDefinition,
-            expectedUpgrades,
-            expectedDowngrades
-          )
-          ()
-        } finally {
-          // clean up
-          ItUtil.packageUninstall(name, appId, all = true)
-          ()
-        }
+    scenario("The user should receive an error if the service is not present") {
+      val appId = AppId("/does-not-exist-4204242")
+      val error = intercept[HttpErrorResponse](Requests.describeService(appId))
+      error.status shouldBe Status.BadRequest
+      error.errorResponse.shouldBe(MarathonAppNotFound(appId): ErrorResponse)
     }
   }
-
 }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
@@ -5,6 +5,7 @@ import com.mesosphere.cosmos.error.MarathonAppNotFound
 import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.universe
+import com.twitter.bijection.Conversion.asMethod
 import com.twitter.finagle.http.Status
 import org.scalatest.FeatureSpec
 import org.scalatest.Matchers
@@ -33,7 +34,7 @@ class ServiceDescribeSpec extends FeatureSpec with Matchers {
       val appId = AppId("/does-not-exist-4204242")
       val error = intercept[HttpErrorResponse](Requests.describeService(appId))
       error.status shouldBe Status.BadRequest
-      error.errorResponse.shouldBe(MarathonAppNotFound(appId): ErrorResponse)
+      error.errorResponse.shouldBe(MarathonAppNotFound(appId).as[ErrorResponse])
     }
   }
 }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
@@ -12,19 +12,19 @@ import org.scalatest.Matchers
 class ServiceDescribeSpec extends FeatureSpec with Matchers {
   feature("The service/describe endpoint") {
     scenario("The user would like to know the upgrades available to a service") {
-      RoundTrips.withInstall("helloworld", Some("0.1.0")) { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0")) { ir =>
         Requests.describeService(ir.appId).upgradesTo.shouldBe(
           List("0.4.2"): List[universe.v3.model.Version])
       }
     }
     scenario("The user would like to know the downgrades available to a service") {
-      RoundTrips.withInstall("helloworld", Some("0.4.2")) { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.4.2")) { ir =>
         Requests.describeService(ir.appId).downgradesTo.shouldBe(
           List("0.4.2", "0.4.1", "0.4.0", "0.1.0"): List[universe.v3.model.Version])
       }
     }
     scenario("The user would like to know the package definition used to run a service") {
-      RoundTrips.withInstall("helloworld", Some("0.1.0")) { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0")) { ir =>
         Requests.describeService(ir.appId).`package`.shouldBe(
           Requests.describePackage(ir.packageName, Some(ir.packageVersion)).`package`)
       }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
@@ -13,19 +13,19 @@ import org.scalatest.Matchers
 class ServiceDescribeSpec extends FeatureSpec with Matchers {
   feature("The service/describe endpoint") {
     scenario("The user would like to know the upgrades available to a service") {
-      RoundTrips.withInstallV1("helloworld", Some("0.1.0")).runWith { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0".detailsVersion)).runWith { ir =>
         Requests.describeService(ir.appId).upgradesTo.shouldBe(
-          List("0.4.2"): List[universe.v3.model.Version])
+          List("0.4.2").map(_.version))
       }
     }
     scenario("The user would like to know the downgrades available to a service") {
-      RoundTrips.withInstallV1("helloworld", Some("0.4.2")).runWith { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.4.2".detailsVersion)).runWith { ir =>
         Requests.describeService(ir.appId).downgradesTo.shouldBe(
-          List("0.4.2", "0.4.1", "0.4.0", "0.1.0"): List[universe.v3.model.Version])
+          List("0.4.2", "0.4.1", "0.4.0", "0.1.0").map(_.version))
       }
     }
     scenario("The user would like to know the package definition used to run a service") {
-      RoundTrips.withInstallV1("helloworld", Some("0.1.0")).runWith { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0".detailsVersion)).runWith { ir =>
         Requests.describeService(ir.appId).`package`.shouldBe(
           Requests.describePackage(ir.packageName, Some(ir.packageVersion)).`package`)
       }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
@@ -12,19 +12,19 @@ import org.scalatest.Matchers
 class ServiceDescribeSpec extends FeatureSpec with Matchers {
   feature("The service/describe endpoint") {
     scenario("The user would like to know the upgrades available to a service") {
-      RoundTrips.withInstallV1("helloworld", Some("0.1.0")) { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0")).runWith { ir =>
         Requests.describeService(ir.appId).upgradesTo.shouldBe(
           List("0.4.2"): List[universe.v3.model.Version])
       }
     }
     scenario("The user would like to know the downgrades available to a service") {
-      RoundTrips.withInstallV1("helloworld", Some("0.4.2")) { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.4.2")).runWith { ir =>
         Requests.describeService(ir.appId).downgradesTo.shouldBe(
           List("0.4.2", "0.4.1", "0.4.0", "0.1.0"): List[universe.v3.model.Version])
       }
     }
     scenario("The user would like to know the package definition used to run a service") {
-      RoundTrips.withInstallV1("helloworld", Some("0.1.0")) { ir =>
+      RoundTrips.withInstallV1("helloworld", Some("0.1.0")).runWith { ir =>
         Requests.describeService(ir.appId).`package`.shouldBe(
           Requests.describePackage(ir.packageName, Some(ir.packageVersion)).`package`)
       }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
@@ -4,13 +4,12 @@ import com.mesosphere.cosmos.ItOps._
 import com.mesosphere.cosmos.error.MarathonAppNotFound
 import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
-import com.mesosphere.universe
 import com.twitter.bijection.Conversion.asMethod
 import com.twitter.finagle.http.Status
 import org.scalatest.FeatureSpec
 import org.scalatest.Matchers
 
-class ServiceDescribeSpec extends FeatureSpec with Matchers {
+final class ServiceDescribeSpec extends FeatureSpec with Matchers {
   feature("The service/describe endpoint") {
     scenario("The user would like to know the upgrades available to a service") {
       RoundTrips.withInstallV1("helloworld", Some("0.1.0".detailsVersion)).runWith { ir =>

--- a/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/util/RoundTrip.scala
+++ b/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/util/RoundTrip.scala
@@ -18,6 +18,7 @@ class RoundTrip[A] private(
     new RoundTrip[B](withResourceB)
   }
 
+  // TODO: runWith
   def apply[B](transform: A => B): B = {
     map(transform).run()
   }
@@ -57,6 +58,7 @@ object RoundTrip {
     }
   }
 
+  // TODO: pure
   def value[A](a: => A): RoundTrip[A] = {
     RoundTrip(a)((_: A) => ())
   }

--- a/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/util/RoundTrip.scala
+++ b/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/util/RoundTrip.scala
@@ -1,4 +1,4 @@
-package com.mesosphere.util
+package com.mesosphere.cosmos.util
 
 class RoundTrip[A](
   private val withResource: (A => Unit) => Unit
@@ -24,7 +24,7 @@ class RoundTrip[A](
     new RoundTrip[B](withResourceB)
   }
 
-  def get(): A = {
+  def run(): A = {
     var innerA: Option[A] = None
     withResource { a: A =>
       innerA = Some(a)
@@ -33,7 +33,7 @@ class RoundTrip[A](
   }
 
   def apply[B](transform: A => B): B = {
-    map(transform).get()
+    map(transform).run()
   }
 
 }
@@ -41,7 +41,7 @@ class RoundTrip[A](
 object RoundTrip {
 
   def apply[A](
-    forward: => A)(
+    forward: => A,
     backwards: A => Unit
   ): RoundTrip[A] = {
     def withResource(aInner: A => Unit): Unit = {
@@ -55,8 +55,8 @@ object RoundTrip {
     new RoundTrip[A](withResource)
   }
 
-  def value[A](a: A): RoundTrip[A] = {
-    RoundTrip(a)((_: A) => ())
+  def apply[A](a: A): RoundTrip[A] = {
+    RoundTrip(a, (_: A) => ())
   }
 
 }

--- a/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/util/RoundTrip.scala
+++ b/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/util/RoundTrip.scala
@@ -1,27 +1,26 @@
 package com.mesosphere.cosmos.util
 
-class RoundTrip[A](
+import scala.language.implicitConversions
+import shapeless._
+
+class RoundTrip[A] private(
   private val withResource: (A => Unit) => Unit
 ) {
 
-  def map[B](transform: A => B): RoundTrip[B] = {
-    def withResourceB(bInner: B => Unit): Unit = {
-      withResource { a: A =>
-        bInner(transform(a))
-      }
-    }
-    new RoundTrip[B](withResourceB)
-  }
-
   def flatMap[B](transform: A => RoundTrip[B]): RoundTrip[B] = {
     def withResourceB(bInner: B => Unit): Unit = {
-      withResource{ a: A =>
+      withResource { a: A =>
         transform(a).withResource { b: B =>
           bInner(b)
         }
       }
     }
+
     new RoundTrip[B](withResourceB)
+  }
+
+  def apply[B](transform: A => B): B = {
+    map(transform).run()
   }
 
   def run(): A = {
@@ -32,13 +31,27 @@ class RoundTrip[A](
     innerA.get
   }
 
-  def apply[B](transform: A => B): B = {
-    map(transform).run()
+  def hList(): RoundTrip[A :: HNil] = {
+    map(_ :: HNil)
+  }
+
+  def map[B](transform: A => B): RoundTrip[B] = {
+    def withResourceB(bInner: B => Unit): Unit = {
+      withResource { a: A =>
+        bInner(transform(a))
+      }
+    }
+
+    new RoundTrip[B](withResourceB)
   }
 
 }
 
 object RoundTrip {
+
+  def apply[A](a: => A): RoundTrip[A] = {
+    RoundTrip(a, (_: A) => ())
+  }
 
   def apply[A](
     forward: => A,
@@ -52,11 +65,24 @@ object RoundTrip {
         backwards(a)
       }
     }
+
     new RoundTrip[A](withResource)
   }
 
-  def apply[A](a: A): RoundTrip[A] = {
-    RoundTrip(a, (_: A) => ())
+  implicit class RoundTripHListOps[B <: HList](self: => RoundTrip[B]) {
+    def &:[A](other: RoundTrip[A]): RoundTrip[A :: B] = {
+      other.flatMap { a =>
+        self.map(a :: _)
+      }
+    }
+  }
+
+  implicit class RoundTripOps[B](self: => RoundTrip[B]) {
+    def &:[A](other: RoundTrip[A]): RoundTrip[A :: B :: HNil] = {
+      other.flatMap { a =>
+        self.map(b => a :: b :: HNil)
+      }
+    }
   }
 
 }

--- a/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/util/RoundTrip.scala
+++ b/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/util/RoundTrip.scala
@@ -63,7 +63,7 @@ object RoundTrip {
 
   def apply[A](
     forward: => A)(
-    backwards: A => Unit
+    backwards: A => Any
   ): RoundTrip[A] = {
     def withResource(aInner: A => Unit): Unit = {
       val a = forward
@@ -71,6 +71,7 @@ object RoundTrip {
         aInner(a)
       } finally {
         backwards(a)
+        ()
       }
     }
     new RoundTrip[A](withResource)

--- a/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/util/RoundTrip.scala
+++ b/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/util/RoundTrip.scala
@@ -69,6 +69,7 @@ object RoundTrip {
     new RoundTrip[A](withResource)
   }
 
+  // scalastyle:off method.name
   implicit class RoundTripHListOps[B <: HList](self: => RoundTrip[B]) {
     def &:[A](other: RoundTrip[A]): RoundTrip[A :: B] = {
       other.flatMap { a =>
@@ -84,5 +85,6 @@ object RoundTrip {
       }
     }
   }
+  // scalastyle:on method.name
 
 }

--- a/cosmos-test-common/src/test/scala/com/mesosphere/util/RoundTripSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/util/RoundTripSpec.scala
@@ -152,8 +152,14 @@ class RoundTripSpec extends FreeSpec with Matchers {
   }
 
   "RoundTrip should be somewhat flat" in {
-    val rt = withIncrement().map(_.toString) &: withIncrement().map(_.toFloat) &: withIncrement()
-    rt.run() shouldBe ("1" :: 2.0 :: 3 :: HNil)
+    val withRt = withIncrement().map(_.toString) &: withIncrement().map(_.toFloat) &: withIncrement()
+    withRt.run() shouldBe ("1" :: 2.0 :: 3 :: HNil)
+
+    assertThrows[Error] {
+      withRt { case (_: String) :: (_: Float) :: (_: Int) :: HNil =>
+        throw new Error("This should throw")
+      }
+    }
   }
 
 }

--- a/cosmos-test-common/src/test/scala/com/mesosphere/util/RoundTripSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/util/RoundTripSpec.scala
@@ -10,32 +10,32 @@ class RoundTripSpec extends FreeSpec with Matchers {
   "RoundTrip.apply(value)" - {
     val i: Int = 3
     "should be map able" in {
-      RoundTrip(i).map(_ * i).run().
+      RoundTrip.value(i).map(_ * i).run().
         shouldBe(i * i)
     }
 
     "should be flatMap able" in {
-      RoundTrip(i).flatMap(i => RoundTrip(i * i)).run().
+      RoundTrip.value(i).flatMap(i => RoundTrip.value(i * i)).run().
         shouldBe(i * i)
     }
 
     "should not throw error if map fails but is not evaluated" in {
-      RoundTrip(i).map(_ => throw new Error("this should not happen"))
+      RoundTrip.value(i).map(_ => throw new Error("this should not happen"))
     }
 
     "throw error if map fails" in {
       assertThrows[Error] {
-        RoundTrip(i).map(_ => throw new Error("this should happen")).run()
+        RoundTrip.value(i).map(_ => throw new Error("this should happen")).run()
       }
     }
 
     "should not throw error if flatMap fails but is not evaluated" in {
-      RoundTrip(i).flatMap(i => RoundTrip(i / 0))
+      RoundTrip.value(i).flatMap(i => RoundTrip.value(i / 0))
     }
 
     "should throw error if flatMap fails when evaluated" in {
       assertThrows[ArithmeticException] {
-        RoundTrip(i).flatMap(i => RoundTrip(i / 0)).run()
+        RoundTrip.value(i).flatMap(i => RoundTrip.value(i / 0)).run()
       }
     }
   }
@@ -51,7 +51,7 @@ class RoundTripSpec extends FreeSpec with Matchers {
     state = previous
   }
   def withChangedState(newValue: Int): RoundTrip[Int] = {
-    RoundTrip(forward(newValue), backwards).map(_ => newValue)
+    RoundTrip(forward(newValue))(backwards).map(_ => newValue)
   }
   def withIncrement(): RoundTrip[Int] = {
     //RoundTrip(state).flatMap { s =>

--- a/cosmos-test-common/src/test/scala/com/mesosphere/util/RoundTripSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/util/RoundTripSpec.scala
@@ -1,0 +1,150 @@
+package com.mesosphere.util
+
+import com.mesosphere.cosmos.util.RoundTrip
+import org.scalatest.FreeSpec
+import org.scalatest.Matchers
+
+class RoundTripSpec extends FreeSpec with Matchers {
+
+  "RoundTrip.apply(value)" - {
+    val i: Int = 3
+    "should be map able" in {
+      RoundTrip(i).map(_ * i).run().
+        shouldBe(i * i)
+    }
+
+    "should be flatMap able" in {
+      RoundTrip(i).flatMap(i => RoundTrip(i * i)).run().
+        shouldBe(i * i)
+    }
+
+    "should not throw error if map fails but is not evaluated" in {
+      RoundTrip(i).map(_ => throw new Error("this should not happen"))
+    }
+
+    "throw error if map fails" in {
+      assertThrows[Error] {
+        RoundTrip(i).map(_ => throw new Error("this should happen")).run()
+      }
+    }
+
+    "should not throw error if flatMap fails but is not evaluated" in {
+      RoundTrip(i).flatMap(i => RoundTrip(i / 0))
+    }
+
+    "should throw error if flatMap fails when evaluated" in {
+      assertThrows[ArithmeticException] {
+        RoundTrip(i).flatMap(i => RoundTrip(i / 0)).run()
+      }
+    }
+  }
+
+
+  var state: Int = 0
+  def forward(newState : Int): Int = {
+    val oldState = state
+    state = newState
+    oldState
+  }
+  def backwards(previous: Int): Unit = {
+    state = previous
+  }
+  def withChangedState(newValue: Int): RoundTrip[Int] = {
+    RoundTrip(forward(newValue), backwards).map(_ => newValue)
+  }
+  def withIncrement(): RoundTrip[Int] = {
+    val newValue = state + 1
+    withChangedState(newValue)
+  }
+
+  "RoundTrip run() should return inner value" in {
+    val i = 3
+    withChangedState(i).run()
+      .shouldBe(i)
+    state shouldBe 0
+  }
+
+  "RoundTrip should map" in {
+    val i = 3
+    withChangedState(i).map(_ * i).run()
+      .shouldBe(i * i)
+    state shouldBe 0
+  }
+
+  "RoundTrip should flatMap" in {
+    val i = 3
+    withChangedState(i).flatMap(i => withChangedState(i * i)).run()
+      .shouldBe(i * i)
+    state shouldBe 0
+  }
+
+  "RoundTrip should revert state even if map throws error" in {
+    val i = 3
+    intercept[Error] {
+      withChangedState(i).map { i =>
+        state shouldBe i
+        throw new Error("This should go back to original state")
+      }.run()
+    }
+    state shouldBe 0
+  }
+
+  "RoundTrip should revert state even if flatMap fails" in {
+    val i = 3
+    intercept[Error] {
+      withChangedState(i).flatMap { i =>
+        state shouldBe i
+        throw new Error("This should go back to original state")
+      }.run()
+    }
+    state shouldBe 0
+  }
+
+  "RoundTrip should be able to use for comprehensions" in {
+    val with3 = for {
+      _ <- withIncrement()
+      _ <- withIncrement()
+      i <- withIncrement()
+    } yield i
+    with3.run() shouldBe 3
+  }
+
+  "RoundTrip.apply should clean up even if flatMap fails" +
+    " after more maps have been added. Other maps should not be executed" in {
+    val result = for {
+      _ <- withIncrement()
+      _ <- withIncrement()
+      i <- withIncrement()
+      r <- withChangedState(i / 0)
+    } yield r
+    intercept[ArithmeticException] {
+      result.run()
+    }
+    state shouldBe 0
+  }
+
+  "RoundTrip should observe the forward context inside map and flatMap" in {
+    val a = 1
+    val b = -2
+    val c = 8
+    withIncrement().flatMap { _ =>
+      state shouldBe a
+      withChangedState(b).flatMap { _ =>
+        state shouldBe b
+        withChangedState(c).map { _ =>
+          state shouldBe c
+        }
+      }
+    }.run()
+    state shouldBe 0
+  }
+
+  "RoundTrip should be able to be used like a IOC function" in {
+    val i = 3
+    withChangedState(i) { j =>
+      j shouldBe i
+    }
+  }
+
+}
+

--- a/cosmos-test-common/src/test/scala/com/mesosphere/util/RoundTripSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/util/RoundTripSpec.scala
@@ -40,7 +40,7 @@ class RoundTripSpec extends FreeSpec with Matchers {
     }
   }
 
-
+  // TODO: make this independent
   var state: Int = 0
   def forward(newState : Int): Int = {
     val oldState = state
@@ -54,11 +54,10 @@ class RoundTripSpec extends FreeSpec with Matchers {
     RoundTrip(forward(newValue))(backwards).map(_ => newValue)
   }
   def withIncrement(): RoundTrip[Int] = {
-    //RoundTrip(state).flatMap { s =>
+    //RoundTrip.value(state).flatMap { s =>
     //  withChangedState(s + 1)
     //}
-    val newValue = state + 1
-    withChangedState(newValue)
+    withChangedState(state + 1)
   }
 
   "RoundTrip run() should return inner value" in {

--- a/cosmos-test-common/src/test/scala/com/mesosphere/util/RoundTripSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/util/RoundTripSpec.scala
@@ -3,6 +3,7 @@ package com.mesosphere.util
 import com.mesosphere.cosmos.util.RoundTrip
 import org.scalatest.FreeSpec
 import org.scalatest.Matchers
+import shapeless._
 
 class RoundTripSpec extends FreeSpec with Matchers {
 
@@ -53,6 +54,9 @@ class RoundTripSpec extends FreeSpec with Matchers {
     RoundTrip(forward(newValue), backwards).map(_ => newValue)
   }
   def withIncrement(): RoundTrip[Int] = {
+    //RoundTrip(state).flatMap { s =>
+    //  withChangedState(s + 1)
+    //}
     val newValue = state + 1
     withChangedState(newValue)
   }
@@ -116,6 +120,7 @@ class RoundTripSpec extends FreeSpec with Matchers {
       _ <- withIncrement()
       i <- withIncrement()
       r <- withChangedState(i / 0)
+      _ <- withIncrement()
     } yield r
     intercept[ArithmeticException] {
       result.run()
@@ -144,6 +149,11 @@ class RoundTripSpec extends FreeSpec with Matchers {
     withChangedState(i) { j =>
       j shouldBe i
     }
+  }
+
+  "RoundTrip should be somewhat flat" in {
+    val rt = withIncrement().map(_.toString) &: withIncrement().map(_.toFloat) &: withIncrement()
+    rt.run() shouldBe ("1" :: 2.0 :: 3 :: HNil)
   }
 
 }


### PR DESCRIPTION
I worked on this over the weekend. RoundTrip is an abstraction that takes care of clean up. You can construct it with a pair of functions: one that goes forward (makes a state change) and one that goes backwards (reverts the state change). The value that the RoundTrip stores is the result of the forward function. You can use map and flatMap to create new RoundTrips. You can execute a RoundTrip by either .get()ing the value inside the RoundTrip or .apply()ing a transformation to the value inside it. This is a generalization of the `withSomeStateChange()` methods that are scattered over the code.