### PR TITLE
Increase the maxClientResponseSize

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/package.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/package.scala
@@ -66,7 +66,7 @@ package cosmos {
   )
 
   object maxClientResponseSize extends GlobalFlag[StorageUnit](
-    5.megabytes,
+    40.megabytes,
     "Maximum size for the response for requests initiated by Cosmos in Megabytes"
   )
 


### PR DESCRIPTION
Cosmos has to interact with marathon's /v2/apps endpoint. This can grow quite large in a busy cluster.