### PR TITLE
Add content disposition header in resource proxy endpoint

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ResourceProxyHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ResourceProxyHandler.scala
@@ -44,8 +44,11 @@ final class ResourceProxyHandler private(
           response.content = Buf.ByteArray.Owned(contentBytes)
           response.contentType = responseData.contentType.show
           response.contentLength = contentBytes.length.toLong
-          response.headerMap.add(Fields.ContentDisposition,
-            s"""attachment; filename="${getFileNameFromUrl(uri)}"""")
+          getFileNameFromUrl(uri) match {
+            case Some(filename) => response.headerMap.add(Fields.ContentDisposition,
+              s"""attachment; filename="$filename"""")
+            case _ =>
+          }
           response
         }
         .map(Output.payload(_))
@@ -96,11 +99,11 @@ object ResourceProxyHandler {
     }
   }
 
-  def getFileNameFromUrl(url: Uri): String = {
+  def getFileNameFromUrl(url: Uri): Option[String] = {
     url.pathParts match {
-      case _ :+ last if !last.part.isEmpty => last.part
-      case _ :+ secondLast :+ last if last.part.isEmpty => secondLast.part
-      case _ => url.host.getOrElse("")
+      case _ :+ last if !last.part.isEmpty => Some(last.part)
+      case _ :+ secondLast :+ last if last.part.isEmpty => Some(secondLast.part)
+      case _ => None
     }
   }
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ResourceProxyHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ResourceProxyHandler.scala
@@ -44,10 +44,9 @@ final class ResourceProxyHandler private(
           response.content = Buf.ByteArray.Owned(contentBytes)
           response.contentType = responseData.contentType.show
           response.contentLength = contentBytes.length.toLong
-          getFileNameFromUrl(uri) match {
-            case Some(filename) => response.headerMap.add(Fields.ContentDisposition,
+          for (filename <- getFileNameFromUrl(uri)) {
+            response.headerMap.add(Fields.ContentDisposition,
               s"""attachment; filename="$filename"""")
-            case _ =>
           }
           response
         }

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/handler/ResourceProxyHandlerSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/handler/ResourceProxyHandlerSpec.scala
@@ -158,29 +158,29 @@ final class ResourceProxyHandlerSpec extends FreeSpec with PropertyChecks with M
 
     ResourceProxyHandler.getFileNameFromUrl(
       Uri.parse("http://doesntreallymatter.com/c.d")
-    ) shouldEqual "c.d"
+    ) shouldEqual Some("c.d")
 
     ResourceProxyHandler.getFileNameFromUrl(
       Uri.parse("http://doesntreallymatter.com/a/b/c.d")
-    ) shouldEqual "c.d"
+    ) shouldEqual Some("c.d")
 
     ResourceProxyHandler.getFileNameFromUrl(
       Uri.parse("http://doesntreallymatter.com/a/b/c")
-    ) shouldEqual "c"
+    ) shouldEqual Some("c")
 
     ResourceProxyHandler.getFileNameFromUrl(
       Uri.parse("http://doesntreallymatter.com/a/b/c/")
-    ) shouldEqual "c"
+    ) shouldEqual Some("c")
 
     // These should never happen, but just in case.
 
     ResourceProxyHandler.getFileNameFromUrl(
       Uri.parse("http://doesntreallymatter.com/")
-    ) shouldEqual "doesntreallymatter.com"
+    ) shouldEqual None
 
     ResourceProxyHandler.getFileNameFromUrl(
       Uri.parse("https://doesntreallymatter.com")
-    ) shouldEqual "doesntreallymatter.com"
+    ) shouldEqual None
 
   }
 

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/handler/ResourceProxyHandlerSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/handler/ResourceProxyHandlerSpec.scala
@@ -19,10 +19,11 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatest.Assertion
 import org.scalatest.FreeSpec
+import org.scalatest.Matchers
 import org.scalatest.prop.PropertyChecks
 import scala.collection.mutable
 
-final class ResourceProxyHandlerSpec extends FreeSpec with PropertyChecks {
+final class ResourceProxyHandlerSpec extends FreeSpec with PropertyChecks with Matchers {
 
   type TestData = (StorageUnit, mutable.WrappedArray[Byte], Uri, MediaType)
 
@@ -151,6 +152,36 @@ final class ResourceProxyHandlerSpec extends FreeSpec with PropertyChecks {
     val responseData = ResponseData(MediaType.parse("application/random").get, None, contentStream)
     val exception = intercept[CosmosException](ResourceProxyHandler.getContentBytes(Uri.parse("/random"), responseData, 1.bytes))
     assert(exception.error.isInstanceOf[GenericHttpError])
+  }
+
+  "Parses the filename correctly" in {
+
+    ResourceProxyHandler.getFileNameFromUrl(
+      Uri.parse("http://doesntreallymatter.com/c.d")
+    ) shouldEqual "c.d"
+
+    ResourceProxyHandler.getFileNameFromUrl(
+      Uri.parse("http://doesntreallymatter.com/a/b/c.d")
+    ) shouldEqual "c.d"
+
+    ResourceProxyHandler.getFileNameFromUrl(
+      Uri.parse("http://doesntreallymatter.com/a/b/c")
+    ) shouldEqual "c"
+
+    ResourceProxyHandler.getFileNameFromUrl(
+      Uri.parse("http://doesntreallymatter.com/a/b/c/")
+    ) shouldEqual "c"
+
+    // These should never happen, but just in case.
+
+    ResourceProxyHandler.getFileNameFromUrl(
+      Uri.parse("http://doesntreallymatter.com/")
+    ) shouldEqual "doesntreallymatter.com"
+
+    ResourceProxyHandler.getFileNameFromUrl(
+      Uri.parse("https://doesntreallymatter.com")
+    ) shouldEqual "doesntreallymatter.com"
+
   }
 
   def assertFailure(output: Future[Output[Response]]): Assertion = {


### PR DESCRIPTION
Add content disposition header to make sure the proxied filename is consistent. Addresses [DCOS_OSS-1802](https://jira.mesosphere.com/browse/DCOS_OSS-1802)