### PR TITLE
Release patch v0.4.4

### DIFF
--- a/docker/ramltools/Dockerfile
+++ b/docker/ramltools/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:4.8
+FROM node:9.1
 RUN npm install -g raml2html && \
     npm install -g https://github.com/stoplightio/api-spec-converter
 COPY raml2swagger.js /usr/local/bin/raml2swagger

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -143,7 +143,7 @@ object Deps {
 
 object V {
   val projectScalaVersion = "2.11.7"
-  val projectVersion = "0.4.3"
+  val projectVersion = "0.4.4"
 
   val aws = "1.11.63"
   val bijection = "0.9.4"


### PR DESCRIPTION
Address [DCOS-37674](https://jira.mesosphere.com/browse/DCOS-37674)

We are using a very old version of node js (used for generating docs) which resulted in [this error](https://teamcity.mesosphere.io/viewLog.html?buildId=1079083&buildTypeId=DcosIo_Cosmos_PublishRelease&tab=buildLog&_focus=13619). This is not needed for cosmos 0.5.x and above as we have moved the documentation to dcos docs site.