### PR TITLE
[DCOS-57014] Change the regex for dc/os version parser to accept any suffix

### DIFF
--- a/cosmos-common/src/main/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionParser.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionParser.scala
@@ -8,11 +8,12 @@ object DcosReleaseVersionParser {
 
   private[this] val versionFragment = "(?:0|[1-9][0-9]*)"
   private[this] val subVersionFragment = "\\." + versionFragment
-  private[this] val suffixFragment = "[A-Za-z0-9]+"
+  private[this] val suffixFragment =
+    "((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)"
 
   private[v3] val versionRegex = s"^$versionFragment$$"
   private[v3] val suffixRegex = s"^$suffixFragment$$"
-  private[v3] val fullRegex = s"^$versionFragment(?:$subVersionFragment)*(?:-$suffixFragment)?$$"
+  private[v3] val fullRegex = s"^$versionFragment(?:$subVersionFragment)*(?<suffix>-$suffixFragment)?$$"
 
   private[v3] val versionPattern = Pattern.compile(versionRegex)
   private[v3] val suffixPattern = Pattern.compile(suffixRegex)
@@ -28,10 +29,10 @@ object DcosReleaseVersionParser {
       s
     } flatMap { validatedString =>
       validatedString.split('-').toList match {
-        case version :: suffix :: Nil=>
-          Return(version -> Some(suffix))
-        case version :: Nil =>
+        case Seq(version) =>
           Return(version -> None)
+        case Seq(version, tail @ _*) =>
+          Return(version -> Some(tail.mkString("-")))
         case _ =>
           Throw(new AssertionError(errMsg))
       }

--- a/cosmos-test-common/src/test/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionParserSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionParserSpec.scala
@@ -7,7 +7,7 @@ import org.scalatest.Assertion
 import org.scalatest.FreeSpec
 
 class DcosReleaseVersionParserSpec extends FreeSpec {
-  private[this] val regex = "^(?:0|[1-9][0-9]*)(?:\\.(?:0|[1-9][0-9]*))*(?:-[A-Za-z0-9]+)?$"
+  private[this] val regex = DcosReleaseVersionParser.fullRegex.toString
 
   "DcosReleaseVersionParser should" - {
     "succeed for" - {
@@ -37,6 +37,26 @@ class DcosReleaseVersionParserSpec extends FreeSpec {
         )
         assertResult(expected)(parse)
       }
+
+      "1.2.3-alpha.7" in {
+        val Return(parse) = DcosReleaseVersionParser.parse("1.2.3-alpha.7")
+        val expected = DcosReleaseVersion(
+          DcosReleaseVersion.Version(1),
+          List(DcosReleaseVersion.Version(2), DcosReleaseVersion.Version(3)),
+          Some(DcosReleaseVersion.Suffix("alpha.7"))
+        )
+        assertResult(expected)(parse)
+      }
+
+      "1.2.3-abc123-aA.123-pP.99-ts" in {
+        val Return(parse) = DcosReleaseVersionParser.parse("1.2.3-abc123-aA.123-pP.99-ts")
+        val expected = DcosReleaseVersion(
+          DcosReleaseVersion.Version(1),
+          List(DcosReleaseVersion.Version(2), DcosReleaseVersion.Version(3)),
+          Some(DcosReleaseVersion.Suffix("abc123-aA.123-pP.99-ts"))
+        )
+        assertResult(expected)(parse)
+      }
     }
 
     "fail for" - {
@@ -59,9 +79,9 @@ class DcosReleaseVersionParserSpec extends FreeSpec {
         }
       }
 
-      "1--" in {
-        assertAssertionError(s"assertion failed: Value '1--' does not conform to expected format $regex") {
-          DcosReleaseVersionParser.parse("1--")
+      "1.2.3-" in {
+        assertAssertionError(s"assertion failed: Value '1.2.3-' does not conform to expected format $regex") {
+          DcosReleaseVersionParser.parse("1.2.3-")
         }
       }
 

--- a/cosmos-test-common/src/test/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/universe/v3/model/DcosReleaseVersionSpec.scala
@@ -95,6 +95,14 @@ class DcosReleaseVersionSpec extends FreeSpec {
         "10.20.30.40 >= 1.50.60.70" in {
           assert(o.gteq("10.20.30.40", "1.50.60.70"))
         }
+
+        "1.0.0-alpha.1 > 1.0.0-alpha" in {
+          assert(o.gteq("1.0.0-alpha", "1.0.0-alpha.1"))
+        }
+
+        "1.0.0-alpha.beta == 1.0.0-beta" in {
+          assert(o.equiv("1.0.0-alpha.beta", "1.0.0-beta"))
+        }
       }
 
       "fail for" - {
@@ -118,6 +126,10 @@ class DcosReleaseVersionSpec extends FreeSpec {
 
         "1.6.1 >= 1.8-dev" in {
           assert(!o.gteq("1.6.1", "1.8-dev"))
+        }
+
+        "1.0.0-rc.1 > 1.0.0" in {
+          assert(!o.lt("1.0.0-rc.1", "1.0.0"))
         }
       }
     }
@@ -182,20 +194,21 @@ class DcosReleaseVersionSpec extends FreeSpec {
           "BETA" in {
             assertResult("BETA")(DcosReleaseVersion.Suffix("BETA").value)
           }
+          "alpha.1" in {
+            assertResult("alpha.1")(DcosReleaseVersion.Suffix("alpha.1").value)
+          }
+          "beta-dev.11.12.2020" in {
+            assertResult("beta-dev.11.12.2020")(DcosReleaseVersion.Suffix("beta-dev.11.12.2020").value)
+          }
         }
         "fail for" - {
           "!" in {
-            assertAssertionError("assertion failed: Value '!' does not conform to expected format ^[A-Za-z0-9]+$") {
+            assertAssertionError(s"assertion failed: Value '!' does not conform to expected format ${DcosReleaseVersionParser.suffixPattern.toString}") {
               DcosReleaseVersion.Suffix("!")
             }
           }
-          "-" in {
-            assertAssertionError("assertion failed: Value '-' does not conform to expected format ^[A-Za-z0-9]+$") {
-              DcosReleaseVersion.Suffix("-")
-            }
-          }
           "." in {
-            assertAssertionError("assertion failed: Value '.' does not conform to expected format ^[A-Za-z0-9]+$") {
+            assertAssertionError(s"assertion failed: Value '.' does not conform to expected format ${DcosReleaseVersionParser.suffixPattern.toString}") {
               DcosReleaseVersion.Suffix(".")
             }
           }


### PR DESCRIPTION
See [DCOS-57014](https://jira.mesosphere.com/browse/DCOS-57014)

Relaxes the stringent regex for DC/OS version to allow for semver complaint pre-release suffix : https://semver.org/#spec-item-9  (Note that we are not strictly semver complaint - like we do not have mandatory major, minor patch nor do we support build metadata to be part of the version string)