### PR TITLE
[TOOLS] Change scalauri to lemonlabs

### DIFF
--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/circe/Decoders.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/circe/Decoders.scala
@@ -7,7 +7,7 @@ import com.mesosphere.cosmos.finch.MediaTypedDecoder
 import com.mesosphere.error.Result
 import com.mesosphere.error.ResultOps
 import com.mesosphere.http.MediaType
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Decoder
 import io.circe.DecodingFailure
 import io.circe.Error

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/circe/Encoders.scala
@@ -4,7 +4,7 @@ import cats.data.Ior
 import com.mesosphere.cosmos.error.CosmosException
 import com.mesosphere.cosmos.rpc
 import com.mesosphere.universe.common.ByteBuffers
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.finagle.http.Status
 import com.twitter.util.Duration
 import com.twitter.util.StorageUnit

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/EndpointUriConnection.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/EndpointUriConnection.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.error
 
 import com.mesosphere.cosmos.circe.Encoders._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Encoder
 import io.circe.JsonObject
 import io.circe.generic.semiauto.deriveEncoder

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/EndpointUriSyntax.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/EndpointUriSyntax.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.error
 
 import com.mesosphere.cosmos.circe.Encoders._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Encoder
 import io.circe.JsonObject
 import io.circe.generic.semiauto.deriveEncoder

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/GenericHttpError.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/GenericHttpError.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.error
 
 import com.mesosphere.cosmos.circe.Encoders._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.circe.Encoder
 import io.circe.JsonObject

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/IndexNotFound.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/IndexNotFound.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.error
 
 import com.mesosphere.cosmos.circe.Encoders._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Encoder
 import io.circe.JsonObject
 import io.circe.generic.semiauto.deriveEncoder

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/RepositoryAlreadyPresent.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/RepositoryAlreadyPresent.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos.error
 
 import cats.data.Ior
 import com.mesosphere.cosmos.circe.Encoders._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.JsonObject
 import io.circe.syntax._
 

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/RepositoryNotPresent.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/RepositoryNotPresent.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos.error
 
 import cats.data.Ior
 import com.mesosphere.cosmos.circe.Encoders._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.JsonObject
 import io.circe.syntax._
 

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/UnsupportedRepositoryUri.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/error/UnsupportedRepositoryUri.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.error
 
 import com.mesosphere.cosmos.circe.Encoders._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Encoder
 import io.circe.JsonObject
 import io.circe.generic.semiauto.deriveEncoder

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/finch/RequestValidators.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/finch/RequestValidators.scala
@@ -8,7 +8,7 @@ import com.mesosphere.http.MediaType
 import com.mesosphere.http.OriginHostScheme
 import com.mesosphere.util.ForwardedProtoHeader
 import com.mesosphere.util.UrlSchemeHeader
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.finagle.http.Fields
 import io.finch._
 import shapeless.::

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/model/PackageOrigin.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/model/PackageOrigin.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.cosmos.model
 
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 
 sealed trait PackageOrigin {
   val uri: Uri

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
@@ -16,7 +16,7 @@ import com.mesosphere.universe
 import com.mesosphere.universe.common.ByteBuffers
 import com.mesosphere.universe.common.JsonUtil
 import com.mesosphere.universe.v4.model.PackageDefinition
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Json
 import io.circe.JsonObject
 import io.circe.syntax._

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/PackageRepository.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/PackageRepository.scala
@@ -5,7 +5,7 @@ import com.mesosphere.cosmos.finch.MediaTypedEncoder
 import com.mesosphere.cosmos.http.MediaTypes
 import com.mesosphere.cosmos.circe.Decoders._
 import com.mesosphere.cosmos.circe.Encoders._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.generic.semiauto._

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/PackageRepositoryAddRequest.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/PackageRepositoryAddRequest.scala
@@ -5,7 +5,7 @@ import com.mesosphere.cosmos.finch.MediaTypedRequestDecoder
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.circe.Decoders.decodeUri
 import com.mesosphere.cosmos.circe.Encoders.encodeUri
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.generic.semiauto.deriveDecoder

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/PackageRepositoryDeleteRequest.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/rpc/v1/model/PackageRepositoryDeleteRequest.scala
@@ -5,7 +5,7 @@ import com.mesosphere.cosmos.finch.MediaTypedRequestDecoder
 import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.circe.Decoders.decodeUri
 import com.mesosphere.cosmos.circe.Encoders.encodeUri
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.generic.semiauto.deriveDecoder

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/thirdparty/marathon/model/AppId.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/thirdparty/marathon/model/AppId.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.cosmos.thirdparty.marathon.model
 
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.syntax._

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/thirdparty/marathon/model/MarathonApp.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/thirdparty/marathon/model/MarathonApp.scala
@@ -6,7 +6,7 @@ import com.mesosphere.cosmos.model.PackageOrigin
 import com.mesosphere.cosmos.model.StorageEnvelope
 import com.mesosphere.error.ResultOps
 import com.mesosphere.universe
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Decoder
 import io.circe.JsonObject
 import io.circe.generic.semiauto._

--- a/cosmos-common/src/main/scala/com/mesosphere/universe/bijection/UniverseConversions.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/universe/bijection/UniverseConversions.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.universe.bijection
 
 import com.mesosphere.universe
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.bijection.Bijection
 import com.twitter.bijection.Conversion
 import com.twitter.bijection.Conversion.asMethod

--- a/cosmos-common/src/main/scala/com/mesosphere/universe/v2/model/PackageFiles.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/universe/v2/model/PackageFiles.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.universe.v2.model
 
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.JsonObject

--- a/cosmos-common/src/main/scala/com/mesosphere/universe/v3/model/License.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/universe/v3/model/License.scala
@@ -2,7 +2,7 @@ package com.mesosphere.universe.v3.model
 
 import com.mesosphere.cosmos.circe.Decoders._
 import com.mesosphere.cosmos.circe.Encoders._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.generic.semiauto.deriveDecoder

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/IntegrationBeforeAndAfterAll.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/IntegrationBeforeAndAfterAll.scala
@@ -5,7 +5,7 @@ import com.mesosphere.cosmos.circe.Decoders.parse
 import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import com.twitter.finagle.http.Status
 import io.circe.jawn.decode
 import java.io.InputStreamReader

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RequestErrorsSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RequestErrorsSpec.scala
@@ -6,7 +6,7 @@ import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepositoryAddRequest
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient._
 import com.mesosphere.http.CompoundMediaTypeParser
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import com.twitter.finagle.http.Fields
 import com.twitter.finagle.http.Status
 import io.circe.Json

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/Requests.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/Requests.scala
@@ -11,7 +11,7 @@ import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.cosmos.thirdparty.marathon.model.Deployment
 import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonApp
 import com.mesosphere.universe
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.finagle.http.Response
 import com.twitter.util.Await
 import io.circe.Decoder

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/RoundTrips.scala
@@ -3,7 +3,7 @@ package com.mesosphere.cosmos
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.universe
 import com.mesosphere.util.RoundTrip
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.JsonObject
 
 object RoundTrips {

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServicesIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/ServicesIntegrationSpec.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.cosmos
 
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import com.twitter.conversions.storage._
 import com.twitter.finagle.http.RequestBuilder
 import com.twitter.finagle.http.Status

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/PackageRepositorySpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/PackageRepositorySpec.scala
@@ -20,8 +20,8 @@ import com.mesosphere.cosmos.rpc.v1.model.ErrorResponse
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
 import com.mesosphere.universe.MediaTypes
 import com.mesosphere.universe.v2.model.UniverseVersion
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import com.twitter.bijection.Conversion.asMethod
 import com.twitter.finagle.http.Status
 import io.netty.handler.codec.http.HttpResponseStatus

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/PackageSearchSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/PackageSearchSpec.scala
@@ -58,10 +58,10 @@ final class PackageSearchSpec extends FreeSpec with IntegrationBeforeAndAfterAll
 
 private object PackageSearchSpec extends TableDrivenPropertyChecks {
 
-  val uri = TestContext.fromSystemProperties().uri
+  val uri = TestContext.fromSystemProperties().uri.toUrl
   val originInfo = OriginHostScheme(
-    s"${uri.host.get}:${uri.port.get}",
-    OriginHostScheme.Scheme(uri.scheme.get).get
+    s"${uri.hostOption.get}:${uri.port.get}",
+    OriginHostScheme.Scheme(uri.schemeOption.get).get
   )
 
   val ArangodbSearchResult = SearchResult(

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/ResourceProxyHandlerIntegrationSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/ResourceProxyHandlerIntegrationSpec.scala
@@ -8,7 +8,7 @@ import com.mesosphere.cosmos.http.CosmosRequests
 import com.mesosphere.cosmos.http.TestContext
 import com.mesosphere.cosmos.rpc
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.finagle.http.Fields
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.stats.StatsReceiver
@@ -77,7 +77,7 @@ final class ResourceProxyHandlerIntegrationSpec extends FreeSpec
     }
     val numberOfBytesRead = Await.result(future)
     numberOfBytesRead should be > 0
-    val rawUrl = parsedUrl
+    val rawUrl = parsedUrl.toUrl
       .query
       .params
       .find(x => x._1.equals("url"))

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/handler/UninstallHandlerSpec.scala
@@ -15,7 +15,7 @@ import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient.CosmosClient
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.universe.v2.model.PackageDetailsVersion
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import com.twitter.finagle.http.Fields
 import com.twitter.finagle.http.Response
 import com.twitter.finagle.http.Status

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/http/CosmosRequests.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos.http
 
 import com.mesosphere.cosmos.rpc
 import com.mesosphere.http.MediaType
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 
 object CosmosRequests {
 

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/repository/UniverseClientSpec.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/repository/UniverseClientSpec.scala
@@ -7,8 +7,8 @@ import com.mesosphere.cosmos.error.UniverseClientHttpError
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
 import com.mesosphere.cosmos.test.CosmosIntegrationTestClient
 import com.mesosphere.universe
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import com.twitter.util.Await
 import com.twitter.util.Throw
 import io.netty.handler.codec.http.HttpResponseStatus
@@ -31,7 +31,7 @@ final class UniverseClientSpec extends FreeSpec with Matchers {
       )
     }
 
-    val baseRepoUri: Uri = "https://downloads.mesosphere.com/universe/dce867e9af73b85172d5a36bf8114c69b3be024e"
+    val baseRepoUri = "https://downloads.mesosphere.com/universe/dce867e9af73b85172d5a36bf8114c69b3be024e"
 
     def repository(repoFilename: String): PackageRepository = {
       PackageRepository("repo", baseRepoUri / repoFilename)

--- a/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/test/CosmosIntegrationTestClient.scala
+++ b/cosmos-integration-tests/src/main/scala/com/mesosphere/cosmos/test/CosmosIntegrationTestClient.scala
@@ -11,8 +11,8 @@ import com.mesosphere.cosmos.dcosUri
 import com.mesosphere.cosmos.http.HttpRequest
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.http.TestContext
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import com.twitter.conversions.storage._
 import com.twitter.finagle.Service
 import com.twitter.finagle.SimpleFilter

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/AdminRouterClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/AdminRouterClient.scala
@@ -5,8 +5,8 @@ import com.mesosphere.cosmos.rpc.MediaTypes
 import com.mesosphere.cosmos.thirdparty.adminrouter.model.DcosVersion
 import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.util
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import com.twitter.finagle.Service
 import com.twitter.finagle.http._
 import com.twitter.util.Await

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Cosmos.scala
@@ -37,7 +37,7 @@ import com.mesosphere.cosmos.service.CustomPackageManagerRouter
 import com.mesosphere.cosmos.service.ServiceUninstaller
 import com.mesosphere.universe
 import com.mesosphere.util.UrlSchemeHeader
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.app.App
 import com.twitter.finagle.Http
 import com.twitter.finagle.ListeningServer
@@ -190,7 +190,7 @@ trait CosmosApp
   }
 
   private[this] def configureDcosClients(): Try[AdminRouter] = {
-    import com.netaporter.uri.dsl._
+    import io.lemonlabs.uri.dsl._
 
     Try(dcosUri())
       .map { dh =>

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Flaggables.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Flaggables.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos
 
 import com.mesosphere.cosmos.model.ZooKeeperUri
 import com.mesosphere.error.ResultOps
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.app.Flaggable
 import com.twitter.conversions.storage._
 import com.twitter.util.StorageUnit

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/HttpProxySupport.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.cosmos
 
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import java.net.Authenticator.RequestorType
 import java.net.Authenticator
 import java.net.PasswordAuthentication
@@ -172,8 +172,8 @@ private[cosmos] object HttpProxySupport {
           case _ => None
         }
 
-        val passAuth = uriOpt.flatMap {
-          case Uri(_, Some(user), Some(pass), _, _, _, _, _) =>
+        val passAuth = uriOpt.map(_.toUrl).map(url => (url.user, url.password)).flatMap {
+          case (Some(user), Some(pass)) =>
             Some(new PasswordAuthentication(user, pass.toCharArray))
           case _ => None
         }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonClient.scala
@@ -11,11 +11,13 @@ import com.mesosphere.cosmos.thirdparty.marathon.model.Deployment
 import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonAppResponse
 import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonAppsResponse
 import com.mesosphere.error.ResultOps
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import com.twitter.finagle.Service
 import com.twitter.finagle.http._
 import com.twitter.util.Future
+import io.lemonlabs.uri.QueryString
+import io.lemonlabs.uri.Url
 import io.netty.handler.codec.http.HttpResponseStatus
 import org.jboss.netty.handler.codec.http.HttpMethod
 
@@ -62,7 +64,7 @@ class MarathonClient(
   ): Future[Response] = {
     client(
       put(
-        "v2" / "apps" / appId.toUri ? ("force" -> "true"),
+        Url(path = "v2" / "apps" / appId.toUri,  query = QueryString.fromPairs("force" -> "true")),
         Json.fromJsonObject(appJson)
       )
     )
@@ -74,10 +76,8 @@ class MarathonClient(
     implicit session: RequestSession
   ): Future[Option[MarathonAppResponse]] = {
     getAppResponse(appId).map {
-      _ match {
-        case Some(response) => Some(decodeJsonTo[MarathonAppResponse](response))
-        case None => None
-      }
+      case Some(response) => Some(decodeJsonTo[MarathonAppResponse](response))
+      case None => None
     }
   }
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonClient.scala
@@ -112,9 +112,10 @@ class MarathonClient(
   ): Future[Response] = {
     val uriPath = "v2" / "apps" / appId.toUri
 
-    force match {
-      case true => client(delete(uriPath ? ("force" -> "true")))
-      case false => client(delete(uriPath))
+    if (force) {
+      client(delete(uriPath ? ("force" -> "true")))
+    } else {
+      client(delete(uriPath))
     }
   }
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/MesosMasterClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/MesosMasterClient.scala
@@ -1,12 +1,13 @@
 package com.mesosphere.cosmos
 
 import com.mesosphere.cosmos.http.RequestSession
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import com.twitter.finagle.Service
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.http.Response
 import com.twitter.util.Future
+import io.lemonlabs.uri.QueryString
 import org.jboss.netty.handler.codec.http.HttpMethod
 
 class MesosMasterClient(
@@ -19,7 +20,7 @@ class MesosMasterClient(
   )(
     implicit session: RequestSession
   ): Future[thirdparty.mesos.master.model.MesosFrameworkTearDownResponse] = {
-    val formData = Uri.empty.addParam("frameworkId", frameworkId)
+    val formData = QueryString.fromPairs("frameworkId" -> frameworkId).toString()
     /* scala-uri makes it convenient to encode the actual framework id, but it will think its for
      * a Uri so we strip the leading '?' that signifies the start of a query string
      */

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/ServiceClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/ServiceClient.scala
@@ -10,6 +10,7 @@ import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.error.ResultOps
 import com.mesosphere.http.MediaType
 import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import com.twitter.finagle.http.Fields
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.http.RequestBuilder
@@ -105,7 +106,7 @@ abstract class ServiceClient(baseUri: Uri) {
     implicit session: RequestSession
   ): RequestBuilder[RequestBuilder.Valid, Nothing] = {
     RequestBuilder()
-      .url(s"$cleanedBaseUri${uri.toString}")
+      .url((cleanedBaseUri / uri).toStringRaw)
       .addHeader(Fields.UserAgent, s"cosmos/$cosmosVersion")
       .addHeaders(
         session

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/ServiceClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/ServiceClient.scala
@@ -9,7 +9,7 @@ import com.mesosphere.cosmos.http.MediaTypes
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.error.ResultOps
 import com.mesosphere.http.MediaType
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.finagle.http.Fields
 import com.twitter.finagle.http.Request
 import com.twitter.finagle.http.RequestBuilder

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Services.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Services.scala
@@ -5,7 +5,7 @@ import com.mesosphere.cosmos.error.CosmosException
 import com.mesosphere.cosmos.error.Forbidden
 import com.mesosphere.cosmos.error.ServiceUnavailable
 import com.mesosphere.cosmos.error.Unauthorized
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.finagle.ChannelException
 import com.twitter.finagle.Filter
 import com.twitter.finagle.Http

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/Uris.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/Uris.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.cosmos
 
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.util.Try
 
 object Uris {
@@ -9,11 +9,11 @@ object Uris {
   private[this] val httpPort = 80
 
   def extractHostAndPort(uri: Uri): Try[ConnectionDetails] = Try {
-
-    (uri.scheme, uri.host, uri.port) match {
-      case (Some("https"), Some(h), p) => ConnectionDetails(h, p.getOrElse(httpsPort), tls = true)
-      case (Some("http"), Some(h), p) => ConnectionDetails(h, p.getOrElse(httpPort), tls = false)
-      case (_, _, _) => throw err(uri.toString)
+    val url = uri.toUrl
+    (url.schemeOption, url.hostOption, url.port) match {
+      case (Some("https"), Some(h), p) => ConnectionDetails(h.toString, p.getOrElse(httpsPort), tls = true)
+      case (Some("http"), Some(h), p) => ConnectionDetails(h.toString, p.getOrElse(httpPort))
+      case (_, _, _) => throw err(url.toString)
     }
   }
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageRepositoryAddHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/PackageRepositoryAddHandler.scala
@@ -24,7 +24,7 @@ private[cosmos] final class PackageRepositoryAddHandler(
     implicit session: RequestSession
   ): Future[rpc.v1.model.PackageRepositoryAddResponse] = {
     val repository = rpc.v1.model.PackageRepository(request.name, request.uri)
-    request.uri.scheme match {
+    request.uri.schemeOption match {
       case Some("http") | Some("https") =>
         checkThatRepoWorks(repository)
           .flatMap { _ =>

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ResourceProxyHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ResourceProxyHandler.scala
@@ -7,7 +7,7 @@ import com.mesosphere.cosmos.error.InvalidContentLengthLimit
 import com.mesosphere.cosmos.error.ResourceTooLarge
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.repository.PackageCollection
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.finagle.http.Fields
 import com.twitter.finagle.http.Response
 import com.twitter.finagle.http.Status
@@ -85,9 +85,9 @@ object ResourceProxyHandler {
   }
 
   def getFileNameFromUrl(url: Uri): Option[String] = {
-    url.pathParts match {
-      case _ :+ last if !last.part.isEmpty => Some(last.part)
-      case _ :+ secondLast :+ last if last.part.isEmpty => Some(secondLast.part)
+    url.path.parts match {
+      case _ :+ last if !last.isEmpty => Some(last)
+      case _ :+ secondLast :+ last if last.isEmpty => Some(secondLast)
       case _ => None
     }
   }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ServiceUpdateHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/ServiceUpdateHandler.scala
@@ -14,7 +14,7 @@ import com.mesosphere.cosmos.thirdparty.marathon.model.AppId
 import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonAppResponse
 import com.mesosphere.universe
 import com.mesosphere.universe.common.JsonUtil
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.util.Future
 import io.circe.JsonObject
 

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/UninstallHandler.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/UninstallHandler.scala
@@ -116,7 +116,7 @@ private[cosmos] final class UninstallHandler(
   )(
     implicit session: RequestSession
   ): Future[UninstallDetails] = {
-    destroyMarathonApp(op.appId)(session = session) flatMap { _ =>
+    destroyMarathonApp(op.appId) flatMap { _ =>
       op.frameworkName match {
         case Some(fwName) =>
           lookupFrameworkIds(fwName).flatMap {
@@ -216,7 +216,10 @@ private[cosmos] final class UninstallHandler(
     adminRouter.deleteApp(appId, force = true).map { resp =>
       resp.status match {
         case Status.Ok => MarathonAppDeleteSuccess()
-        case _ => throw MarathonAppDeleteError(appId).exception
+        case _ => {
+          logger.info(s"Marathon responded with error : [${resp.status}], ${resp.contentString}")
+          throw MarathonAppDeleteError(appId).exception
+        }
       }
     }
   }

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/package.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/handler/package.scala
@@ -6,7 +6,7 @@ import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.repository.PackageCollection
 import com.mesosphere.cosmos.thirdparty.marathon.model.MarathonApp
 import com.mesosphere.universe
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.util.Future
 
 package object handler {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/package.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/package.scala
@@ -3,7 +3,7 @@ package com.mesosphere
 import com.mesosphere.cosmos.Flaggables._
 import com.mesosphere.cosmos.model.ZooKeeperUri
 import com.mesosphere.error.ResultOps
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.app.GlobalFlag
 import com.twitter.conversions.storage._
 import com.twitter.conversions.time._

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageCollection.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageCollection.scala
@@ -8,7 +8,7 @@ import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.rpc
 import com.mesosphere.http.OriginHostScheme
 import com.mesosphere.universe
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.util.Future
 import com.twitter.util.Throw
 import java.util.concurrent.TimeUnit

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageSourcesStorage.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/PackageSourcesStorage.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos.repository
 
 import cats.data.Ior
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.util.Future
 
 private[cosmos] trait PackageSourcesStorage {

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/UniverseClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/UniverseClient.scala
@@ -25,7 +25,7 @@ import com.mesosphere.http.MediaType
 import com.mesosphere.universe
 import com.mesosphere.universe.MediaTypes
 import com.mesosphere.universe.bijection.UniverseConversions._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.bijection.Conversion.asMethod
 import com.twitter.finagle.http.Fields
 import com.twitter.finagle.stats.NullStatsReceiver

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/ZkRepositoryList.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/ZkRepositoryList.scala
@@ -12,7 +12,7 @@ import com.mesosphere.cosmos.model.ZooKeeperUri
 import com.mesosphere.cosmos.repository.DefaultRepositories._
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
 import com.mesosphere.error.ResultOps
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.finagle.stats.Stat
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.util.Timer

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/package.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/repository/package.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos
 
 import com.mesosphere.http.OriginHostScheme
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try

--- a/cosmos-test-common/src/main/scala/com/mesosphere/Generators.scala
+++ b/cosmos-test-common/src/main/scala/com/mesosphere/Generators.scala
@@ -1,7 +1,7 @@
 package com.mesosphere
 
 import com.mesosphere.http.MediaType
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.testing.instances._
 import java.nio.ByteBuffer
 import java.util.UUID

--- a/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/http/TestContext.scala
+++ b/cosmos-test-common/src/main/scala/com/mesosphere/cosmos/http/TestContext.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.http
 
 import com.mesosphere.http.OriginHostScheme
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import org.slf4j.LoggerFactory
 
 final case class TestContext(
@@ -30,7 +30,7 @@ object TestContext {
       token,
       OriginHostScheme(
         extractHostFromUri(url),
-        OriginHostScheme.Scheme(url.scheme.get).get
+        OriginHostScheme.Scheme(url.schemeOption.get).get
       )
     )
   }
@@ -41,12 +41,10 @@ object TestContext {
       .getOrElse(throw new AssertionError(s"Missing system property '$property' "))
   }
 
-  def extractHostFromUri(uri: Uri): String = {
-    s"${uri.host.get}${
-      uri.port match {
-        case Some(x) => s":$x"
-        case None => ""
-      }
-    }"
-  }
+  def extractHostFromUri(uri: Uri): String = s"${uri.toUrl.hostOption.get}${
+    uri.toUrl.port match {
+      case Some(x) => s":$x"
+      case None => ""
+    }
+  }"
 }

--- a/cosmos-test-common/src/main/scala/com/mesosphere/universe/test/TestingPackages.scala
+++ b/cosmos-test-common/src/main/scala/com/mesosphere/universe/test/TestingPackages.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.universe.test
 
 import com.mesosphere.universe
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import io.circe.Json
 import io.circe.JsonObject
 import io.circe.syntax._

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/HttpClientSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/HttpClientSpec.scala
@@ -3,8 +3,8 @@ package com.mesosphere.cosmos
 import com.mesosphere.cosmos.error.CosmosException
 import com.mesosphere.cosmos.error.EndpointUriSyntax
 import com.mesosphere.universe
-import com.netaporter.uri.Uri
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.Uri
+import io.lemonlabs.uri.dsl._
 import com.twitter.finagle.stats.NullStatsReceiver
 import com.twitter.finagle.stats.StatsReceiver
 import com.twitter.util.Await

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/HttpProxySupportSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/HttpProxySupportSpec.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos
 
 import com.mesosphere.cosmos.HttpProxySupport.CosmosHttpProxyPasswordAuthenticator
 import com.mesosphere.cosmos.HttpProxySupport.ProxyEnvVariables
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import java.net.Authenticator
 import java.net.Authenticator.RequestorType
 import java.net.URI

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/ServiceClientSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/ServiceClientSpec.scala
@@ -5,7 +5,7 @@ import com.mesosphere.cosmos.http.Authorization
 import com.mesosphere.cosmos.http.RequestSession
 import com.mesosphere.cosmos.test.TestUtil
 import com.mesosphere.http.OriginHostScheme
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.finagle.http.Request
 import org.scalatest.FreeSpec
 import org.scalatest.Inside

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/ServicesSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/ServicesSpec.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos
 
 import com.mesosphere.cosmos.error.CosmosException
 import com.mesosphere.cosmos.error.ServiceUnavailable
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import com.twitter.conversions.storage._
 import com.twitter.finagle.http.RequestBuilder
 import com.twitter.util.Await

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/UrisSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/UrisSpec.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.cosmos
 
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import com.twitter.util.{Return, Throw}
 import org.scalatest.FreeSpec
 
@@ -37,12 +37,12 @@ class UrisSpec extends FreeSpec {
     "fail for" - {
       "domain" in {
         val Throw(err) = Uris.extractHostAndPort("domain")
-        val expectedMessage = "Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual '/domain'"
+        val expectedMessage = "Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual 'domain'"
         assertResult(expectedMessage)(err.getMessage)
       }
       "domain:8080" in {
         val Throw(err) = Uris.extractHostAndPort("domain:8080")
-        val expectedMessage = "Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual '/domain:8080'"
+        val expectedMessage = "Unsupported or invalid URI. Expected format 'http[s]://example.com[:port][/base-path]' actual 'domain:8080'"
         assertResult(expectedMessage)(err.getMessage)
       }
       "ftp://domain" in {

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/handler/ResourceProxyHandlerSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/handler/ResourceProxyHandlerSpec.scala
@@ -4,7 +4,7 @@ import com.mesosphere.Generators.Implicits._
 import com.mesosphere.cosmos.error.CosmosException
 import com.mesosphere.cosmos.error.GenericHttpError
 import com.mesosphere.cosmos.error.ResourceTooLarge
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.conversions.storage._
 import com.twitter.finagle.http.Response
 import com.twitter.util.Await

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/render/PackageDefinitionRendererSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/render/PackageDefinitionRendererSpec.scala
@@ -15,7 +15,7 @@ import com.mesosphere.error.ResultOps
 import com.mesosphere.universe
 import com.mesosphere.universe.test.TestingPackages
 import com.mesosphere.universe.v3.model._
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import io.circe.Json
 import io.circe.JsonObject
 import io.circe.syntax._

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/repository/DefaultRepositoriesSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/repository/DefaultRepositoriesSpec.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos.repository
 
 import com.mesosphere.cosmos.repository.DefaultRepositories._
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import com.twitter.util.Return
 import io.circe.ParsingFailure
 import org.scalatest.FreeSpec

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/repository/PackageCollectionSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/repository/PackageCollectionSpec.scala
@@ -7,7 +7,7 @@ import com.mesosphere.cosmos.repository.PackageCollection
 import com.mesosphere.http.OriginHostScheme
 import com.mesosphere.universe
 import com.mesosphere.universe.test.TestingPackages
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.util.Return
 import com.twitter.util.Throw
 import com.twitter.util.Try

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/repository/ZkRepositoryListSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/repository/ZkRepositoryListSpec.scala
@@ -2,7 +2,7 @@ package com.mesosphere.cosmos.repository
 
 import cats.data.Ior
 import com.mesosphere.cosmos.rpc.v1.model.PackageRepository
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import org.scalatest.FreeSpec
 
 class ZkRepositoryListSpec extends FreeSpec {

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/thirdparty/marathon/model/AppIdSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/thirdparty/marathon/model/AppIdSpec.scala
@@ -1,6 +1,6 @@
 package com.mesosphere.cosmos.thirdparty.marathon.model
 
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.dsl._
 import org.scalatest.FreeSpec
 
 final class AppIdSpec extends FreeSpec {
@@ -32,10 +32,10 @@ final class AppIdSpec extends FreeSpec {
 
     "generate uri" - {
       "absolute" in {
-        assertResult("cassandra" / "dcos")(AppId(absolute).toUri)
+        assertResult("/cassandra" / "dcos")(AppId(absolute).toUri)
       }
       "relative" in {
-        assertResult("cassandra" / "dcos")(AppId(relative).toUri)
+        assertResult("/cassandra" / "dcos")(AppId(relative).toUri)
       }
     }
   }

--- a/cosmos-test-common/src/test/scala/com/mesosphere/universe/bijection/UniverseConversionsSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/universe/bijection/UniverseConversionsSpec.scala
@@ -4,7 +4,7 @@ import com.mesosphere.universe
 import com.mesosphere.universe.bijection.TestUniverseConversions._
 import com.mesosphere.universe.bijection.UniverseConversions._
 import com.mesosphere.universe.test.TestingPackages._
-import com.netaporter.uri.Uri
+import io.lemonlabs.uri.Uri
 import com.twitter.bijection.Conversion.asMethod
 import com.twitter.bijection.Injection
 import org.scalatest.FreeSpec

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -106,7 +106,7 @@ object Deps {
 
   // APLv2.0
   val scalaUri = Seq(
-    "com.netaporter" %% "scala-uri" % V.scalaUri
+    "io.lemonlabs" %% "scala-uri" % V.scalaUri
   )
 
   // APLv2.0
@@ -153,7 +153,7 @@ object V {
   val scalaCheck = "1.13.5"
   val scalaCheckShapeless = "1.1.8"
   val scalaTest = "3.0.5"
-  val scalaUri = "0.4.16"
+  val scalaUri = "1.4.0"
   val slf4j = "1.7.25"
   val twitterUtil = "18.3.0"
 }


### PR DESCRIPTION
[Techdebt] Move from the https://github.com/NET-A-PORTER/scala-uri (no longer maintained) to https://github.com/lemonlabsuk/scala-uri