### PR TITLE
Updated integration tests to use the new universe converter service

### DIFF
--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/IntegrationBeforeAndAfterAll.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/IntegrationBeforeAndAfterAll.scala
@@ -7,7 +7,7 @@ import org.scalatest.Suite
 trait IntegrationBeforeAndAfterAll extends BeforeAndAfterAll { this: Suite =>
 
   private[this] val universeUri = "https://downloads.mesosphere.com/universe/02493e40f8564a39446d06c002f8dcc8e7f6d61f/repo-up-to-1.8.json"
-  private[this] val universeConverterUri = "http://universe-converter.mesosphere.com/transform?url=" + universeUri
+  private[this] val universeConverterUri = "https://universe-converter.mesosphere.com/transform?url=" + universeUri
 
   override def beforeAll(): Unit = {
     Requests.deleteRepository(Some("Universe"))

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/IntegrationBeforeAndAfterAll.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/IntegrationBeforeAndAfterAll.scala
@@ -7,26 +7,27 @@ import org.scalatest.Suite
 trait IntegrationBeforeAndAfterAll extends BeforeAndAfterAll { this: Suite =>
 
   private[this] val universeUri = "https://downloads.mesosphere.com/universe/02493e40f8564a39446d06c002f8dcc8e7f6d61f/repo-up-to-1.8.json"
+  private[this] val universeConverterUri = "http://universe-converter.mesosphere.com/transform?url=" + universeUri
 
   override def beforeAll(): Unit = {
     Requests.deleteRepository(Some("Universe"))
 
     Requests.addRepository(
       "Universe",
-      universeUri,
+      universeConverterUri,
       Some(0)
     )
 
     val _ = Requests.addRepository(
       "V4TestUniverse",
-      ItObjects.V4TestUniverse,
+      ItObjects.V4TestUniverseConverterURI,
       Some(0)
     )
   }
 
   override def afterAll(): Unit = {
     Requests.deleteRepository(Some("V4TestUniverse"))
-    Requests.deleteRepository(None, Some(universeUri))
+    Requests.deleteRepository(None, Some(universeConverterUri))
     val _ = Requests.addRepository("Universe", "https://universe.mesosphere.com/repo")
   }
 }

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItObjects.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItObjects.scala
@@ -13,9 +13,10 @@ import java.util.Base64
 import org.scalatest.prop.TableFor2
 
 object ItObjects {
-  val V4TestUniverse =
-    "https://downloads.mesosphere.com/universe/" +
+
+  val V4TestUniverse = "https://downloads.mesosphere.com/universe/" +
     "ae6a07ac0b53924154add2cd61403c5233272d93/repo/repo-up-to-1.10.json"
+  val V4TestUniverseConverterURI = "http://universe-converter.mesosphere.com/transform?url=" + V4TestUniverse
 
   val helloWorldMarathonMustache: String = {
     """{
@@ -220,14 +221,14 @@ object ItObjects {
   // scalastyle:on line.size.limit
 
   val defaultHelloWorldPackageDefinition: (Json, Json) =
-    parse(helloWorldPackageDefinition042).toOption.get -> V4TestUniverse.asJson
+    parse(helloWorldPackageDefinition042).toOption.get -> V4TestUniverseConverterURI.asJson
 
   val helloWorldPackageDefinitions: TableFor2[Json, Json] =
     new TableFor2(
       "Package Definition" -> "Package Source",
-      parse(helloWorldPackageDefinition0).toOption.get -> V4TestUniverse.asJson,
-      parse(helloWorldPackageDefinition3).toOption.get -> V4TestUniverse.asJson,
-      parse(helloWorldPackageDefinition4).toOption.get -> V4TestUniverse.asJson
+      parse(helloWorldPackageDefinition0).toOption.get -> V4TestUniverseConverterURI.asJson,
+      parse(helloWorldPackageDefinition3).toOption.get -> V4TestUniverseConverterURI.asJson,
+      parse(helloWorldPackageDefinition4).toOption.get -> V4TestUniverseConverterURI.asJson
     )
 
   val metadataFields: Set[String] = {
@@ -319,7 +320,7 @@ object ItObjects {
   def decodedHelloWorldLabels(
     packageDefinition: Json,
     options: Json,
-    packageSource: Json = V4TestUniverse.asJson
+    packageSource: Json = V4TestUniverseConverterURI.asJson
   ): Map[String, Json] = {
     val pkg = packageDefinition.asObject.get
     Map(
@@ -335,7 +336,7 @@ object ItObjects {
   def renderHelloWorldMarathonMustacheDecodedLabels(
     packageDefinition: Json,
     options: Json,
-    packageSource: Json = V4TestUniverse.asJson
+    packageSource: Json = V4TestUniverseConverterURI.asJson
   ): Json = {
     val mustache = renderHelloWorldMarathonMustacheNoLabels(options)
     val labels = decodedHelloWorldLabels(packageDefinition, options, packageSource)
@@ -352,7 +353,7 @@ object ItObjects {
   def helloWorldRenderResponseDecodedLabels(
     packageDefinition: Json,
     options: Json,
-    packageSource: Json = V4TestUniverse.asJson
+    packageSource: Json = V4TestUniverseConverterURI.asJson
   ): Json = {
     val marathonJson = renderHelloWorldMarathonMustacheDecodedLabels(
       packageDefinition,

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItObjects.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ItObjects.scala
@@ -16,7 +16,7 @@ object ItObjects {
 
   val V4TestUniverse = "https://downloads.mesosphere.com/universe/" +
     "ae6a07ac0b53924154add2cd61403c5233272d93/repo/repo-up-to-1.10.json"
-  val V4TestUniverseConverterURI = "http://universe-converter.mesosphere.com/transform?url=" + V4TestUniverse
+  val V4TestUniverseConverterURI = "https://universe-converter.mesosphere.com/transform?url=" + V4TestUniverse
 
   val helloWorldMarathonMustache: String = {
     """{


### PR DESCRIPTION
I have changed the integration tests to fetch the repo json from the new converter service. This makes sure that the converter service is running as expected and helps us test the converter service frequently.