### PR TITLE
Use HTTP PUT as if it was PUT

### DIFF
--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonClient.scala
@@ -64,7 +64,7 @@ class MarathonClient(
   ): Future[Response] = {
     client(
       put(
-        Url(path = "v2" / "apps" / appId.toUri,  query = QueryString.fromPairs("force" -> "true", " partialUpdate" -> "false")),
+        Url(path = "v2" / "apps" / appId.toUri,  query = QueryString.fromPairs("force" -> "true", "partialUpdate" -> "false")),
         Json.fromJsonObject(appJson)
       )
     )

--- a/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonClient.scala
+++ b/cosmos-server/src/main/scala/com/mesosphere/cosmos/MarathonClient.scala
@@ -64,7 +64,7 @@ class MarathonClient(
   ): Future[Response] = {
     client(
       put(
-        Url(path = "v2" / "apps" / appId.toUri,  query = QueryString.fromPairs("force" -> "true")),
+        Url(path = "v2" / "apps" / appId.toUri,  query = QueryString.fromPairs("force" -> "true", " partialUpdate" -> "false")),
         Json.fromJsonObject(appJson)
       )
     )


### PR DESCRIPTION
Oh wow, this was truly a ride. First I thought there is a bug in cosmos but then after an hour I found this in marathon API docs (because I could not drop that constraint even from UI).

```
Without specifying this parameter, this method has a patch like semantic:
All values that are not defined in the json, will not change existing values.
This was the default behaviour in previous Marathon versions.
For backward compatibility, we will not change this behaviour, but let users opt in for a proper PUT.
Note: We will change the default behaviour in the next Marathon version to support PATCH and PUT as HTTP methods.
```

JIRA: DCOS-49941