### PR TITLE
Cleanup uninstall handler logic

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/CustomEndpointHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/CustomEndpointHandler.scala
@@ -10,4 +10,11 @@ trait CustomEndpointHandler[A, B] extends EndpointHandler[A, B] {
   )(
     implicit session: RequestSession
   ) : Future[Option[B]]
+
+  def orElseGet(b : Future[Option[B]])(alternative: => Future[B]): Future[B] = {
+    b.flatMap {
+      case None => alternative
+      case Some(x) => Future(x)
+    }
+  }
 }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/CustomEndpointHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/CustomEndpointHandler.scala
@@ -1,0 +1,13 @@
+package com.mesosphere.cosmos.handler
+
+import com.mesosphere.cosmos.finch.EndpointHandler
+import com.mesosphere.cosmos.http.RequestSession
+import com.twitter.util.Future
+
+trait CustomEndpointHandler[A, B] extends EndpointHandler[A, B] {
+  def tryCustomPackageManager(
+    a : A
+  )(
+    implicit session: RequestSession
+  ) : Future[Option[B]]
+}

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageInstallHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageInstallHandler.scala
@@ -4,7 +4,6 @@ import com.mesosphere.cosmos.MarathonPackageRunner
 import com.mesosphere.cosmos.error.CosmosException
 import com.mesosphere.cosmos.error.PackageAlreadyInstalled
 import com.mesosphere.cosmos.error.ServiceAlreadyStarted
-import com.mesosphere.cosmos.finch.EndpointHandler
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.render.PackageDefinitionRenderer
 import com.mesosphere.cosmos.repository.PackageCollection
