### PR TITLE
Ensure use of Basic auth for HTTPS tunneling through proxies

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
@@ -109,6 +109,9 @@ private[cosmos] object HttpProxySupport {
     parseAllProperties(proxyEnvVariables)
       .foreach { case (key, value) => setPropertyIfUnset(key, value) }
 
+    // Ensure we can use Basic authentication for HTTPS tunneling through proxies
+    setPropertyIfUnset("jdk.http.auth.tunneling.disabledSchemes", "")
+
     val authenticator = new CosmosHttpProxyPasswordAuthenticator(proxyEnvVariables)
     setAuthenticator(authenticator)
   }


### PR DESCRIPTION
This will prevent errors when testing proxies during development.
See http://www.oracle.com/technetwork/java/javase/8u111-relnotes-3124969.html