### PR TITLE
Adding `asJson` template to mustache

### DIFF
--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
@@ -1,7 +1,7 @@
 package com.mesosphere.cosmos.render
 
 import com.github.fge.jsonschema.main.JsonSchemaFactory
-import com.github.mustachejava.DefaultMustacheFactory
+import com.github.mustachejava.{DefaultMustacheFactory, TemplateFunction}
 import com.mesosphere.cosmos.circe.Decoders.convertToCosmosError
 import com.mesosphere.cosmos.circe.Decoders.parse
 import com.mesosphere.cosmos.error.JsonSchemaMismatch
@@ -25,6 +25,7 @@ import java.io.StringWriter
 import java.io.Writer
 import java.nio.charset.StandardCharsets
 import java.util.Base64
+import collection.JavaConverters._
 
 object PackageDefinitionRenderer {
 
@@ -83,14 +84,40 @@ object PackageDefinitionRenderer {
       .foldLeft(JsonObject.empty)(JsonUtil.merge)
   }
 
+  private def jsonTemplateFnForContext(context: JsonObject) = new TemplateFunction {
+    override def apply(t: String): String = {
+      context(t) match  {
+        case None => "null"
+        case Some(jsonValue) => {
+          parse(jsonValue.toString()).getOrThrow.asString match {
+            case None => "null"
+            case Some(jsonString) => jsonString
+          }
+        }
+      }
+    }
+  }
+
   def renderTemplate(
     template: String,
     context: JsonObject
   ): JsonObject = {
     val renderedJsonString = {
       val mustache = MustacheFactory.compile(new StringReader(template), ".marathon.v2AppMustacheTemplate")
-      val params = jsonToJava(Json.fromJsonObject(context), isParentArray = false)
+      var params = jsonToJava(Json.fromJsonObject(context), isParentArray = false)
       val output = new StringWriter()
+
+      // Implement the interface to {{#asJson}}varName{{/asJson}}
+      // Note that the contents of the function must be the *NAME* to the variable
+      // to render as raw JSON.
+      params match {
+        case mapParams:java.util.Map[_, _] => {
+          val castedMap = mapParams.asScala.asInstanceOf[scala.collection.mutable.Map[String, Any]]
+          params = (castedMap + ("asJson" -> jsonTemplateFnForContext(context))).asJava
+        }
+        case _ => Unit
+      }
+
       mustache.execute(output, params).flush()
       output.toString
     }

--- a/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/render/PackageDefinitionRendererSpec.scala
+++ b/cosmos-test-common/src/test/scala/com/mesosphere/cosmos/render/PackageDefinitionRendererSpec.scala
@@ -430,11 +430,44 @@ class PackageDefinitionRendererSpec extends FreeSpec with Matchers with TableDri
   }
 
   "renderTemplate" - {
+
+    "should correctly render 'asJson' lambda" in {
+      val template =
+        """
+          |{
+          |  "existingKey": {{#asJson}}existingKey{{/asJson}},
+          |  "missingKey": {{#asJson}}missingKey{{/asJson}},
+          |  "nonJsonStringKey": {{#asJson}}nonJsonStringKey{{/asJson}}
+          |}
+        """.stripMargin
+
+      val context = JsonObject.fromMap(
+        Map(
+          ("existingKey", "{\"foo\": [\"bar\", \"baz\"]}".asJson),
+          ("nonJsonStringKey", 1234.asJson)
+        )
+      )
+
+      PackageDefinitionRenderer.renderTemplate(
+        template,
+        context
+      ) shouldBe JsonObject.fromMap(
+        Map(
+          ("existingKey", Json.obj(
+            "foo" -> Json.arr("bar".asJson, "baz".asJson)
+          )),
+          ("missingKey", Json.Null),
+          ("nonJsonStringKey", Json.Null)
+        )
+      )
+    }
+
     "should not use html encoding for special characters" in {
       val template =
         """
           |{
           |  "string": "{{stringExample}}",
+          |  "stringJson": {{#asJson}}stringJsonExample{{/asJson}},
           |  "simpleString": "{{simpleStringExample}}",
           |  "htmlString": "{{htmlStringExample}}",
           |  "int": {{intExample}},
@@ -447,6 +480,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with Matchers with TableDri
       val context = JsonObject.fromMap(
         Map(
           ("stringExample", "\n\'\"\\\r\t\b\f".asJson),
+          ("stringJsonExample", """["a"]""".asJson ),
           ("simpleStringExample", "foo\"bar".asJson),
           ("htmlStringExample", "<a>Foo&Bar Inc.</a>".asJson),
           ("intExample", 42.asJson),
@@ -462,6 +496,7 @@ class PackageDefinitionRendererSpec extends FreeSpec with Matchers with TableDri
       ) shouldBe JsonObject.fromMap(
         Map(
           ("string", "\n\'\"\\\r\t\b\f".asJson),
+          ("stringJson", Json.arr("a".asJson)),
           ("simpleString", "foo\"bar".asJson),
           ("htmlString", "<a>Foo&Bar Inc.</a>".asJson),
           ("int", 42.asJson),


### PR DESCRIPTION
This PR adds the `{{#asJson}}varName{{/asJson}}` function that enables rendering a string as raw, un-escaped JSON.