### PR TITLE
cosmos-common: fix typo in the error message

### DIFF
--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/CustomPackageManagerNotFound.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/CustomPackageManagerNotFound.scala
@@ -7,7 +7,7 @@ import io.circe.generic.semiauto.deriveEncoder
 
 final case class CustomPackageManagerNotFound(managerId: AppId) extends CosmosError {
   override def data: Option[JsonObject] = CosmosError.deriveData(this)
-  override def message: String = s"the custom manager: '$managerId', is not installed for this package'"
+  override def message: String = s"the custom manager: '$managerId', is not installed for this package"
 }
 
 object CustomPackageManagerNotFound {


### PR DESCRIPTION
It seems we added an extra single quote at the end of the message that should be removed.

```
dcos package install --yes kubernetes-cluster
By Deploying, you agree to the Terms and Conditions https://mesosphere.com/catalog-terms-conditions/#certified-services
Kubernetes on DC/OS.

	Documentation: https://docs.mesosphere.com/service-docs/kubernetes-cluster
	Issues: https://github.com/mesosphere/dcos-kubernetes-quickstart/issues
Installing Marathon app for package [kubernetes-cluster] version [stub-universe]
the custom manager: '/kubernetes', is not installed for this package'

```