@@ -20,16 +19,65 @@ private[cosmos] final class PackageInstallHandler(
   packageCollection: PackageCollection,
   packageRunner: MarathonPackageRunner,
   customPackageManagerRouter: CustomPackageManagerRouter
-) extends EndpointHandler[rpc.v1.model.InstallRequest, rpc.v2.model.InstallResponse] {
+) extends CustomEndpointHandler[rpc.v1.model.InstallRequest, rpc.v2.model.InstallResponse] {
 
   private[this] lazy val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
-  // scalastyle:off method.length
   override def apply(
     request: rpc.v1.model.InstallRequest
   )(
     implicit session: RequestSession
   ): Future[rpc.v2.model.InstallResponse] = {
+    tryCustomPackageManager(request).flatMap {
+      case Some(customResponse) => Future(customResponse)
+      case None =>
+        packageCollection
+          .getPackageByPackageVersion(
+            request.packageName,
+            request.packageVersion.as[Option[universe.v3.model.Version]]
+          )
+          .flatMap { case (pkg, sourceUri) =>
+            PackageDefinitionRenderer.renderMarathonV2App(
+              sourceUri,
+              pkg,
+              request.options,
+              request.appId
+            ) match {
+              case Some(renderedMarathonJson) =>
+                packageRunner.launch(renderedMarathonJson)
+                  .map { runnerResponse =>
+                    rpc.v2.model.InstallResponse(
+                      packageName = pkg.name,
+                      packageVersion = pkg.version,
+                      appId = Some(runnerResponse.id),
+                      postInstallNotes = pkg.postInstallNotes,
+                      cli = pkg.rewrite(rewriteUrlWithProxyInfo(session.originInfo), identity).cli
+                    )
+                  }
+                  .handle {
+                    case CosmosException(ServiceAlreadyStarted(_), _, _) =>
+                      throw PackageAlreadyInstalled().exception
+                  }
+              case None =>
+                Future {
+                  rpc.v2.model.InstallResponse(
+                    packageName = pkg.name,
+                    packageVersion = pkg.version,
+                    appId = None,
+                    postInstallNotes = pkg.postInstallNotes,
+                    cli = pkg.rewrite(rewriteUrlWithProxyInfo(session.originInfo), identity).cli
+                  )
+                }
+            }
+          }
+    }
+  }
+
+  override def tryCustomPackageManager(
+    request: rpc.v1.model.InstallRequest
+  )(
+    implicit session: RequestSession
+  ): Future[Option[rpc.v2.model.InstallResponse]] = {
     customPackageManagerRouter.getCustomPackageManagerId(
       request.managerId,
       Option(request.packageName),
@@ -38,49 +86,8 @@ private[cosmos] final class PackageInstallHandler(
     ).flatMap {
       case Some((Some(managerId), _, _)) if !managerId.isEmpty =>
         logger.debug(s"Request [$request] requires a custom manager: [$managerId]")
-        customPackageManagerRouter.callCustomPackageInstall(request, managerId)
-      case _ =>
-        packageCollection
-          .getPackageByPackageVersion(
-            request.packageName,
-            request.packageVersion.as[Option[universe.v3.model.Version]]
-          )
-          .flatMap {
-            case (pkg, sourceUri) =>
-              PackageDefinitionRenderer.renderMarathonV2App(
-                sourceUri,
-                pkg,
-                request.options,
-                request.appId
-              ) match {
-                case Some(renderedMarathonJson) =>
-                  packageRunner.launch(renderedMarathonJson)
-                    .map { runnerResponse =>
-                      rpc.v2.model.InstallResponse(
-                        packageName = pkg.name,
-                        packageVersion = pkg.version,
-                        appId = Some(runnerResponse.id),
-                        postInstallNotes = pkg.postInstallNotes,
-                        cli = pkg.rewrite(rewriteUrlWithProxyInfo(session.originInfo), identity).cli
-                      )
-                    }
-                    .handle {
-                      case CosmosException(ServiceAlreadyStarted(_), _, _) =>
-                        throw PackageAlreadyInstalled().exception
-                    }
-                case None =>
-                  Future {
-                    rpc.v2.model.InstallResponse(
-                      packageName = pkg.name,
-                      packageVersion = pkg.version,
-                      appId = None,
-                      postInstallNotes = pkg.postInstallNotes,
-                      cli = pkg.rewrite(rewriteUrlWithProxyInfo(session.originInfo), identity).cli
-                    )
-                  }
-              }
-          }
+        customPackageManagerRouter.callCustomPackageInstall(request, managerId).map(Some(_))
+      case _ => Future(None)
     }
   }
-  // scalastyle:on method.length
 }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ServiceUpdateHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ServiceUpdateHandler.scala
@@ -5,12 +5,10 @@ import com.mesosphere.cosmos.ServiceUpdater
 import com.mesosphere.cosmos.error.AppIdChanged
 import com.mesosphere.cosmos.error.OptionsNotStored
 import com.mesosphere.cosmos.error.VersionUpgradeNotSupportedInOpen
-import com.mesosphere.cosmos.finch.EndpointHandler
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.render.PackageDefinitionRenderer
 import com.mesosphere.cosmos.repository.PackageCollection
 import com.mesosphere.cosmos.rpc
-import com.mesosphere.cosmos.rpc.v1.model.ServiceUpdateRequest
 import com.mesosphere.cosmos.service.CustomPackageManagerRouter
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonAppResponse
@@ -25,7 +23,7 @@ final class ServiceUpdateHandler(
   packageCollection: PackageCollection,
   serviceUpdater: ServiceUpdater,
   customPackageManagerRouter: CustomPackageManagerRouter
-) extends EndpointHandler[rpc.v1.model.ServiceUpdateRequest, rpc.v1.model.ServiceUpdateResponse] {
+) extends CustomEndpointHandler[rpc.v1.model.ServiceUpdateRequest, rpc.v1.model.ServiceUpdateResponse] {
 
   import ServiceUpdateHandler._
 
@@ -36,16 +34,9 @@ final class ServiceUpdateHandler(
   )(
     implicit session: RequestSession
   ): Future[rpc.v1.model.ServiceUpdateResponse] = {
-    customPackageManagerRouter.getCustomPackageManagerId(
-      request.managerId,
-      request.packageName,
-      request.packageVersion,
-      Option(request.appId)
-    ).flatMap {
-      case Some((Some(managerId), Some(pkgName), Some(pkgVersion))) if !managerId.isEmpty =>
-        logger.debug(s"Request [$request] requires a custom manager: [$managerId]")
-        customPackageManagerRouter.callCustomServiceUpdate(request, managerId, pkgName, pkgVersion)
-      case _ =>
+    tryCustomPackageManager(request).flatMap {
+      case Some(customResponse) => Future(customResponse)
+      case None =>
         adminRouter.getApp(request.appId).flatMap { marathonAppResponse =>
           getPackageWithSourceOrThrow(packageCollection, marathonAppResponse.app).flatMap {
             case (packageDefinition, packageSource) =>
@@ -70,6 +61,28 @@ final class ServiceUpdateHandler(
     }
   }
 
+  override def tryCustomPackageManager(
+    request: rpc.v1.model.ServiceUpdateRequest
+  )(
+    implicit session: RequestSession
+  ): Future[Option[rpc.v1.model.ServiceUpdateResponse]] = {
+    customPackageManagerRouter.getCustomPackageManagerId(
+      request.managerId,
+      request.packageName,
+      request.packageVersion,
+      Option(request.appId)
+    ).flatMap {
+      case Some((Some(managerId), Some(pkgName), Some(pkgVersion))) if !managerId.isEmpty =>
+        logger.debug(s"Request [$request] requires a custom manager: [$managerId]")
+        customPackageManagerRouter.callCustomServiceUpdate(
+          request,
+          managerId,
+          pkgName,
+          pkgVersion
+        ).map(Some(_))
+      case _ => Future(None)
+    }
+  }
 }
 
 object ServiceUpdateHandler {
@@ -77,7 +90,7 @@ object ServiceUpdateHandler {
   def update(
     serviceUpdater: ServiceUpdater,
     marathonAppResponse: MarathonAppResponse,
-    serviceUpdateRequest: ServiceUpdateRequest,
+    serviceUpdateRequest: rpc.v1.model.ServiceUpdateRequest,
     packageDefinition: universe.v4.model.PackageDefinition,
     packageSource: Uri
   )(

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/UninstallHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/UninstallHandler.scala
@@ -12,7 +12,6 @@ import com.mesosphere.cosmos.error.MultipleFrameworkIds
 import com.mesosphere.cosmos.error.PackageNotInstalled
 import com.mesosphere.cosmos.error.ServiceUnavailable
 import com.mesosphere.cosmos.error.UninstallNonExistentAppForPackage
-import com.mesosphere.cosmos.finch.EndpointHandler
 import com.mesosphere.cosmos.handler.UninstallHandler._
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.repository.PackageCollection
@@ -36,74 +35,78 @@ private[cosmos] final class UninstallHandler(
   packageCollection: PackageCollection,
   uninstaller: ServiceUninstaller,
   customPackageManagerRouter: CustomPackageManagerRouter
-) extends EndpointHandler[rpc.v1.model.UninstallRequest, rpc.v1.model.UninstallResponse] {
+) extends CustomEndpointHandler[rpc.v1.model.UninstallRequest, rpc.v1.model.UninstallResponse] {
 
   private[this] lazy val logger = org.slf4j.LoggerFactory.getLogger(getClass)
 
   private type FwIds = List[String]
 
-  // scalastyle:off cyclomatic.complexity
-  // scalastyle:off method.length
   override def apply(
     req: rpc.v1.model.UninstallRequest
   )(
     implicit session: RequestSession
   ): Future[rpc.v1.model.UninstallResponse] = {
     getMarathonApps(req.packageName, req.appId)
-      .flatMap { apps =>
-        customPackageManagerRouter.getCustomPackageManagerId(
-          req.managerId,
-          Option(req.packageName),
-          apps.head.packageVersion,
-          Option(req.appId.getOrElse(apps.head.id))
-        ).flatMap {
-          case Some((Some(managerId), Some(pkgName), Some(pkgVersion))) if !managerId.isEmpty =>
-            logger.debug(s"Request [$req] requires a custom manager: [$managerId]")
-            customPackageManagerRouter.callCustomPackageUninstall(
-              req, managerId, pkgName, pkgVersion, req.appId.getOrElse(apps.head.id))
-          case _ => {
-            val uninstallOps = createUninstallOperations(req.packageName, apps)
-            val all = req.all.contains(true)
-            if (!(all || uninstallOps.size <= 1)) {
-              throw AmbiguousAppId(req.packageName, uninstallOps.map(_._2.appId)).exception
-            }
-            Future.collect(
-              uninstallOps
-                .map { case (app, uninstallOp) => (app, runUninstall(uninstallOp)) }
-                .map { case (app, f) => f.map(app -> _) }
-            )
-            .flatMap { uninstallDetails =>
-              Future.collect(
-                uninstallDetails.map { case (app, detail) =>
-                  getPackageWithSource(packageCollection, app).map { res =>
-                    (
-                      detail,
-                      res match {
-                        case Some((pkg, _)) => pkg.postUninstallNotes
-                        case None => None
-                      }
-                    )
-                  }
-                }
-              )
-            }
-            .map { detailsAndNotes =>
-              val results = detailsAndNotes.map { case (detail, postUninstallNotes) =>
-                rpc.v1.model.UninstallResult(
-                  detail.packageName,
-                  detail.appId,
-                  detail.packageVersion,
-                  postUninstallNotes
-                )
-              }
-              rpc.v1.model.UninstallResponse(results.toList)
-            }
-          }
+      .map(apps => createUninstallOperations(req.packageName, apps))
+      .map { uninstallOps =>
+        val all = req.all.contains(true)
+        if (all || uninstallOps.size <= 1) {
+          uninstallOps
+        } else {
+          throw AmbiguousAppId(req.packageName, uninstallOps.map(_._2.appId)).exception
         }
       }
+      .flatMap { apps =>
+        Future.collect {
+          apps.map { case (app, op) =>
+            customPackageManagerRouter
+              .getCustomPackageManagerId(
+                req.managerId,
+                Some(req.packageName),
+                app.packageVersion,
+                Some(req.appId.getOrElse(app.id))
+              )
+              .flatMap {
+                case Some((Some(managerId), Some(pkgName), Some(pkgVersion))) if !managerId.isEmpty =>
+                  logger.debug(s"Request [$req] requires a custom manager: [$managerId]")
+                  customPackageManagerRouter.callCustomPackageUninstall(
+                    req,
+                    managerId,
+                    pkgName,
+                    pkgVersion,
+                    req.appId.getOrElse(app.id)
+                  )
+                case _ => opToUninstallResponse(op, app)
+              }
+          }
+        }.map(_.map(_.results).toList.flatten).map(rpc.v1.model.UninstallResponse(_))
+      }
   }
-  // scalastyle:on method.length
-  // scalastyle:on cyclomatic.complexity
+
+  private def opToUninstallResponse(
+    uninstallOp: UninstallOperation,
+    app: MarathonApp
+  )(
+    implicit session: RequestSession
+  ): Future[rpc.v1.model.UninstallResponse] = {
+    Future
+      .join(
+        runUninstall(uninstallOp),
+        getPackageWithSource(packageCollection, app).map(_.flatMap(_._1.postUninstallNotes))
+      )
+      .map { case (details, postUninstallNotes) =>
+        rpc.v1.model.UninstallResponse(
+          List(
+            rpc.v1.model.UninstallResult(
+              details.packageName,
+              details.appId,
+              details.packageVersion,
+              postUninstallNotes
+            )
+          )
+        )
+      }
+  }
 
   private def runUninstall(
     uninstallOp: UninstallOperation
@@ -270,6 +273,12 @@ private[cosmos] final class UninstallHandler(
     }
     uninstallOperations
   }
+
+  override def tryCustomPackageManager(
+    req: rpc.v1.model.UninstallRequest
+  )(
+    implicit session: RequestSession
+  ): Future[Option[rpc.v1.model.UninstallResponse]] = throw new NotImplementedError()
 }
 
 object UninstallHandler {


### PR DESCRIPTION
Sidenote : Please cleanup all the branches when you are done.

- Removed the cyclomatic complexity. The code was too complicated to be edited by some one in the future.
- We should think about deprecating the `--all` flag in CLI. If not one is using it, removing it makes sense.

- We should have augmented `EndpointHanlder` to contain a generic routing logic for custom package manager. With this in mind, I have created `CustomEndpointHanlder` to enable us to move the routing logic to `EndpointHanlder` in future. When we had design doc for CustomPackageManager, we had a superficial header/payload based proxying to custom manager. We significantly deviated from this (especially in `UninstallHanlder`) and this PR fixes some of this behavior. 
- Also, by doing the above, it makes is trivial to get rid of the custom package manager logic if we ever need to.