### PR TITLE
add dcos-log v2 capability

### DIFF
--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/CapabilitiesHandlerSpec.scala
@@ -23,7 +23,8 @@ final class CapabilitiesHandlerSpec extends FreeSpec {
       Capability("PACKAGE_MANAGEMENT"),
       Capability("SUPPORT_CLUSTER_REPORT"),
       Capability("METRONOME"),
-      Capability("LOGGING")
+      Capability("LOGGING"),
+      Capability("LOGGING_V2")
     ))
     assertResult(expected)(body)
   }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/CapabilitiesHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/CapabilitiesHandler.scala
@@ -12,7 +12,8 @@ private[cosmos] final class CapabilitiesHandler
     List(Capability("PACKAGE_MANAGEMENT"),
          Capability("SUPPORT_CLUSTER_REPORT"),
          Capability("METRONOME"),
-         Capability("LOGGING")))
+         Capability("LOGGING"),
+         Capability("LOGGING_V2")))
 
   override def apply(v1: Unit)(implicit
     session: RequestSession


### PR DESCRIPTION
with DC/OS 1.11 we are introducing new logging API. Also known as dcos-log v2.
A new capability is required to handle the logs properly from dcos-cli.

dcos-log v2 [design doc](https://docs.google.com/document/d/1Z2gWi1H7lc3nNGqLUU9Hecvm9EyPLI-6t3uK1ANlHyA/edit#heading=h.apvnjfls8tkq)

Related PRs:
[dcos-log](https://github.com/dcos/dcos-log/pull/43)
[dcos-cli](https://github.com/dcos/dcos-cli/pull/1105)
[dcos](https://github.com/dcos/dcos/pull/1935)