### PR TITLE
Bump JSON Schema version and lower cache size.

### DIFF
--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/jsonschema/JsonSchema.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/jsonschema/JsonSchema.scala
@@ -59,7 +59,7 @@ object JsonSchema {
     val Right(documentNode) = document.as[JsonNode]
     val Right(schemaNode) = schema.as[JsonNode]
 
-    val validationErrors = jsf.getValidator.validate(schemaNode, documentNode)
+    val validationErrors = jsf.getJsonSchema(schemaNode).validate(documentNode)
     if (validationErrors.isSuccess) {
       Right[ValidationErrors, Unit](())
     } else {
@@ -147,7 +147,7 @@ object JsonSchema {
         },
         jsonObject = { obj =>
           val objectNode = JsonNodeFactory.instance.objectNode()
-          objectNode.setAll(obj.toMap.mapValues(circeJsonToJsonNode).asJava)
+          objectNode.setAll[JsonNode](obj.toMap.mapValues(circeJsonToJsonNode).asJava)
         }
       )
     }

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
@@ -25,6 +25,9 @@ import java.io.StringWriter
 import java.io.Writer
 import java.nio.charset.StandardCharsets
 import java.util.Base64
+
+import com.github.fge.jsonschema.cfg.ValidationConfiguration
+
 import collection.JavaConverters._
 
 object PackageDefinitionRenderer {
@@ -38,7 +41,11 @@ object PackageDefinitionRenderer {
     }
   }
 
-  private[this] implicit val jsf: JsonSchemaFactory = JsonSchemaFactory.byDefault()
+  private[this] implicit val jsf: JsonSchemaFactory = {
+    val validationConfiguration = ValidationConfiguration.newBuilder().setCacheSize(10).freeze()
+    JsonSchemaFactory.newBuilder()
+      .setValidationConfiguration(validationConfiguration).freeze()
+  }
 
   def renderMarathonV2App(
     sourceUri: Uri,

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
@@ -42,7 +42,8 @@ object PackageDefinitionRenderer {
   }
 
   private[this] implicit val jsf: JsonSchemaFactory = {
-    // Disable cache
+    // Disable cache because it uses the URI as a key. Since we are not using the URI the key is different on each 
+    // call and thus has not performance advantage.
     val validationConfiguration = ValidationConfiguration.newBuilder().setCacheSize(0).freeze()
     JsonSchemaFactory.newBuilder()
       .setValidationConfiguration(validationConfiguration).freeze()

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
@@ -42,7 +42,7 @@ object PackageDefinitionRenderer {
   }
 
   private[this] implicit val jsf: JsonSchemaFactory = {
-    // Disable cache because it uses the URI as a key. Since we are not using the URI the key is different on each 
+    // Disable cache because it uses the URI as a key. Since we are not using the URI the key is different on each
     // call and thus has not performance advantage.
     val validationConfiguration = ValidationConfiguration.newBuilder().setCacheSize(0).freeze()
     JsonSchemaFactory.newBuilder()

--- a/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
+++ b/cosmos-common/src/main/scala/com/mesosphere/cosmos/render/PackageDefinitionRenderer.scala
@@ -42,7 +42,8 @@ object PackageDefinitionRenderer {
   }
 
   private[this] implicit val jsf: JsonSchemaFactory = {
-    val validationConfiguration = ValidationConfiguration.newBuilder().setCacheSize(10).freeze()
+    // Disable cache
+    val validationConfiguration = ValidationConfiguration.newBuilder().setCacheSize(0).freeze()
     JsonSchemaFactory.newBuilder()
       .setValidationConfiguration(validationConfiguration).freeze()
   }

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -66,7 +66,9 @@ object Deps {
 
   // APLv2.0 / LGPLv3.0
   val jsonSchema = Seq(
-    "com.github.fge" % "json-schema-validator" % V.jsonSchema
+    "com.github.java-json-tools" % "json-schema-validator" % V.jsonSchema,
+    // Override Jackson dependency
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % V.jackson
   )
 
   // EPLv1.0 / LGPLv2.1
@@ -146,7 +148,8 @@ object V {
   val fastparse = "1.0.0"
   val finch = "0.18.0"
   val guava = "28.0-jre"
-  val jsonSchema = "2.2.6"
+  val jackson = "2.11.0"
+  val jsonSchema = "2.2.14"
   val logback = "1.2.3"
   val mockito = "2.16.0"
   val mustache = "0.9.6"


### PR DESCRIPTION
Summary:
This will lower the memory usage by ignoring the JSON schema cache.
Since we are not using any URIs to load the JSON schema it is cached
each time a new.

JIRA issues: D2IQ-68617