### PR TITLE
Fix a race condition while trying to create zk nodes

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -247,6 +247,7 @@ trait CosmosApp
     val api = endpoints.handle {
       case ce: CosmosException =>
         logger.info(s"Cosmos Exception : ${ce.getMessage}")
+        logger.debug(s"${ce.getMessage} : ", ce)
         stats.counter(s"definedError/${sanitizeClassName(ce.error.getClass)}").incr()
         val output = Output.failure(
           ce,
@@ -257,6 +258,7 @@ trait CosmosApp
         ce.headers.foldLeft(output) { case (out, kv) => out.withHeader(kv) }
       case fe @ (_: _root_.io.finch.Error | _: _root_.io.finch.Errors) =>
         logger.warn(s"Finch Exception : ${fe.getMessage}", fe)
+        logger.info(s"${fe.getMessage} : ", fe)
         stats.counter(s"finchError/${sanitizeClassName(fe.getClass)}").incr()
         Output.failure(
           fe.asInstanceOf[Exception], // Must be an Exception based on the types

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -246,8 +246,8 @@ trait CosmosApp
 
     val api = endpoints.handle {
       case ce: CosmosException =>
-        logger.info(s"Cosmos Exception : ${ce.getMessage}")
-        logger.debug(s"${ce.getMessage} : ", ce)
+        if (logger.isDebugEnabled) logger.debug(s"Cosmos Exception : ${ce.getMessage}", ce)
+        else logger.info(s"Cosmos Exception : ${ce.getMessage}")
         stats.counter(s"definedError/${sanitizeClassName(ce.error.getClass)}").incr()
         val output = Output.failure(
           ce,
@@ -258,7 +258,6 @@ trait CosmosApp
         ce.headers.foldLeft(output) { case (out, kv) => out.withHeader(kv) }
       case fe @ (_: _root_.io.finch.Error | _: _root_.io.finch.Errors) =>
         logger.warn(s"Finch Exception : ${fe.getMessage}", fe)
-        logger.info(s"${fe.getMessage} : ", fe)
         stats.counter(s"finchError/${sanitizeClassName(fe.getClass)}").incr()
         Output.failure(
           fe.asInstanceOf[Exception], // Must be an Exception based on the types

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpClient.scala
@@ -164,7 +164,7 @@ object HttpClient {
       s"$contentLengthStr" +
       s"${userAgent match {
         case Some(uaStr) => s" ${escape("\"")}${escape(uaStr)}${escape("\"")}"
-        case None => "-"
+        case None => " -"
       }}"
   }
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageCollection.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageCollection.scala
@@ -21,8 +21,6 @@ final class PackageCollection(
   universeClient: UniverseClient
 ) {
 
-  private[this] val logger = org.slf4j.LoggerFactory.getLogger(getClass)
-
   val repositoryCache: LoadingCache[RequestSession, Future[List[(universe.v4.model.Repository, Uri)]]] = {
     Caffeine
       .newBuilder()

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageCollection.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageCollection.scala
@@ -21,7 +21,7 @@ final class PackageCollection(
   universeClient: UniverseClient
 ) {
 
-  val repositoryCache: LoadingCache[RequestSession, Future[List[(universe.v4.model.Repository, Uri)]]] = {
+  private[this] lazy val repositoryCache: LoadingCache[RequestSession, Future[List[(universe.v4.model.Repository, Uri)]]] = {
     Caffeine
       .newBuilder()
       .expireAfterWrite(1, TimeUnit.MINUTES)

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageCollection.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageCollection.scala
@@ -1,6 +1,7 @@
 package com.mesosphere.cosmos.repository
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.LoadingCache
 import com.mesosphere.cosmos.error.PackageNotFound
 import com.mesosphere.cosmos.error.VersionNotFound
 import com.mesosphere.cosmos.http.RequestSession
@@ -8,7 +9,6 @@ import com.mesosphere.cosmos.rpc
 import com.mesosphere.http.OriginHostScheme
 import com.mesosphere.universe
 import com.netaporter.uri.Uri
-import com.twitter.cache.caffeine.LoadingFutureCache
 import com.twitter.util.Future
 import com.twitter.util.Throw
 import java.util.concurrent.TimeUnit
@@ -21,24 +21,29 @@ final class PackageCollection(
   universeClient: UniverseClient
 ) {
 
-  private[this] lazy val repositoryCache: LoadingFutureCache[(rpc.v1.model.PackageRepository,
-    RequestSession), (universe.v4.model.Repository, Uri)] = new LoadingFutureCache(
+  private[this] val logger = org.slf4j.LoggerFactory.getLogger(getClass)
+
+  val repositoryCache: LoadingCache[RequestSession, Future[List[(universe.v4.model.Repository, Uri)]]] = {
     Caffeine
       .newBuilder()
       .expireAfterWrite(1, TimeUnit.MINUTES)
-      .build { case (
-        packageRepository: rpc.v1.model.PackageRepository,
-        session: RequestSession) =>
-        val result = universeClient(packageRepository)(session).map((_, packageRepository.uri))
-        result.respond {
-          case Throw(_) =>
-            repositoryCache.evict((packageRepository, session), result)
-            ()
-          case _ => ()
-        }
-        result
+      .build { case session: RequestSession =>
+        packageRepositoryStorage
+          .readCache()
+          .flatMap { packageRepositories =>
+            Future.traverseSequentially(packageRepositories){ packageRepository =>
+              universeClient(packageRepository)(session)
+                .map((_, packageRepository.uri))
+                .respond {
+                  case Throw(_) =>
+                    repositoryCache.invalidate(session)
+                    ()
+                  case _ => ()
+                }
+            }.map(_.toList)
+          }
       }
-  )
+  }
 
   def getPackagesByPackageName(
     packageName: String
@@ -104,15 +109,7 @@ final class PackageCollection(
 
   private[this] def all()(
     implicit session: RequestSession
-  ): Future[List[(universe.v4.model.Repository, Uri)]] = {
-    packageRepositoryStorage
-      .readCache()
-      .flatMap(
-        Future.traverseSequentially(_)(
-          pkgRepo => repositoryCache((pkgRepo, session))
-        ).map(_.toList)
-      )
-  }
+  ): Future[List[(universe.v4.model.Repository, Uri)]] = repositoryCache.get(session)
 }
 
 object PackageCollection {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/ZkRepositoryList.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/ZkRepositoryList.scala
@@ -272,10 +272,10 @@ private final class WriteHandler(
 private final class CreateHandler(
   promise: Promise[List[PackageRepository]],
   repositories: List[PackageRepository]
-) extends  BackgroundCallback {
+) extends BackgroundCallback {
   private[this] val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
-  override def processResult(client: CuratorFramework, event: CuratorEvent): Unit ={
+  override def processResult(client: CuratorFramework, event: CuratorEvent): Unit = {
     if (event.getType == CuratorEventType.CREATE) {
       val code = KeeperException.Code.get(event.getResultCode)
       if (code == KeeperException.Code.OK) {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/service/ServiceUninstaller.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/service/ServiceUninstaller.scala
@@ -144,5 +144,5 @@ object ServiceUninstaller {
 
   val RetryInterval: Duration = 10.seconds
 
-  private val DefaultRetries: Int = 50
+  private val DefaultRetries: Int = 10000
 }


### PR DESCRIPTION
Address [DCOS-40633](https://jira.mesosphere.com/browse/DCOS-40633)

**Problem** :
When multiple requests (e.g.: Package describe requests) try to use `PackageCollection`, cosmos is translating those multiple requests in to multiple non-synchronized calls to ZK to `createOrSet` and this is problematic as only the first create call succeeds and all the rest of the calls throw an error.

**Solution** :
Move the ZK read logic to be inside the caffeine future `LoadingCache` which auto manages multiple requests that result in futures.