### PR TITLE
Add logging to the uninstall function, fix looking for SDK_UNINSTALL env var

### DIFF
--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/UninstallFailed.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/UninstallFailed.scala
@@ -1,0 +1,15 @@
+package com.mesosphere.cosmos.error
+
+import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
+import io.circe.{Encoder, JsonObject}
+import io.circe.generic.semiauto.deriveEncoder
+
+final case class UninstallFailed(appId: AppId) extends CosmosError {
+  override def data: Option[JsonObject] = CosmosError.deriveData(this)
+  override def message: String = s"Uninstall of app [$appId] failed."
+}
+
+object UninstallFailed {
+  implicit val encoder: Encoder[UninstallFailed] = deriveEncoder
+}
+

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/Requests.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/Requests.scala
@@ -208,6 +208,13 @@ object Requests {
     }
   }
 
+  def waitForMarathonAppToDisappear(appId: AppId): Unit = {
+    eventually(timeout(5.minutes), interval(5.seconds)) {
+      assertResult(false)(isMarathonAppInstalled(appId))
+    }
+    ()
+  }
+
   def waitForDeployments(): Unit = {
     eventually(timeout(5.minutes), interval(5.seconds)) {
       listDeployments() shouldBe empty

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServiceDescribeSpec.scala
@@ -66,6 +66,7 @@ final class ServiceDescribeSpec extends FeatureSpec with Matchers {
       assertResult(Status.Ok)(serviceDescribeResponse.status)
 
       Requests.uninstall("cassandra", managerId = Some(ItObjects.customManagerAppName))
+      Requests.waitForMarathonAppToDisappear(appId)
     }
   }
 

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/ServiceUpdateSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/ServiceUpdateSpec.scala
@@ -155,6 +155,7 @@ class ServiceUpdateSpec extends FeatureSpec with Matchers {
       assertResult(Status.Ok)(serviceUpdateResponse.status)
 
       Requests.uninstall("cassandra", managerId = Some(ItObjects.customManagerAppName))
+      Requests.waitForMarathonAppToDisappear(appId)
     }
   }
 

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
@@ -201,7 +201,7 @@ final class UninstallHandlerSpec extends FreeSpec with Eventually with SpanSugar
   def waitUntilDeployed(appId: AppId, clue: Any): Assertion = {
     eventually(timeout(2.minutes), interval(10.seconds)) {
       // TODO Get the CommonsVersionLabel ("v1") from the Marathon app, instead of hardcoding
-      val version = Await.result(adminRouter.getApp(appId).map(_.app.labels.getOrElse(UninstallHandler.SdkVersionLabel, "v1")))
+      val version = Await.result(adminRouter.getApp(appId).map(_.app.getLabel(UninstallHandler.SdkVersionLabel).getOrElse("v1")))
       val statusFuture = adminRouter.getSdkServicePlanStatus(appId, version, "deploy")
 
       assertResult(Status.Ok, clue)(Await.result(statusFuture).status)

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/AdminRouter.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/AdminRouter.scala
@@ -29,10 +29,6 @@ class AdminRouter(
     marathon.getAppOption(appId)
   }
 
-  def getAppRawJson(appId: AppId)(implicit session: RequestSession): Future[JsonObject] = {
-    marathon.getAppRawJson(appId)
-  }
-
   def getApp(appId: AppId)(implicit session: RequestSession): Future[MarathonAppResponse] = {
     marathon.getApp(appId)
   }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonClient.scala
@@ -93,16 +93,6 @@ class MarathonClient(
     }
   }
 
-  def getAppRawJson(appId: AppId)(implicit session: RequestSession): Future[JsonObject] = {
-    getAppResponse(appId).map {
-      _ match {
-        // No need to return an option as Some json should always be present.
-        case Some(response) => decodeJsonTo[JsonObject](response)
-        case None => throw MarathonAppNotFound(appId).exception // Should not happen
-      }
-    }
-  }
-
   def getApp(appId: AppId)(implicit session: RequestSession): Future[MarathonAppResponse] = {
     getAppOption(appId).map { appOption =>
       appOption.getOrElse(throw MarathonAppNotFound(appId).exception)

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/service/ServiceUninstaller.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/service/ServiceUninstaller.scala
@@ -76,8 +76,8 @@ final class ServiceUninstaller(
   ): Future[StepResult] = {
     getApp(appId).flatMap {
       case Some(schedulerApp) =>
-        val schedulerVersion = schedulerApp.app.labels.getOrElse(UninstallHandler.SdkVersionLabel, "v1")
-        val sdkUninstallLabelPresent = schedulerApp.app.labels.getOrElse(UninstallHandler.SdkUninstallEnvvar, "false").toBoolean
+        val schedulerVersion = schedulerApp.app.getLabel(UninstallHandler.SdkVersionLabel).getOrElse("v1")
+        val sdkUninstallLabelPresent = schedulerApp.app.getEnv(UninstallHandler.SdkUninstallEnvvar).exists(_.toBoolean)
         if (sdkUninstallLabelPresent) {
           checkSdkUninstallCompleted(
             appId,

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/service/ServiceUninstaller.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/service/ServiceUninstaller.scala
@@ -88,6 +88,7 @@ final class ServiceUninstaller(
             case _ => Retry
           }
         } else {
+          logger.warn(s"No SDK_UNINSTALL label present on app $appId: $schedulerApp")
           Future(Retry)
         }
       case None =>


### PR DESCRIPTION
- More verbose logging to be able to say at which step of uninstall you are or the process failed
- SDK_UNINSTALL env was not being looked at properly
- reduced number of marathon requests (we pulled app two times for unknown reason)
- refactored the overall flow to a pipeline of steps

JIRA issues: DCOS_OSS-4662